### PR TITLE
Changed Spacer default display to block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 node_js:
 - '7'
 script:
-- npm run codestyle-check
+- npm run cs-check
 - npm run build
 - npm run test

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
   },
   "scripts": {
     "test": "jest --config=./config/jest/jest.config.json --coverage",
-    "prepare": "npm run codestyle-check && npm run test && npm run build",
+    "prepare": "npm run cs-check && npm run test && npm run build",
     "build": "webpack --config ./config/webpack/webpack.config.js",
-    "codestyle-fix": "tslint --fix --project ./config/typescript/tsconfig.json --config ./config/typescript/tslint.json ./src/**/*.{ts,tsx}",
-    "codestyle-check": "tslint --force --project ./config/typescript/tsconfig.json --config ./config/typescript/tslint.json ./src/**/*.{ts,tsx}",
+    "cs-fix": "tslint --fix --project ./config/typescript/tsconfig.json --config ./config/typescript/tslint.json ./src/**/*.{ts,tsx}",
+    "cs-check": "tslint --force --project ./config/typescript/tsconfig.json --config ./config/typescript/tslint.json ./src/**/*.{ts,tsx}",
     "watch": "start-storybook -p 9001 -c ./config/storybook"
   },
   "files": [

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -347,7 +347,6 @@ exports[`Storyshots Button With a link 1`] = `
 
 exports[`Storyshots Spacer With margin 1`] = `
 .c0 {
-  display: inline-block;
   margin: 12px 12px 12px 12px;
 }
 
@@ -369,7 +368,6 @@ exports[`Storyshots Spacer With margin 1`] = `
 
 exports[`Storyshots Spacer With padding 1`] = `
 .c1 {
-  display: inline-block;
   padding: 12px 12px 12px 12px;
 }
 
@@ -391,7 +389,6 @@ exports[`Storyshots Spacer With padding 1`] = `
 
 exports[`Storyshots Spacer Without props 1`] = `
 .c0 {
-  display: inline-block;
   margin: 0px 0px 0px 0px;
 }
 

--- a/src/components/Spacer/Spacer.style.tsx
+++ b/src/components/Spacer/Spacer.style.tsx
@@ -3,7 +3,6 @@ import { ThemeType } from '../../themes';
 import SpacerTemplate, { OffsetType, PropsType } from './Spacer.template';
 
 const Spacer:StyledComponentClass<PropsType, ThemeType> = styled(SpacerTemplate)`
-    display: inline-block;
     ${({ offsetType }):string => offsetType === 'inner' ? 'padding' : 'margin'}:
         ${({ top }):OffsetType => top !== undefined ? top : 0}px
         ${({ right }):OffsetType => right !== undefined ? right : 0}px

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,2 +1,0 @@
-export { default as Spacer } from './components/Spacer';
-export { default as Button } from './components/Button';


### PR DESCRIPTION
This PR:
- changes the default `display` value of `Spacer` to `block`.
- changes `codestyle-check` and `codestyle-fix` to `cs-check` and `cs-fix`