### PR TITLE
Added Foldout resizing on inner resize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12831,6 +12831,11 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz",
+      "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
+    },
     "resolve": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@types/react": "^16.3.5",
     "@types/react-dom": "^16.0.4",
+    "resize-observer-polyfill": "^1.5.0",
     "styled-components": "^3.2.3"
   },
   "devDependencies": {

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -507,88 +507,6 @@ exports[`Storyshots FlatButton default 1`] = `
 </button>
 `;
 
-exports[`Storyshots FoldOut Closed 1`] = `
-.c0 {
-  -webkit-transition: height 300ms cubic-bezier(0.5,0,0.1,1);
-  transition: height 300ms cubic-bezier(0.5,0,0.1,1);
-  overflow: hidden;
-  height: 0px;
-}
-
-<div
-  className="c0"
->
-  <div>
-    
-    Now this is the story all about how
-    My life got flipped, turned upside down
-    And I'd like to take a minute just sit right there
-    I'll tell you how I became the prince of a town called Bel-air
-
-    In west Philadelphia born and raised
-    On the playground where I spent most of my days
-    Chilling out, maxing, relaxing all cool
-    And all shooting some b-ball outside of the school
-    When a couple of guys, they were up to no good
-    Started making trouble in my neighbourhood
-    I got in one little fight and my mom got scared
-    And said "You're moving with your auntie and uncle in Bel-air"
-
-    I whistled for a cab and when it came near the
-    License plate said "fresh" and had a dice in the mirror
-    If anything I could say that this cab was rare
-    But I thought nah, forget it, yo homes to Bel-air!
-
-    I pulled up to a house about seven or eight
-    And I yelled to the cabby "Yo, homes smell you later!"
-    Looked at my kingdom I was finally there
-    To sit on my throne as the prince of Bel-air
-
-  </div>
-</div>
-`;
-
-exports[`Storyshots FoldOut Open 1`] = `
-.c0 {
-  -webkit-transition: height 300ms cubic-bezier(0.5,0,0.1,1);
-  transition: height 300ms cubic-bezier(0.5,0,0.1,1);
-  overflow: hidden;
-  height: 900px;
-}
-
-<div
-  className="c0"
->
-  <div>
-    
-    Now this is the story all about how
-    My life got flipped, turned upside down
-    And I'd like to take a minute just sit right there
-    I'll tell you how I became the prince of a town called Bel-air
-
-    In west Philadelphia born and raised
-    On the playground where I spent most of my days
-    Chilling out, maxing, relaxing all cool
-    And all shooting some b-ball outside of the school
-    When a couple of guys, they were up to no good
-    Started making trouble in my neighbourhood
-    I got in one little fight and my mom got scared
-    And said "You're moving with your auntie and uncle in Bel-air"
-
-    I whistled for a cab and when it came near the
-    License plate said "fresh" and had a dice in the mirror
-    If anything I could say that this cab was rare
-    But I thought nah, forget it, yo homes to Bel-air!
-
-    I pulled up to a house about seven or eight
-    And I yelled to the cabby "Yo, homes smell you later!"
-    Looked at my kingdom I was finally there
-    To sit on my throne as the prince of Bel-air
-
-  </div>
-</div>
-`;
-
 exports[`Storyshots FoldOut With a toggle 1`] = `
 .c1 {
   -webkit-appearance: none;
@@ -664,7 +582,7 @@ exports[`Storyshots FoldOut With a toggle 1`] = `
   -webkit-transition: height 300ms cubic-bezier(0.5,0,0.1,1);
   transition: height 300ms cubic-bezier(0.5,0,0.1,1);
   overflow: hidden;
-  height: 0px;
+  height: 0;
 }
 
 .c0 {

--- a/src/components/FoldOut/FoldOut.story.tsx
+++ b/src/components/FoldOut/FoldOut.story.tsx
@@ -68,14 +68,4 @@ class DemoComponent extends Component<{}, StateType> {
 storiesOf('FoldOut', module)
     .add('With a toggle', () => (
         <DemoComponent />
-    ))
-    .add('Open', () => (
-        <FoldOut isOpen>
-            {demoContent}
-        </FoldOut>
-    ))
-    .add('Closed', () => (
-        <FoldOut isOpen={false}>
-            {demoContent}
-        </FoldOut>
     ));

--- a/src/components/FoldOut/FoldOut.style.tsx
+++ b/src/components/FoldOut/FoldOut.style.tsx
@@ -5,10 +5,17 @@ import { ContentProps } from './FoldOut.template';
 const StyledFoldOut = styled.div`
     transition: height 300ms cubic-bezier(0.5, 0, 0.1, 1);
     overflow: hidden;
-    height: ${(props:ContentProps):string => `${!!props.isOpen
-        ? props.contentHeight
-        : 0
-    }px`}
+    height: ${(props:ContentProps):string => {
+        if (!props.isOpen) {
+            return '0';
+        }
+
+        if (props.contentHeight !== undefined) {
+            return `${props.contentHeight}px`;
+        }
+
+        return 'auto';
+    }}
 `;
 
 export default StyledFoldOut;

--- a/src/components/FoldOut/FoldOut.test.tsx
+++ b/src/components/FoldOut/FoldOut.test.tsx
@@ -1,18 +1,64 @@
-import 'jest-styled-components';
 import React from 'react';
 import renderer from 'react-test-renderer';
+import ResizeObserver from 'resize-observer-polyfill';
 import FoldOut from '../FoldOut';
 
-describe('FoldOut', () => {
-    it('should not break on unmounted refs', () => {
-        const fn = ():void => {
-            renderer.create(<FoldOut isOpen />, {
-                /* tslint:disable */
-                createNodeMock: ():null => null,
-                /* tslint:enable */
-            });
-        };
+const renderOptions = {
+    createNodeMock: ():Object => ({
+        contentRect: {
+            height: 900,
+        }
+    }),
+};
 
-        expect(fn).not.toThrow();
+/* tslint:disable */
+(global as any).console = {
+    warn: (jest.fn() as Function),
+};
+/* tslint:enable */
+
+jest.mock('resize-observer-polyfill', () => jest
+    .fn()
+    .mockImplementation((callback) => ({
+        observe: jest.fn().mockImplementation((element) => {
+            callback([element]);
+        }),
+        unobserve: jest.fn(),
+    }))
+);
+
+describe('FoldOut', () => {
+    it('should have a height when open', () => {
+        const foldOut = renderer.create(
+            <FoldOut isOpen />,
+            renderOptions,
+        ).toJSON();
+
+        expect(foldOut).toMatchSnapshot();
+    });
+
+    it('should have no height when closed', () => {
+        const foldOut = renderer.create(
+            <FoldOut isOpen={false} />,
+            renderOptions
+        ).toJSON();
+
+        expect(foldOut).toMatchSnapshot();
+    });
+
+    it('should use the fallback and warn once ResizeObserver is not available or throws', () => {
+        const spy = jest.spyOn(console, 'warn');
+
+        (ResizeObserver as jest.Mock<ResizeObserver>).mockImplementation(() => {
+            throw TypeError;
+        });
+
+        const foldOut = renderer.create(
+            <FoldOut isOpen />,
+            renderOptions
+        ).toJSON();
+
+        expect(foldOut).toMatchSnapshot();
+        expect(spy).toHaveBeenCalled();
     });
 });

--- a/src/components/FoldOut/__snapshots__/FoldOut.test.tsx.snap
+++ b/src/components/FoldOut/__snapshots__/FoldOut.test.tsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FoldOut should have a height when open 1`] = `
+.c0 {
+  -webkit-transition: height 300ms cubic-bezier(0.5,0,0.1,1);
+  transition: height 300ms cubic-bezier(0.5,0,0.1,1);
+  overflow: hidden;
+  height: 900px;
+}
+
+<div
+  className="c0"
+>
+  <div />
+</div>
+`;
+
+exports[`FoldOut should have no height when closed 1`] = `
+.c0 {
+  -webkit-transition: height 300ms cubic-bezier(0.5,0,0.1,1);
+  transition: height 300ms cubic-bezier(0.5,0,0.1,1);
+  overflow: hidden;
+  height: 0;
+}
+
+<div
+  className="c0"
+>
+  <div />
+</div>
+`;
+
+exports[`FoldOut should use the fallback and warn once ResizeObserver is not available or throws 1`] = `
+.c0 {
+  -webkit-transition: height 300ms cubic-bezier(0.5,0,0.1,1);
+  transition: height 300ms cubic-bezier(0.5,0,0.1,1);
+  overflow: hidden;
+  height: auto;
+}
+
+<div
+  className="c0"
+>
+  <div />
+</div>
+`;


### PR DESCRIPTION
### This PR:

**Resolves** #27 

**Adds** ✨
- `resize-observer-polyfill` dependency.

**Changes** 🌀
- Implementation of `ResizeObserver` for update on inner height regardless of window resize.

**Removes** 👋
- window `resize` event listener.
