### PR TITLE
Added trbl utility

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### This PR:
 
-**Resolves** #[resolved issue number]
+resolves #[resolved issue number]
 
 **Adds** ✨
 - Feature `foo`

--- a/config/jest/jest.config.json
+++ b/config/jest/jest.config.json
@@ -32,11 +32,12 @@
     },
     "collectCoverageFrom": [
         "src/**/*.{ts,tsx}",
+        "!src/**/__snapshots__/*",
         "!<rootDir>/node_modules/",
         "!src/**/*.story.{ts,tsx}",
         "!src/**/*.test.{ts,tsx}",
         "!src/**/*.d.ts",
-        "!src/**/index.{ts,tsx}"
+        "!src/index.ts"
     ],
     "setupTestFrameworkScriptFile": "./config/jest/setup.tsx",
     "moduleNameMapper": {

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -1520,40 +1520,6 @@ exports[`Storyshots Spacer With padding 1`] = `
 </div>
 `;
 
-exports[`Storyshots Spacer Without props 1`] = `
-.c2 {
-  color: #333740;
-  font-family: Source Sans Pro,sans-serif;
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 1.5;
-  margin: 0;
-}
-
-.c0 {
-  margin: 0px 0px 0px 0px;
-}
-
-.c1 {
-  border: solid 3px rgba(255,36,94,0.3);
-  border-radius: 5px;
-}
-
-<div
-  className="c0"
->
-  <div
-    className="c1"
-  >
-    <p
-      className="c2"
-    >
-      This has no spacing.
-    </p>
-  </div>
-</div>
-`;
-
 exports[`Storyshots SubHeading With a hierarchy 1`] = `
 .c0 {
   color: #88979d;

--- a/src/components/FoldOut/FoldOut.story.tsx
+++ b/src/components/FoldOut/FoldOut.story.tsx
@@ -1,6 +1,7 @@
 import { storiesOf } from '@storybook/react';
 import React, { Component } from 'react';
 import FoldOut from '.';
+import trbl from '../../utility/trbl';
 import Button from '../Button';
 import Spacer from '../Spacer';
 import Text from '../Text';
@@ -48,7 +49,7 @@ class DemoComponent extends Component<{}, StateType> {
         return (
             <div>
                 <FoldOut isOpen={this.state.isOpen}>
-                    <Spacer bottom={12} offsetType="inner">
+                    <Spacer offset={trbl(0, 0, 12)} offsetType="inner">
                         <Text>{demoContent}</Text>
                     </Spacer>
                 </FoldOut>

--- a/src/components/Icon/Icon.story.tsx
+++ b/src/components/Icon/Icon.story.tsx
@@ -1,6 +1,7 @@
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import Icon from '.';
+import trbl from '../../utility/trbl';
 import Spacer from '../Spacer';
 
 storiesOf('Icon', module)
@@ -17,7 +18,7 @@ storiesOf('Icon', module)
         <div>
             <Icon size="small" icon="mos" />
             <span> With some text</span>
-            <Spacer top={12}>
+            <Spacer offset={trbl(12, 0, 0, 0)}>
                 <Icon size="large" icon="award" />
                 <span> With some other text</span>
             </Spacer>

--- a/src/components/Notification/Notification.template.tsx
+++ b/src/components/Notification/Notification.template.tsx
@@ -1,5 +1,6 @@
 import React, { StatelessComponent } from 'react';
 import { StyledType } from '../../utility/styled';
+import trbl from '../../utility/trbl';
 import Icon, { SmallIcons } from '../Icon';
 import Spacer from '../Spacer';
 
@@ -24,10 +25,7 @@ const Notification:StatelessComponent<PropsType> = (props):JSX.Element => {
     return (
         <div className={props.className}>
             <Spacer
-                top={12}
-                right={12}
-                bottom={12}
-                left={12}
+                offset={trbl(12)}
                 offsetType="outer"
             >
                 <Icon size="small" icon={icon} />

--- a/src/components/Spacer/Spacer.story.tsx
+++ b/src/components/Spacer/Spacer.story.tsx
@@ -2,6 +2,7 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import styled from 'styled-components';
 import Spacer from '.';
+import trbl from '../../utility/trbl';
 import Text from '../Text';
 
 const StyledDiv = styled.div`
@@ -11,12 +12,7 @@ const StyledDiv = styled.div`
 
 storiesOf('Spacer', module)
     .add('With margin', () => (
-        <Spacer
-            top={12}
-            right={12}
-            bottom={12}
-            left={12}
-        >
+        <Spacer offset={trbl(12)}>
             <StyledDiv>
                 <Text>This has a margin.</Text>
             </StyledDiv>
@@ -25,20 +21,10 @@ storiesOf('Spacer', module)
     .add('With padding', () => (
         <StyledDiv>
             <Spacer
-                top={12}
-                right={12}
-                bottom={12}
-                left={12}
+                offset={trbl(12)}
                 offsetType="inner"
             >
                 <Text>This has padding.</Text>
             </Spacer>
         </StyledDiv>
-    ))
-    .add('Without props', () => (
-        <Spacer>
-            <StyledDiv>
-                <Text>This has no spacing.</Text>
-            </StyledDiv>
-        </Spacer>
     ));

--- a/src/components/Spacer/Spacer.style.tsx
+++ b/src/components/Spacer/Spacer.style.tsx
@@ -1,13 +1,10 @@
 import styled, { StyledComponentClass } from 'styled-components';
 import ThemeType from '../../themes/types/ThemeType';
-import SpacerTemplate, { OffsetType, PropsType } from './Spacer.template';
+import SpacerTemplate, { PropsType } from './Spacer.template';
 
 const Spacer:StyledComponentClass<PropsType, ThemeType> = styled(SpacerTemplate)`
     ${({ offsetType }):string => offsetType === 'inner' ? 'padding' : 'margin'}:
-        ${({ top }):OffsetType => top !== undefined ? top : 0}px
-        ${({ right }):OffsetType => right !== undefined ? right : 0}px
-        ${({ bottom }):OffsetType => bottom !== undefined ? bottom : 0}px
-        ${({ left }):OffsetType => left !== undefined ? left : 0}px;
+        ${({ offset }):string => `${offset.top} ${offset.right} ${offset.bottom} ${offset.left}`}
 `;
 
 export default Spacer;

--- a/src/components/Spacer/Spacer.template.tsx
+++ b/src/components/Spacer/Spacer.template.tsx
@@ -1,13 +1,9 @@
 import React, { StatelessComponent } from 'react';
 import { StyledType } from '../../utility/styled';
-
-type OffsetType = 0 | 6 | 9 | 12 | 24 | 36 | 48;
+import { TrblType } from '../../utility/trbl';
 
 type PropsType = StyledType & {
-    top?:OffsetType;
-    right?:OffsetType;
-    bottom?:OffsetType;
-    left?:OffsetType;
+    offset:TrblType;
     offsetType?:'inner' | 'outer';
 };
 
@@ -15,5 +11,5 @@ const Spacer:StatelessComponent<PropsType> = (props):JSX.Element => {
     return <div className={props.className}>{props.children}</div>;
 };
 
-export { OffsetType, PropsType };
+export { PropsType };
 export default Spacer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,4 @@ export { default as PriceTag } from './components/PriceTag';
 export { default as Spacer } from './components/Spacer';
 export { default as SubHeading } from './components/SubHeading';
 export { default as Text } from './components/Text';
+export { default as trbl } from './utility/trbl';

--- a/src/utility/trbl/index.ts
+++ b/src/utility/trbl/index.ts
@@ -1,0 +1,38 @@
+type TrblType = {
+    top:string;
+    right:string;
+    bottom:string;
+    left:string;
+};
+
+type PxCoordinateType = 0|6|9|12|24|36|48|-6|-9|-12|-24|-36|-48|'auto';
+
+const coordinatesFromShorthand = <GenericCoordinate>(...coordinates:Array<GenericCoordinate>):[
+    GenericCoordinate,
+    GenericCoordinate,
+    GenericCoordinate,
+    GenericCoordinate
+] => {
+    switch (coordinates.length) {
+        case 1: return [coordinates[0], coordinates[0], coordinates[0], coordinates[0]];
+        case 2: return [coordinates[0], coordinates[1], coordinates[0], coordinates[1]];
+        case 3: return [coordinates[0], coordinates[1], coordinates[2], coordinates[1]];
+        case 4: return [coordinates[0], coordinates[1], coordinates[2], coordinates[3]];
+        default: throw new Error('Incorrect amount of coordinates provided.');
+    }
+};
+
+const trbl = (...coordinates:Array<PxCoordinateType>):TrblType => {
+    const px = coordinatesFromShorthand(...coordinates).map((coordinate):string => coordinate === 'auto'
+        ? coordinate
+        : `${coordinate}px`
+    );
+
+    return { top: px[0], right: px[1], bottom: px[2], left: px[3] };
+};
+
+export default trbl;
+export {
+    TrblType,
+    PxCoordinateType,
+};

--- a/src/utility/trbl/trbl.test.ts
+++ b/src/utility/trbl/trbl.test.ts
@@ -1,0 +1,31 @@
+import trbl from '.';
+
+describe('trbl', () => {
+    it('should handle the auto value', () => {
+        expect(trbl(12, 'auto')).toEqual({ top: '12px', right: 'auto', bottom: '12px', left: 'auto' });
+    });
+
+    it('should generate px values from a shorthand with 1 coordinate', () => {
+        expect(trbl(12)).toEqual({ top: '12px', right: '12px', bottom: '12px', left: '12px' });
+    });
+
+    it('should generate px values from a shorthand with 2 coordinates', () => {
+        expect(trbl(12, 24)).toEqual({ top: '12px', right: '24px', bottom: '12px', left: '24px' });
+    });
+
+    it('should generate px values from a shorthand with 3 coordinates', () => {
+        expect(trbl(12, 24, 48)).toEqual({ top: '12px', right: '24px', bottom: '48px', left: '24px' });
+    });
+
+    it('should generate px values from a shorthand with 4 coordinates', () => {
+        expect(trbl(12, 24, 36, 48)).toEqual({ top: '12px', right: '24px', bottom: '36px', left: '48px' });
+    });
+
+    it('should throw an exeception when an incorrect amount of coordinates is provided', () => {
+        const fn = ():void => {
+            trbl(0, 0, 0, 0, 0, 0, 0, 0);
+        };
+
+        expect(fn).toThrowError();
+    });
+});


### PR DESCRIPTION
### This PR:

resolves #48 

**Adds** ✨
- `trbl` util that helps with building 4-points coordinates of (css-like) shorthands.

**Changes** 🌀
- `Spacer` to support `trbl`
- The `resolves` line in the PR-template so it actually closes issues.