### PR TITLE
Added transparent background color to Link hover state

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -1959,6 +1959,7 @@ exports[`Storyshots Link Action with child element 1`] = `
 
 .c1:hover {
   color: #5bd16a;
+  background-color: transparent;
 }
 
 <p
@@ -1993,10 +1994,12 @@ exports[`Storyshots Link Default 1`] = `
   text-decoration: underline;
   -webkit-transition: color 100ms;
   transition: color 100ms;
+  background-color: transparent;
 }
 
 .c1:hover {
   color: #5bd16a;
+  background-color: transparent;
 }
 
 <p

--- a/src/components/Link/style.tsx
+++ b/src/components/Link/style.tsx
@@ -18,9 +18,11 @@ const StyledLink = styled.a`
     color: ${({ theme }): string => theme.Link.default.color};
     text-decoration: ${({ theme }): string => theme.Link.default.textDecoration};
     transition: color 100ms;
+    background-color: transparent;
 
     &:hover {
         color: ${({ theme }): string => theme.Link.hover.color};
+        background-color: transparent;
     }
 `;
 
@@ -37,6 +39,7 @@ const StyledButton = styled.button`
 
     &:hover {
         color: ${({ theme }): string => theme.Link.hover.color};
+        background-color: transparent;
     }
 `;
 


### PR DESCRIPTION
### This PR:

**Changes** 🌀
- `Link` now has a transparent background on its hover state to provide a more consistent styling.

