### PR TITLE
replaced close icon and updated webpack config to remove tags from svgs

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -33,8 +33,10 @@ module.exports = {
             {
                 test: /\.svg$/,
                 loader: 'svg-inline-loader',
-                removeTags: true,
-                removingTags: ['title', 'desc', 'defs', 'style'],
+                options: {
+                    removeTags: true,
+                    removingTags: ['title', 'desc', 'defs', 'style'],
+                },
             },
             { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' },
         ],

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -1,43 +1,43 @@
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 
 module.exports = {
-    entry: "./src/index.ts",
+    entry: './src/index.ts',
     stats: {
         assets: true,
         modules: false,
         children: false,
     },
     output: {
-        filename: "index.js",
-        path: __dirname + "/../../dist",
+        filename: 'index.js',
+        path: __dirname + '/../../dist',
         library: 'bricks',
         libraryTarget: 'umd',
         umdNamedDefine: true,
     },
     resolve: {
-        extensions: [".ts", ".tsx", ".js", ".json"]
+        extensions: ['.ts', '.tsx', '.js', '.json'],
     },
     module: {
         rules: [
             {
                 test: /\.tsx?$/,
-                loader: "ts-loader",
+                loader: 'ts-loader',
                 options: {
-                    configFile: __dirname + "/../typescript/tsconfig.json",
-                }
+                    configFile: __dirname + '/../typescript/tsconfig.json',
+                },
             },
             {
                 test: /\.css$/,
-                use: [ 'style-loader', 'css-loader' ]
+                use: ['style-loader', 'css-loader'],
             },
             {
                 test: /\.svg$/,
-                loader: 'svg-inline-loader'
+                loader: 'svg-inline-loader',
+                removeTags: true,
+                removingTags: ['title', 'desc', 'defs', 'style'],
             },
-            { enforce: "pre", test: /\.js$/, loader: "source-map-loader" }
-        ]
+            { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' },
+        ],
     },
-    plugins: [
-        new UglifyJSPlugin()
-    ]
+    plugins: [new UglifyJSPlugin()],
 };

--- a/src/components/Icon/assets/close.svg
+++ b/src/components/Icon/assets/close.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12"><style>.cls-1{stroke:#333740;stroke-width:1.5px;}</style><line class="cls-1" x1="1" y1="1" x2="11" y2="11"/><line class="cls-1" x1="11" y1="1" x2="1" y2="11"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18"><defs><style>.a{fill:#333740;}</style></defs><title>MOS icons NEW</title><polygon class="a" points="10.06 9 17.53 16.47 16.47 17.53 9 10.06 1.53 17.53 0.47 16.47 7.94 9 0.47 1.53 1.53 0.47 9 7.94 16.47 0.47 17.53 1.53 10.06 9"/></svg>


### PR DESCRIPTION
### This PR:

resolves #109 

**Adds** ✨
- Removal of 'title', 'desc', 'defs', 'style' tags when loading svg's in webpack config

**Changes** 🌀
- Updated medium sized close icon to fill-based version