### PR TITLE
Popover offset on both axes

### DIFF
--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -10,11 +10,25 @@ type PropsType = {
     isOpen: boolean;
     fixed?: boolean;
     offset?: number;
+    distance?: number;
     stretch?: boolean;
     renderContent(): JSX.Element | string;
 };
 
 const Popover: StatelessComponent<PropsType> = (props): JSX.Element => {
+    const mapOffset = (props: PropsType): string => {
+        switch (true) {
+            case props.offset === undefined && props.distance === undefined:
+                return '0, 16px';
+            case props.offset !== undefined && props.distance === undefined:
+                return `${props.offset}px, 16px`;
+            case props.offset === undefined && props.distance !== undefined:
+                return `0, ${props.distance}px`;
+            default:
+                return `${props.offset}px, ${props.distance}px`;
+        }
+    };
+
     return (
         <>
             <Manager>
@@ -31,7 +45,7 @@ const Popover: StatelessComponent<PropsType> = (props): JSX.Element => {
                         placement={props.placement !== undefined ? props.placement : 'bottom'}
                         modifiers={{
                             offset: {
-                                offset: props.offset !== undefined ? `0, ${props.offset}px` : '0, 16px',
+                                offset: mapOffset(props),
                             },
                             flip: {
                                 enabled: false,

--- a/src/components/Popover/story.tsx
+++ b/src/components/Popover/story.tsx
@@ -12,6 +12,7 @@ type PropsType = {
     placement: PlacementType;
     fixed: boolean;
     offset: number;
+    distance: number;
 };
 
 type StateType = {
@@ -53,6 +54,7 @@ class Demo extends Component<PropsType, StateType> {
                         placement={this.props.placement}
                         fixed={this.props.fixed}
                         offset={this.props.offset}
+                        distance={this.props.distance}
                         renderContent={(): JSX.Element => <DemoContent />}
                     >
                         <Button variant="primary" title="Toggle" action={this.toggle} />
@@ -90,7 +92,8 @@ storiesOf('Popover', module).add('Default', () => (
             ) as PlacementType
         }
         fixed={boolean('fixed', false)}
-        offset={number('offset', 16)}
+        offset={number('offset', 0)}
+        distance={number('distance', 16)}
     />
     /* tslint:enable */
 ));

--- a/src/components/Popover/test.tsx
+++ b/src/components/Popover/test.tsx
@@ -37,9 +37,43 @@ describe('Popover', () => {
         expect(popper.prop('positionFixed')).toEqual(true);
     });
 
-    it('should render with a custom offset', () => {
+    it('should render with a custom distance and offset', () => {
         const component = shallowWithTheme(
-            <Popover isOpen={true} offset={6} renderContent={(): string => 'Mock content'} />,
+            <Popover isOpen={true} offset={20} distance={6} renderContent={(): string => 'Mock content'} />,
+        );
+
+        const popper = component.find(Popper);
+
+        expect(popper.prop('modifiers')).toEqual({
+            offset: {
+                offset: '20px, 6px',
+            },
+            flip: {
+                enabled: false,
+            },
+        });
+    });
+
+    it('should render with only a custom offset', () => {
+        const component = shallowWithTheme(
+            <Popover isOpen={true} offset={20} renderContent={(): string => 'Mock content'} />,
+        );
+
+        const popper = component.find(Popper);
+
+        expect(popper.prop('modifiers')).toEqual({
+            offset: {
+                offset: '20px, 16px',
+            },
+            flip: {
+                enabled: false,
+            },
+        });
+    });
+
+    it('should render with only a custom distance', () => {
+        const component = shallowWithTheme(
+            <Popover isOpen={true} distance={6} renderContent={(): string => 'Mock content'} />,
         );
 
         const popper = component.find(Popper);


### PR DESCRIPTION
### This PR:

proposed release: `minor`

resolves #116 

**Changes** 🌀
- Popover offset can now be set for both the horizontal and the vertical axes, instead of only for the vertical axis. This is implemented using `offset` and `distance` props. Distance specifies the distance between toggle and popover while offset specifies the offset of the popover body relative to the popover arrow.