### PR TITLE
changed default textAlign on Header

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -3857,7 +3857,6 @@ exports[`Storyshots Modal Default 1`] = `
   font-weight: 400;
   line-height: 1.25;
   text-transform: none;
-  text-align: left;
   margin: 0;
 }
 
@@ -4922,7 +4921,6 @@ Array [
   font-weight: 400;
   line-height: 1.5;
   text-transform: none;
-  text-align: left;
   margin: 0;
 }
 
@@ -5050,7 +5048,6 @@ Array [
   font-weight: 400;
   line-height: 1.5;
   text-transform: none;
-  text-align: left;
   margin: 0;
 }
 
@@ -6081,7 +6078,6 @@ exports[`Storyshots TransitionAnimation Default 1`] = `
   font-weight: 400;
   line-height: 1.5;
   text-transform: none;
-  text-align: left;
   margin: 0;
 }
 

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -34,7 +34,7 @@ type HeadingThemeType = StyledType & {
 
 type PropsType = StyledType & {
     hierarchy?: 1 | 2 | 3 | 4 | 5 | 6;
-    element?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'div' | 'span' | 'p' ;
+    element?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'div' | 'span' | 'p';
     textAlign?: 'left' | 'right' | 'center' | 'justify';
 };
 
@@ -60,9 +60,10 @@ const StyledHeading = styled(HeadingElement)`
     line-height: ${({ hierarchy, theme }): string =>
         !hierarchy ? theme.Heading.default.lineHeight : theme.Heading.hierarchy[`hierarchy${hierarchy}`].lineHeight};
     text-transform: ${({ hierarchy, theme }): string =>
-        !hierarchy ? theme.Heading.default.textTransform : theme.Heading.hierarchy[`hierarchy${hierarchy}`].textTransform}
-    text-align: ${({ textAlign }): string =>
-        textAlign !== undefined ? textAlign : 'left'}
+        !hierarchy
+            ? theme.Heading.default.textTransform
+            : theme.Heading.hierarchy[`hierarchy${hierarchy}`].textTransform}
+    text-align: ${({ textAlign }): string => (textAlign !== undefined ? textAlign : '')};
     margin: 0;
 `;
 


### PR DESCRIPTION
### This PR:

proposed release: `patch`

**Changes** 🌀
- Changes default textAlign on Heading to `''` so it assumes alignment from its parent.