### PR TITLE
Scrubs svg classes from icons, adds classPrefix to illustrations

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -36,12 +36,14 @@ module.exports = {
                 options: {
                     removeTags: true,
                     removingTags: ['title', 'desc', 'defs', 'style'],
+                    removingTagAttrs: ['class'],
                 },
             },
             {
                 test: /\.color\.svg$/,
                 loader: 'svg-inline-loader',
                 options: {
+                    classPrefix: true,
                     removeTags: false,
                 },
             },


### PR DESCRIPTION
### This PR:

proposed release: `patch`

**Checklist** 🛡
- [ ] I have exported my addition from `src/index.ts` (check if not applicable)

**Changes** 🌀
- inline-svg-loader options to scrubs attributes and add a class prefix to svg's

