### PR TITLE
Fixed button skeleton height

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -6259,6 +6259,10 @@ exports[`Storyshots Select Default 1`] = `
 
 exports[`Storyshots Skeleton Button 1`] = `
 .c0 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   color: transparent;
   background-color: #f8f9fb;
   background-image: linear-gradient(100deg,transparent,rgba(0,0,0,0.02),transparent);
@@ -6269,13 +6273,9 @@ exports[`Storyshots Skeleton Button 1`] = `
   border-radius: 3px;
   color: transparent;
   display: inline-block;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   line-height: 1;
   padding: 11px 24px;
-  height: 14px;
+  font-size: 14px;
   width: 139px;
 }
 
@@ -6291,6 +6291,10 @@ exports[`Storyshots Skeleton Button 1`] = `
 exports[`Storyshots Skeleton Text 1`] = `
 Array [
   .c0 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   color: transparent;
   background-color: #f8f9fb;
   background-image: linear-gradient(100deg,transparent,rgba(0,0,0,0.02),transparent);
@@ -6301,10 +6305,6 @@ Array [
   border-radius: 3px;
   color: transparent;
   display: inline-block;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   height: 14px;
   margin: calc(14px / 4) 0;
   width: 70%;
@@ -6325,6 +6325,10 @@ Array [
   </div>,
   <br />,
   .c0 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   color: transparent;
   background-color: #f8f9fb;
   background-image: linear-gradient(100deg,transparent,rgba(0,0,0,0.02),transparent);
@@ -6335,10 +6339,6 @@ Array [
   border-radius: 3px;
   color: transparent;
   display: inline-block;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   height: 14px;
   margin: calc(14px / 4) 0;
   width: 70%;
@@ -6359,6 +6359,10 @@ Array [
   </div>,
   <br />,
   .c0 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   color: transparent;
   background-color: #f8f9fb;
   background-image: linear-gradient(100deg,transparent,rgba(0,0,0,0.02),transparent);
@@ -6369,10 +6373,6 @@ Array [
   border-radius: 3px;
   color: transparent;
   display: inline-block;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   height: 14px;
   margin: calc(14px / 4) 0;
   width: 70%;

--- a/src/components/Skeleton/Button/style.tsx
+++ b/src/components/Skeleton/Button/style.tsx
@@ -9,12 +9,12 @@ type PropsType = {
 };
 
 const StyledButtonSkeleton = withProps<PropsType>(styled.div)`
-    ${({ theme }): string => getSkeletonStyles(theme)} color: transparent;
+    ${({ theme }): string => getSkeletonStyles(theme)}
+    color: transparent;
     display: inline-block;
-    user-select: none;
     line-height: 1;
     padding: 11px 24px;
-    height: ${({ theme }): string => theme.Skeleton.Button.fontSize};
+    font-size: ${({ theme }): string => theme.Skeleton.Button.fontSize};
     width: ${({ width }): string => (width !== undefined ? `${width}px` : '0')}
 `;
 

--- a/src/components/Skeleton/Text/style.tsx
+++ b/src/components/Skeleton/Text/style.tsx
@@ -10,9 +10,9 @@ type PropsType = {
 };
 
 const StyledTextSkeleton = withProps<PropsType>(styled.div)`
-    ${({ theme }): string => getSkeletonStyles(theme)} color: transparent;
+    ${({ theme }): string => getSkeletonStyles(theme)}
+    color: transparent;
     display:inline-block;
-    user-select: none;
     height: ${({ theme }): string => theme.Skeleton.Text.fontSize};
     margin: ${({ theme }): string => `calc(${theme.Skeleton.Text.fontSize} / 4) 0`};
     width: ${({ baseWidth }): string =>

--- a/src/components/Skeleton/style.tsx
+++ b/src/components/Skeleton/style.tsx
@@ -27,6 +27,7 @@ const getSkeletonStyles = (theme: ThemeType): string => `
         }
     }
 
+    user-select: none;
     color: transparent;
     background-color: ${theme.Skeleton.common.backgroundColor};
     background-image: linear-gradient(100deg, transparent, rgba(0, 0, 0, 0.02), transparent);


### PR DESCRIPTION
### This PR:

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Changes** 🌀
- Moves `user-select: none` to skeleton base style.
- the skeletons theme font-size is now used as font-size instead of height to make it consistent even when box-sizing border-box is set.