### PR TITLE
Added modal size prop

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -4306,7 +4306,6 @@ exports[`Storyshots Modal Default 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  min-height: 300px;
   height: calc(100% - 24px);
   overflow: hidden;
   max-height: calc(300px + (600 - 300) * (100vh - 300px) / (900 - 300));

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -14,6 +14,7 @@ import StyledModal, { StyledModalWrapper } from './style';
 type PropsType = StyledType & {
     show: boolean;
     title: string;
+    size?: 'small' | 'large';
     closeAction?(): void;
     renderFixed?(): JSX.Element;
 };
@@ -52,6 +53,7 @@ class Modal extends Component<PropsType> {
                     <BreakpointProvider breakpoints={{ small: 0, medium: 320, large: 1200 }}>
                         {(breakpoint): JSX.Element => (
                             <StyledModal
+                                modalSize={this.props.size !== undefined ? this.props.size : 'large'}
                                 innerRef={(ref): void => {
                                     this.styledModalRef = ref;
                                 }}

--- a/src/components/Modal/story.tsx
+++ b/src/components/Modal/story.tsx
@@ -1,4 +1,4 @@
-import { boolean, text } from '@storybook/addon-knobs/react';
+import { boolean, text, select } from '@storybook/addon-knobs/react';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import Modal from '.';
@@ -31,6 +31,7 @@ storiesOf('Modal', module).add('Default', () => {
     return (
         <Modal
             show={boolean('show', true)}
+            size={select('size', ['small', 'large'], 'large')}
             title="Would you like me to be your role modal?"
             closeAction={(): boolean => confirm('You are now closing this modal, do you wish to continue?')}
             renderFixed={(): JSX.Element => (

--- a/src/components/Modal/style.tsx
+++ b/src/components/Modal/style.tsx
@@ -3,6 +3,11 @@ import { StyledComponentClass as _S } from 'styled-components';
 import _T from '../../types/ThemeType';
 import styled, { withProps } from '../../utility/styled';
 
+enum ModalSizes {
+    small = '480px',
+    large = '792px',
+}
+
 type ModalThemeType = {
     backgroundColor: string;
     backdropColor: string;
@@ -36,12 +41,15 @@ const StyledModalWrapper = withProps<ModalWrapperPropsType>(styled.div)`
     }
 `;
 
-const StyledModal = styled.div`
+type ModalPropsType = {
+    modalSize: keyof typeof ModalSizes;
+};
+
+const StyledModal = withProps<ModalPropsType>(styled.div)`
     max-width: 100%;
-    width: 792px;
+    width: ${({ modalSize }): string => ModalSizes[modalSize]};
     display: flex;
     flex-direction: column;
-    min-height: 300px;
     height: calc(100% - 24px);
     overflow: hidden;
     max-height: calc(300px + (600 - 300) * (100vh - 300px) / (900 - 300));

--- a/src/components/Modal/test.tsx
+++ b/src/components/Modal/test.tsx
@@ -25,7 +25,7 @@ describe('Modal', () => {
         );
 
         const component = mountWithTheme(
-            <Modal show={true} renderFixed={(): JSX.Element => <div>bar</div>} title="Foo" />,
+            <Modal size="small" show={true} renderFixed={(): JSX.Element => <div>bar</div>} title="Foo" />,
         );
 
         expect(component.find(StyledModal).length).toBe(1);


### PR DESCRIPTION
### This PR:

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Adds** ✨
- A `size` prop to the `Modal` with the options `small` and `large`