### PR TITLE
Added inline-notification children

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -2591,6 +2591,134 @@ exports[`Storyshots InlineNotification Default 1`] = `
 </p>
 `;
 
+exports[`Storyshots InlineNotification With children 1`] = `
+.c1 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin: 0px 6px 0px 0px;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+}
+
+.c0 {
+  color: #88979d;
+  font-family: Source Sans Pro,sans-serif;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.5;
+  margin: 0;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.c3 {
+  display: inline-block;
+  position: relative;
+  vertical-align: middle;
+  height: 18px;
+  width: 18px;
+}
+
+.c3 svg {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  -webkit-transform: translate(-50%,-50%);
+  -ms-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+  width: 100%;
+  max-height: 100%;
+  max-width: 100%;
+  fill: currentColor;
+}
+
+.c4 {
+  color: #333740;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-transition: color 100ms;
+  transition: color 100ms;
+  background-color: transparent;
+}
+
+.c4:hover {
+  color: #5bd16a;
+  background-color: transparent;
+}
+
+<p
+  className="c0"
+>
+  <span
+    className="c1"
+  >
+    <span
+      className="c2"
+    >
+      <span
+        aria-hidden={true}
+        className="c3"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "test-file-stub",
+          }
+        }
+        role="img"
+      />
+    </span>
+    <span
+      className="c1"
+    >
+      Are you having trouble? Check out 
+      <a
+        className="c4"
+        href="http://google.com"
+        target={undefined}
+        title="some resource"
+      >
+        this
+      </a>
+       resource for more info.
+    </span>
+  </span>
+</p>
+`;
+
 exports[`Storyshots InlineNotification With overwritten Icon 1`] = `
 .c1 {
   box-sizing: border-box;

--- a/src/components/InlineNotification/index.tsx
+++ b/src/components/InlineNotification/index.tsx
@@ -1,4 +1,4 @@
-import React, { SFC } from 'react';
+import React, { SFC, Children } from 'react';
 import SeverityType, { SeverityIcons } from '../../types/SeverityType';
 import Icon, { MediumIcons } from '../Icon';
 import Text from '../Text';
@@ -7,7 +7,7 @@ import trbl from '../../utility/trbl';
 
 type PropsType = {
     icon?: keyof typeof MediumIcons;
-    message: string;
+    message?: string;
     severity: SeverityType;
 };
 
@@ -20,7 +20,7 @@ const InlineNotification: SFC<PropsType> = (props): JSX.Element => {
                 <Box inline margin={trbl(0, 6, 0, 0)}>
                     <Icon size="medium" icon={icon} />
                 </Box>
-                <Box inline>{props.message}</Box>
+                <Box inline>{(Children.count(props.children) > 0 && props.children) || props.message}</Box>
             </Box>
         </Text>
     );

--- a/src/components/InlineNotification/story.tsx
+++ b/src/components/InlineNotification/story.tsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import InlineNotification from '.';
 import SeverityType from '../../types/SeverityType';
+import Link from '../Link';
 
 storiesOf('InlineNotification', module)
     .add('Default', () => (
@@ -17,4 +18,15 @@ storiesOf('InlineNotification', module)
             message="Something is wrong!"
             severity={select('severity', ['error', 'warning', 'success', 'info'], 'error') as SeverityType}
         />
+    ))
+    .add('With children', () => (
+        <InlineNotification
+            icon="infoCircle"
+            severity={select('severity', ['error', 'warning', 'success', 'info'], 'info') as SeverityType}
+        >
+            Are you having trouble? Check out&nbsp;
+            <Link title="some resource" href="http://google.com">
+                this
+            </Link>&nbsp;resource for more info.
+        </InlineNotification>
     ));


### PR DESCRIPTION
### This PR:

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Adds** ✨
- makes the message prop optional and provides an option to render components inside it as children.
