### PR TITLE
Changed info color from lighter2 to lighter3.

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -2636,7 +2636,7 @@ exports[`Storyshots InlineNotification With children 1`] = `
 }
 
 .c0 {
-  color: #88979d;
+  color: #a6aab3;
   font-family: Source Sans Pro,sans-serif;
   font-size: 12px;
   font-weight: 400;

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -636,7 +636,7 @@ const theme: ThemeType = {
         severity: {
             error: { color: red.darker2 },
             success: { color: green.darker2 },
-            info: { color: grey.lighter2 },
+            info: { color: grey.lighter3 },
             warning: { color: yellow.darker2 },
         },
     },


### PR DESCRIPTION
### This PR:

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Changes** 🌀
- Changed the color of  the `info` severity from: `lighter2` to: `lighter3`
