### PR TITLE
Fixed Notification Icon bug

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -4592,10 +4592,10 @@ exports[`Storyshots Notification Error 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   margin: 12px 12px 12px 12px;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
@@ -4613,6 +4613,28 @@ exports[`Storyshots Notification Error 1`] = `
 }
 
 .c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0px 12px 0px 0px;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+}
+
+.c3 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
@@ -4620,7 +4642,7 @@ exports[`Storyshots Notification Error 1`] = `
   width: 18px;
 }
 
-.c2 svg {
+.c3 svg {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -4649,17 +4671,20 @@ exports[`Storyshots Notification Error 1`] = `
   <div
     className="c1"
   >
-    <span
-      aria-hidden={true}
+    <div
       className="c2"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "test-file-stub",
+    >
+      <span
+        aria-hidden={true}
+        className="c3"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "test-file-stub",
+          }
         }
-      }
-      role="img"
-    />
-       
+        role="img"
+      />
+    </div>
     Oops, something wen't wrong. Please try again.
   </div>
 </div>
@@ -4672,10 +4697,10 @@ exports[`Storyshots Notification Info 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   margin: 12px 12px 12px 12px;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
@@ -4693,6 +4718,28 @@ exports[`Storyshots Notification Info 1`] = `
 }
 
 .c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0px 12px 0px 0px;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+}
+
+.c3 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
@@ -4700,7 +4747,7 @@ exports[`Storyshots Notification Info 1`] = `
   width: 18px;
 }
 
-.c2 svg {
+.c3 svg {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -4729,17 +4776,20 @@ exports[`Storyshots Notification Info 1`] = `
   <div
     className="c1"
   >
-    <span
-      aria-hidden={true}
+    <div
       className="c2"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "test-file-stub",
+    >
+      <span
+        aria-hidden={true}
+        className="c3"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "test-file-stub",
+          }
         }
-      }
-      role="img"
-    />
-       
+        role="img"
+      />
+    </div>
     Oops, something wen't wrong. Please try again.
   </div>
 </div>
@@ -4752,10 +4802,10 @@ exports[`Storyshots Notification Success 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   margin: 12px 12px 12px 12px;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
@@ -4773,6 +4823,28 @@ exports[`Storyshots Notification Success 1`] = `
 }
 
 .c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0px 12px 0px 0px;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+}
+
+.c3 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
@@ -4780,7 +4852,7 @@ exports[`Storyshots Notification Success 1`] = `
   width: 18px;
 }
 
-.c2 svg {
+.c3 svg {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -4809,17 +4881,20 @@ exports[`Storyshots Notification Success 1`] = `
   <div
     className="c1"
   >
-    <span
-      aria-hidden={true}
+    <div
       className="c2"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "test-file-stub",
+    >
+      <span
+        aria-hidden={true}
+        className="c3"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "test-file-stub",
+          }
         }
-      }
-      role="img"
-    />
-       
+        role="img"
+      />
+    </div>
     Wow, Great job!
   </div>
 </div>
@@ -4832,10 +4907,10 @@ exports[`Storyshots Notification Warning 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   margin: 12px 12px 12px 12px;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
@@ -4853,6 +4928,28 @@ exports[`Storyshots Notification Warning 1`] = `
 }
 
 .c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0px 12px 0px 0px;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+}
+
+.c3 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
@@ -4860,7 +4957,7 @@ exports[`Storyshots Notification Warning 1`] = `
   width: 18px;
 }
 
-.c2 svg {
+.c3 svg {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -4889,17 +4986,20 @@ exports[`Storyshots Notification Warning 1`] = `
   <div
     className="c1"
   >
-    <span
-      aria-hidden={true}
+    <div
       className="c2"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "test-file-stub",
+    >
+      <span
+        aria-hidden={true}
+        className="c3"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "test-file-stub",
+          }
         }
-      }
-      role="img"
-    />
-       
+        role="img"
+      />
+    </div>
     Careful, this might go wrong.
   </div>
 </div>
@@ -4912,10 +5012,10 @@ exports[`Storyshots Notification With a custom icon 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   margin: 12px 12px 12px 12px;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
@@ -4933,6 +5033,28 @@ exports[`Storyshots Notification With a custom icon 1`] = `
 }
 
 .c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0px 12px 0px 0px;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+}
+
+.c3 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
@@ -4940,7 +5062,7 @@ exports[`Storyshots Notification With a custom icon 1`] = `
   width: 18px;
 }
 
-.c2 svg {
+.c3 svg {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -4969,17 +5091,20 @@ exports[`Storyshots Notification With a custom icon 1`] = `
   <div
     className="c1"
   >
-    <span
-      aria-hidden={true}
+    <div
       className="c2"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "test-file-stub",
+    >
+      <span
+        aria-hidden={true}
+        className="c3"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "test-file-stub",
+          }
         }
-      }
-      role="img"
-    />
-       
+        role="img"
+      />
+    </div>
     Meh, I am not impressed.
   </div>
 </div>

--- a/src/components/ErrorBoundary/__snapshots__/test.tsx.snap
+++ b/src/components/ErrorBoundary/__snapshots__/test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ErrorBoundary should catch an error and report it 1`] = `
-.c2 {
+.c3 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
@@ -9,7 +9,7 @@ exports[`ErrorBoundary should catch an error and report it 1`] = `
   width: 18px;
 }
 
-.c2 svg {
+.c3 svg {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -28,11 +28,33 @@ exports[`ErrorBoundary should catch an error and report it 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   margin: 12px 12px 12px 12px;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-order: 0;
+  -ms-flex-order: 0;
+  order: 0;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 0px 12px 0px 0px;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
@@ -64,17 +86,20 @@ exports[`ErrorBoundary should catch an error and report it 1`] = `
   <div
     className="c1"
   >
-    <span
-      aria-hidden={true}
+    <div
       className="c2"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "test-file-stub",
+    >
+      <span
+        aria-hidden={true}
+        className="c3"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "test-file-stub",
+          }
         }
-      }
-      role="img"
-    />
-       
+        role="img"
+      />
+    </div>
     This has an error
   </div>
 </div>

--- a/src/components/Notification/index.tsx
+++ b/src/components/Notification/index.tsx
@@ -17,9 +17,10 @@ const Notification: StatelessComponent<PropsType> = (props): JSX.Element => {
 
     return (
         <StyledNotification severity={props.severity}>
-            <Box margin={trbl(12)} alignItems={'center'}>
-                <Icon size="medium" icon={icon} />
-                &nbsp;&nbsp;&nbsp;
+            <Box margin={trbl(12)} alignItems={'flex-start'} >
+                <Box margin={trbl(0,12,0,0)}>
+                    <Icon size="medium" icon={icon} />
+                </Box>
                 {props.message}
             </Box>
         </StyledNotification>


### PR DESCRIPTION
### This PR:

proposed release: `patch`
resolves #143 

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Changes** 🌀
- When notification contains a multiline text-message, the icon now aligns on the first text line and the text lines are indented on every line.

