### PR TITLE
Added disabled icon and label to toggle

### DIFF
--- a/src/components/Toggle/__snapshots__/story.storyshot
+++ b/src/components/Toggle/__snapshots__/story.storyshot
@@ -9,12 +9,12 @@ exports[`Storyshots Toggle Default 1`] = `
     className="sc-bwzfXH doEFQb"
   >
     <div
-      checked={true}
-      className="sc-ksYbfQ eRLZjr"
+      checked={false}
+      className="sc-ksYbfQ gctwnu"
       disabled={false}
     >
       <input
-        checked={true}
+        checked={false}
         className="sc-cJSrbW biawQL"
         disabled={false}
         id={undefined}
@@ -27,5 +27,11 @@ exports[`Storyshots Toggle Default 1`] = `
       />
     </div>
   </div>
+  <p
+    className="sc-bxivhb iBTcEE"
+  >
+     
+    Turn me on!
+  </p>
 </div>
 `;

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import trbl from '../../utility/trbl';
 import Box from '../Box';
+import Text from '../Text';
+import Icon from '../Icon';
 import StyledToggle, { StyledToggleSkin, StyledToggleWrapper } from './style';
 
 type StateType = {
@@ -10,9 +12,10 @@ type StateType = {
 type PropsType = {
     checked: boolean;
     disabled?: boolean;
+    disabledIcon?: boolean;
     error?: boolean;
     value: string;
-    label: string;
+    label?: string;
     name: string;
     id?: string;
     changeHandler(change: { checked: boolean }): void;
@@ -61,6 +64,10 @@ class Toggle extends Component<PropsType, StateType> {
                         />
                     </StyledToggleSkin>
                 </Box>
+                <Text descriptive={this.props.disabled ? true : false}>
+                    {this.props.disabledIcon && this.props.disabled && <Icon size="medium" icon="locked" />}{' '}
+                    {this.props.label}
+                </Text>
             </StyledToggleWrapper>
         );
     }

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -12,16 +12,23 @@ type StateType = {
 type PropsType = {
     checked: boolean;
     disabled?: boolean;
-    disabledIcon?: boolean;
     error?: boolean;
     value: string;
     label?: string;
     name: string;
     id?: string;
-    changeHandler(change: { checked: boolean }): void;
+    onChange(change: { checked: boolean }): void;
+} & Partial<DefaultProps>;
+
+type DefaultProps = {
+    disabledIcon: boolean;
 };
 
 class Toggle extends Component<PropsType, StateType> {
+    public static defaultProps: DefaultProps = {
+        disabledIcon: true,
+    };
+
     public constructor(props: PropsType) {
         super(props);
 
@@ -31,7 +38,7 @@ class Toggle extends Component<PropsType, StateType> {
     }
 
     public handleChange = (): void => {
-        this.props.changeHandler({
+        this.props.onChange({
             checked: this.props.disabled ? this.props.checked : !this.props.checked,
         });
     };

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -71,7 +71,7 @@ class Toggle extends Component<PropsType, StateType> {
                         />
                     </StyledToggleSkin>
                 </Box>
-                <Text descriptive={this.props.disabled ? true : false}>
+                <Text descriptive={this.props.disabled}>
                     {this.props.disabledIcon && this.props.disabled && <Icon size="medium" icon="locked" />}{' '}
                     {this.props.label}
                 </Text>

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -18,14 +18,14 @@ type PropsType = {
     name: string;
     id?: string;
     onChange(change: { checked: boolean }): void;
-} & Partial<DefaultProps>;
+} & Partial<DefaultPropsType>;
 
-type DefaultProps = {
+type DefaultPropsType = {
     disabledIcon: boolean;
 };
 
 class Toggle extends Component<PropsType, StateType> {
-    public static defaultProps: DefaultProps = {
+    public static defaultProps: DefaultPropsType = {
         disabledIcon: true,
     };
 
@@ -81,4 +81,4 @@ class Toggle extends Component<PropsType, StateType> {
 }
 
 export default Toggle;
-export { PropsType, StateType };
+export { PropsType, DefaultPropsType, StateType };

--- a/src/components/Toggle/story.tsx
+++ b/src/components/Toggle/story.tsx
@@ -19,14 +19,14 @@ class Demo extends Component<{}, StateType> {
     public render(): JSX.Element {
         return (
             <Toggle
-                changeHandler={({ checked }): void => {
+                onChange={({ checked }): void => {
                     this.setState({ checked });
                 }}
                 name="Toggle"
                 value="foot"
                 checked={boolean('checked', this.state.checked)}
                 disabled={boolean('disabled', false)}
-                disabledIcon={boolean('disabled icon', false)}
+                disabledIcon={boolean('disabled icon', true)}
                 error={boolean('error', false)}
                 label={text('label', 'Turn me on!')}
             />

--- a/src/components/Toggle/story.tsx
+++ b/src/components/Toggle/story.tsx
@@ -19,7 +19,9 @@ class Demo extends Component<{}, StateType> {
     public render(): JSX.Element {
         return (
             <Toggle
-                changeHandler={({ checked }) => this.setState({ checked: checked })}
+                changeHandler={({ checked }): void => {
+                    this.setState({ checked });
+                }}
                 name="Toggle"
                 value="foot"
                 checked={boolean('checked', this.state.checked)}

--- a/src/components/Toggle/story.tsx
+++ b/src/components/Toggle/story.tsx
@@ -1,16 +1,35 @@
-import { boolean } from '@storybook/addon-knobs/react';
+import { boolean, text } from '@storybook/addon-knobs/react';
 import { storiesOf } from '@storybook/react';
-import React from 'react';
+import React, { Component } from 'react';
 import Toggle from '.';
 
-storiesOf('Toggle', module).add('Default', () => (
-    <Toggle
-        changeHandler={(): void => undefined}
-        name="Toggle"
-        value="foot"
-        checked={boolean('checked', true)}
-        disabled={boolean('disabled', false)}
-        error={boolean('error', false)}
-        label="Turn me on!"
-    />
-));
+type StateType = {
+    checked: boolean;
+};
+
+class Demo extends Component<{}, StateType> {
+    public constructor(props: {}) {
+        super(props);
+
+        this.state = {
+            checked: false,
+        };
+    }
+
+    public render(): JSX.Element {
+        return (
+            <Toggle
+                changeHandler={({ checked }) => this.setState({ checked: checked })}
+                name="Toggle"
+                value="foot"
+                checked={boolean('checked', this.state.checked)}
+                disabled={boolean('disabled', false)}
+                disabledIcon={boolean('disabled icon', false)}
+                error={boolean('error', false)}
+                label={text('label', 'Turn me on!')}
+            />
+        );
+    }
+}
+
+storiesOf('Toggle', module).add('Default', () => <Demo />);

--- a/src/components/Toggle/style.tsx
+++ b/src/components/Toggle/style.tsx
@@ -55,6 +55,7 @@ const StyledToggleSkin = withProps<StyledToggleSkinType, HTMLDivElement>(styled.
     position: relative;
     transition: all 100ms;
     box-sizing: border-box;
+    cursor: pointer;
     ${({ theme, elementFocus }): string => (elementFocus ? `box-shadow: ${theme.Toggle.focus.boxShadow};` : '')}
 
     background: ${({ theme, checked, disabled }): string => {

--- a/src/components/Toggle/test.tsx
+++ b/src/components/Toggle/test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import Toggle from '.';
+import Icon from '../Icon';
 import { mosTheme } from '../../themes/MosTheme';
 import { mountWithTheme } from '../../utility/styled/testing';
 import Styledtoggle, { StyledToggleSkin, StyledToggleWrapper } from './style';
 
 describe('Toggle', () => {
-    it('should render a checked background when disabled', () => {
+    it('should render a striped grey background when disabled and unchecked', () => {
         const toggleNotChecked = mountWithTheme(
             <Toggle
                 changeHandler={(): void => undefined}
@@ -22,6 +23,69 @@ describe('Toggle', () => {
         (expect(toggleNotChecked.find(StyledToggleSkin)) as any).toHaveStyleRule(
             'background',
             mosTheme.Toggle.idleDisabled.background,
+        );
+        /* tslint:enable */
+    });
+
+    it('should render a striped green background when disabled and checked', () => {
+        const toggleNotChecked = mountWithTheme(
+            <Toggle
+                changeHandler={(): void => undefined}
+                name="demo"
+                error={true}
+                label="foo"
+                checked={true}
+                disabled={true}
+                value="bar"
+            />,
+        );
+
+        /* tslint:disable */
+        (expect(toggleNotChecked.find(StyledToggleSkin)) as any).toHaveStyleRule(
+            'background',
+            mosTheme.Toggle.checkedDisabled.background,
+        );
+        /* tslint:enable */
+    });
+
+    it('should render an unstriped grey background when unchecked', () => {
+        const toggleNotChecked = mountWithTheme(
+            <Toggle
+                changeHandler={(): void => undefined}
+                name="demo"
+                error={true}
+                label="foo"
+                checked={false}
+                disabled={false}
+                value="bar"
+            />,
+        );
+
+        /* tslint:disable */
+        (expect(toggleNotChecked.find(StyledToggleSkin)) as any).toHaveStyleRule(
+            'background',
+            mosTheme.Toggle.idle.background,
+        );
+        /* tslint:enable */
+    });
+
+    it('should render an unstriped green background when checked', () => {
+        const toggleNotChecked = mountWithTheme(
+            <Toggle
+                changeHandler={(): void => undefined}
+                name="demo"
+                error={true}
+                label="foo"
+                checked={true}
+                disabled={false}
+                value="bar"
+            />,
+        );
+
+        /* tslint:disable */
+        (expect(toggleNotChecked.find(StyledToggleSkin)) as any).toHaveStyleRule(
+            'background',
+            mosTheme.Toggle.checked.background,
         );
         /* tslint:enable */
     });
@@ -93,5 +157,33 @@ describe('Toggle', () => {
         expect(mockHandler).toHaveBeenCalledWith({
             checked: true,
         });
+    });
+
+    it('should render an icon when the disabledIcon prop is set', () => {
+        const mockHandler = jest.fn();
+
+        const toggle = mountWithTheme(
+            <Toggle
+                changeHandler={mockHandler}
+                name="demo"
+                disabled={true}
+                disabledIcon
+                label="foo"
+                checked={true}
+                value="bar"
+            />,
+        );
+
+        expect(toggle.find(Icon).length).toBe(1);
+    });
+
+    it('should render a label when a label is set', () => {
+        const mockHandler = jest.fn();
+
+        const toggle = mountWithTheme(
+            <Toggle changeHandler={mockHandler} name="demo" disabled={true} label="foo" checked={true} value="bar" />,
+        );
+
+        expect(toggle.find('p').length).toBe(1);
     });
 });

--- a/src/components/Toggle/test.tsx
+++ b/src/components/Toggle/test.tsx
@@ -6,10 +6,10 @@ import { mountWithTheme } from '../../utility/styled/testing';
 import Styledtoggle, { StyledToggleSkin, StyledToggleWrapper } from './style';
 
 describe('Toggle', () => {
-    it('should render a striped grey background when disabled and unchecked', () => {
+    it('should render the correct background styling when disabled and unchecked', () => {
         const toggleNotChecked = mountWithTheme(
             <Toggle
-                changeHandler={(): void => undefined}
+                onChange={(): void => undefined}
                 name="demo"
                 error={true}
                 label="foo"
@@ -27,10 +27,10 @@ describe('Toggle', () => {
         /* tslint:enable */
     });
 
-    it('should render a striped green background when disabled and checked', () => {
+    it('should render the correct background styling when disabled and checked', () => {
         const toggleNotChecked = mountWithTheme(
             <Toggle
-                changeHandler={(): void => undefined}
+                onChange={(): void => undefined}
                 name="demo"
                 error={true}
                 label="foo"
@@ -48,10 +48,10 @@ describe('Toggle', () => {
         /* tslint:enable */
     });
 
-    it('should render an unstriped grey background when unchecked', () => {
+    it('should render the correct background styling when unchecked', () => {
         const toggleNotChecked = mountWithTheme(
             <Toggle
-                changeHandler={(): void => undefined}
+                onChange={(): void => undefined}
                 name="demo"
                 error={true}
                 label="foo"
@@ -69,10 +69,10 @@ describe('Toggle', () => {
         /* tslint:enable */
     });
 
-    it('should render an unstriped green background when checked', () => {
+    it('should render the correct background styling when checked', () => {
         const toggleNotChecked = mountWithTheme(
             <Toggle
-                changeHandler={(): void => undefined}
+                onChange={(): void => undefined}
                 name="demo"
                 error={true}
                 label="foo"
@@ -93,7 +93,7 @@ describe('Toggle', () => {
     it('should have a red border when error-state is active', () => {
         const toggleNotChecked = mountWithTheme(
             <Toggle
-                changeHandler={(): void => undefined}
+                onChange={(): void => undefined}
                 name="demo"
                 error={true}
                 label="foo"
@@ -112,7 +112,7 @@ describe('Toggle', () => {
 
     it('should have a box-shadow on focus and remove the box-shadow on blur', () => {
         const toggle = mountWithTheme(
-            <Toggle changeHandler={(): void => undefined} name="demo" label="foo" checked={false} value="bar" />,
+            <Toggle onChange={(): void => undefined} name="demo" label="foo" checked={false} value="bar" />,
         );
 
         toggle.find(Styledtoggle).simulate('focus');
@@ -135,7 +135,7 @@ describe('Toggle', () => {
         const mockHandler = jest.fn();
 
         const toggle = mountWithTheme(
-            <Toggle changeHandler={mockHandler} name="demo" label="foo" checked={false} value="bar" />,
+            <Toggle onChange={mockHandler} name="demo" label="foo" checked={false} value="bar" />,
         );
 
         toggle.find(StyledToggleWrapper).simulate('click');
@@ -149,7 +149,7 @@ describe('Toggle', () => {
         const mockHandler = jest.fn();
 
         const toggle = mountWithTheme(
-            <Toggle changeHandler={mockHandler} name="demo" disabled={true} label="foo" checked={true} value="bar" />,
+            <Toggle onChange={mockHandler} name="demo" disabled={true} label="foo" checked={true} value="bar" />,
         );
 
         toggle.find(StyledToggleWrapper).simulate('click');
@@ -164,7 +164,7 @@ describe('Toggle', () => {
 
         const toggle = mountWithTheme(
             <Toggle
-                changeHandler={mockHandler}
+                onChange={mockHandler}
                 name="demo"
                 disabled={true}
                 disabledIcon
@@ -181,7 +181,7 @@ describe('Toggle', () => {
         const mockHandler = jest.fn();
 
         const toggle = mountWithTheme(
-            <Toggle changeHandler={mockHandler} name="demo" disabled={true} label="foo" checked={true} value="bar" />,
+            <Toggle onChange={mockHandler} name="demo" disabled={true} label="foo" checked={true} value="bar" />,
         );
 
         expect(toggle.find('p').length).toBe(1);

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -707,8 +707,8 @@ const theme: ThemeType = {
             } 12px )`,
         },
         checkedDisabled: {
-            background: `repeating-linear-gradient( -45deg,${green.base},${green.base} 5px,${green.darker1} 5px,${
-                green.darker1
+            background: `repeating-linear-gradient( -45deg,${green.lighter1},${green.lighter1} 5px,${green.base} 5px,${
+                green.base
             } 12px )`,
         },
         error: {


### PR DESCRIPTION
### This PR:

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Changes** 🌀
- Label for `Toggle` is now optional.
- `Toggle` to actually display the toggle label when set.
- Added optional `disabledIcon` prop to `Toggle` to show a lock next to a toggle in disabled state.
- Changed `Toggle` story to a stateful demo with clickable toggle.
- Styling of disabled && checked toggle state and toggle label to more closely reflect the design.



