### PR TITLE
Added additional modal size

### DIFF
--- a/src/components/Modal/__snapshots__/story.storyshot
+++ b/src/components/Modal/__snapshots__/story.storyshot
@@ -15,7 +15,7 @@ exports[`Storyshots Modal Default 1`] = `
       }
     >
       <div
-        className="sc-jAaTju hGocDT"
+        className="sc-jAaTju dVbUhv"
       >
         <div
           className="sc-bwzfXH kpHVAA"

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -14,13 +14,14 @@ import StyledModal, { StyledModalWrapper } from './style';
 type PropsType = StyledType & {
     show: boolean;
     title: string;
-    size?: 'small' | 'large';
+    size?: 'small' | 'medium' | 'large';
     closeAction?(): void;
     renderFixed?(): JSX.Element;
 };
 
 class Modal extends Component<PropsType> {
     private styledModalRef: HTMLDivElement;
+    private styledModalWrapperRef: HTMLDivElement;
 
     public constructor(props: PropsType) {
         super(props);
@@ -33,7 +34,11 @@ class Modal extends Component<PropsType> {
     };
 
     public handleClickOutside = (event: Event): void => {
-        if (this.props.show && !this.styledModalRef.contains(event.target as Node)) {
+        if (
+            this.props.show &&
+            this.styledModalWrapperRef.contains(event.target as Node) &&
+            !this.styledModalRef.contains(event.target as Node)
+        ) {
             this.closeAction();
         }
     };
@@ -48,7 +53,12 @@ class Modal extends Component<PropsType> {
 
     public render(): JSX.Element {
         return (
-            <StyledModalWrapper show={this.props.show}>
+            <StyledModalWrapper
+                show={this.props.show}
+                innerRef={(ref): void => {
+                    this.styledModalWrapperRef = ref;
+                }}
+            >
                 <TransitionAnimation key={0} show={this.props.show} animation="zoom">
                     <BreakpointProvider breakpoints={{ small: 0, medium: 320, large: 1200 }}>
                         {(breakpoint): JSX.Element => (

--- a/src/components/Modal/story.tsx
+++ b/src/components/Modal/story.tsx
@@ -31,7 +31,7 @@ storiesOf('Modal', module).add('Default', () => {
     return (
         <Modal
             show={boolean('show', true)}
-            size={select('size', ['small', 'large'], 'large')}
+            size={select('size', ['small', 'medium', 'large'], 'large')}
             title="Would you like me to be your role modal?"
             closeAction={(): boolean => confirm('You are now closing this modal, do you wish to continue?')}
             renderFixed={(): JSX.Element => (

--- a/src/components/Modal/style.tsx
+++ b/src/components/Modal/style.tsx
@@ -5,7 +5,8 @@ import styled, { withProps } from '../../utility/styled';
 
 enum ModalSizes {
     small = '480px',
-    large = '792px',
+    medium = '792px',
+    large = '1068px',
 }
 
 type ModalThemeType = {


### PR DESCRIPTION
### This PR:

proposed release: `patch`
resolves #175 #173 

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Adds** ✨
- Additional modal size with width of 1068px

**Changes** 🌀
- 'large' modal variant is now 'medium', 'large' is replaced with a wider variant
- Eventlistener behavior has been changed to only close the modal when the modal overlay is the event target.

**Breaking changes** 🔥
- `Modal` components using the 'large' variant need to change this to 'medium' to retain the same size! 'medium' is now the same size 'large' used to be while 'large' has become larger.
