### PR TITLE
changed label flex-basis to 233px

### DIFF
--- a/src/components/FormRow/__snapshots__/story.storyshot
+++ b/src/components/FormRow/__snapshots__/story.storyshot
@@ -6,7 +6,7 @@ exports[`Storyshots FormRow Default 1`] = `
     className="sc-bwzfXH mMgCW"
   >
     <div
-      className="sc-bwzfXH hTSTRQ"
+      className="sc-bwzfXH dJkEBK"
     >
       <label>
         <div
@@ -122,7 +122,7 @@ exports[`Storyshots FormRow Default 1`] = `
     className="sc-bwzfXH mMgCW"
   >
     <div
-      className="sc-bwzfXH hTSTRQ"
+      className="sc-bwzfXH dJkEBK"
     >
       <label>
         <div
@@ -210,7 +210,7 @@ exports[`Storyshots FormRow Default 1`] = `
     className="sc-bwzfXH mMgCW"
   >
     <div
-      className="sc-bwzfXH hTSTRQ"
+      className="sc-bwzfXH dJkEBK"
     >
       <label>
         <div

--- a/src/components/FormRow/index.tsx
+++ b/src/components/FormRow/index.tsx
@@ -10,7 +10,7 @@ type PropsType = {
 
 const FormRow: SFC<PropsType> = (props): JSX.Element => (
     <Box wrap margin={trbl(0, 0, 12, 0)}>
-        <Box basis="420px" grow={1} margin={trbl(18, 18, 0, 0)} wrap justifyContent="stretch">
+        <Box basis="233px" grow={1} margin={trbl(18, 18, 0, 0)} wrap justifyContent="stretch">
             {props.label}
         </Box>
         <Box grow={1} basis="420px" margin={trbl(9, 0)} alignItems="flex-start">


### PR DESCRIPTION
### This PR:

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Changes** 🌀
- The flex-basis from the label-box in the form-row from: `420px` to: `233px`
