### PR TITLE
Added id's to form elements and margin to Toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8639,7 +8639,7 @@
     },
     "jest-leak-detector": {
       "version": "22.4.3",
-      "resolved": "http://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
       "integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
       "dev": true,
       "requires": {
@@ -8663,7 +8663,7 @@
         },
         "pretty-format": {
           "version": "22.4.3",
-          "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
           "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
           "dev": true,
           "requires": {
@@ -10933,7 +10933,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
@@ -14789,7 +14789,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {

--- a/src/components/Checkbox/__snapshots__/story.storyshot
+++ b/src/components/Checkbox/__snapshots__/story.storyshot
@@ -22,6 +22,7 @@ exports[`Storyshots Checkbox Default 1`] = `
   <input
     checked={true}
     className="sc-VigVT jXADSx"
+    id={undefined}
     name="foo"
     onBlur={[Function]}
     onChange={[Function]}

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -11,6 +11,7 @@ type PropsType = {
     checked: boolean | 'indeterminate';
     value: string;
     name: string;
+    id?: string;
     onChange(change: { checked: boolean | 'indeterminate' }): void;
     onMount?(): void;
     onUnmount?(): void;
@@ -63,6 +64,7 @@ class Checkbox extends Component<PropsType, StateType> {
                     onBlur={this.toggleFocus}
                     name={this.props.name}
                     value={this.props.value}
+                    id={this.props.id}
                     checked={htmlChecked}
                     type="checkbox"
                     onChange={this.changeHandler}

--- a/src/components/FormRow/__snapshots__/story.storyshot
+++ b/src/components/FormRow/__snapshots__/story.storyshot
@@ -51,6 +51,7 @@ exports[`Storyshots FormRow Default 1`] = `
             </div>
             <input
               className="sc-dxgOiQ iyMjck"
+              id={undefined}
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -79,6 +80,7 @@ exports[`Storyshots FormRow Default 1`] = `
             </div>
             <input
               className="sc-dxgOiQ iyMjck"
+              id={undefined}
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -107,6 +109,7 @@ exports[`Storyshots FormRow Default 1`] = `
             </div>
             <input
               className="sc-dxgOiQ iyMjck"
+              id={undefined}
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -167,6 +170,7 @@ exports[`Storyshots FormRow Default 1`] = `
             </div>
             <input
               className="sc-dxgOiQ iyMjck"
+              id={undefined}
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -195,6 +199,7 @@ exports[`Storyshots FormRow Default 1`] = `
             </div>
             <input
               className="sc-dxgOiQ iyMjck"
+              id={undefined}
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -252,6 +257,7 @@ exports[`Storyshots FormRow Default 1`] = `
                 <input
                   checked={true}
                   className="sc-kGXeez sKBUe"
+                  id={undefined}
                   name="bool"
                   onBlur={[Function]}
                   onChange={[Function]}
@@ -289,6 +295,7 @@ exports[`Storyshots FormRow Default 1`] = `
                 <input
                   checked={false}
                   className="sc-kGXeez sKBUe"
+                  id={undefined}
                   name="bool"
                   onBlur={[Function]}
                   onChange={[Function]}
@@ -326,6 +333,7 @@ exports[`Storyshots FormRow Default 1`] = `
                 <input
                   checked={false}
                   className="sc-kGXeez sKBUe"
+                  id={undefined}
                   name="bool"
                   onBlur={[Function]}
                   onChange={[Function]}

--- a/src/components/RadioButton/__snapshots__/story.storyshot
+++ b/src/components/RadioButton/__snapshots__/story.storyshot
@@ -15,6 +15,7 @@ exports[`Storyshots RadioButton Default 1`] = `
       <input
         checked={true}
         className="sc-kGXeez sKBUe"
+        id={undefined}
         name="demo"
         onBlur={[Function]}
         onChange={[Function]}

--- a/src/components/RadioButton/index.tsx
+++ b/src/components/RadioButton/index.tsx
@@ -12,6 +12,7 @@ type PropsType = {
     checked: boolean;
     value: string;
     name: string;
+    id?: string;
     label: string;
     onChange(change: { checked: boolean; value: string }): void;
 };
@@ -49,6 +50,7 @@ class RadioButton extends Component<PropsType, StateType> {
                             type="radio"
                             name={this.props.name}
                             value={this.props.value}
+                            id={this.props.id}
                         />
                     </StyledRadioButtonSkin>
                 </Box>

--- a/src/components/RadioButtonGroup/__snapshots__/story.storyshot
+++ b/src/components/RadioButtonGroup/__snapshots__/story.storyshot
@@ -24,6 +24,7 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
             <input
               checked={true}
               className="sc-kGXeez sKBUe"
+              id={undefined}
               name="demo"
               onBlur={[Function]}
               onChange={[Function]}
@@ -61,6 +62,7 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
             <input
               checked={false}
               className="sc-kGXeez sKBUe"
+              id={undefined}
               name="demo"
               onBlur={[Function]}
               onChange={[Function]}
@@ -98,6 +100,7 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
             <input
               checked={false}
               className="sc-kGXeez sKBUe"
+              id={undefined}
               name="demo"
               onBlur={[Function]}
               onChange={[Function]}

--- a/src/components/TextField/formatters/withCurrencyFormatting/__snapshots__/story.storyshot
+++ b/src/components/TextField/formatters/withCurrencyFormatting/__snapshots__/story.storyshot
@@ -18,6 +18,7 @@ exports[`Storyshots TextField Default 1`] = `
   </div>
   <input
     className="sc-dxgOiQ iyMjck"
+    id={undefined}
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
@@ -55,6 +56,7 @@ Array [
     </div>
     <input
       className="sc-dxgOiQ iyMjck"
+      id={undefined}
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}
@@ -115,6 +117,7 @@ Array [
     </div>
     <input
       className="sc-dxgOiQ iyMjck"
+      id={undefined}
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -9,6 +9,7 @@ import withCurrencyFormatting, { WithCurrencyFormattingType } from './formatters
 type PropsType = {
     value: string;
     name: string;
+    id?: string;
     feedback?: {
         severity: SeverityType;
         message: string;
@@ -88,6 +89,7 @@ class TextField extends Component<PropsType, StateType> {
                         type="text"
                         active={this.state.active}
                         value={this.props.value}
+                        id={this.props.id}
                         focus={this.state.focus}
                         onChange={this.onChange}
                         onFocus={this.handleFocus}

--- a/src/components/Toggle/__snapshots__/story.storyshot
+++ b/src/components/Toggle/__snapshots__/story.storyshot
@@ -6,32 +6,36 @@ exports[`Storyshots Toggle Default 1`] = `
   onClick={[Function]}
 >
   <div
-    className="sc-bwzfXH doEFQb"
+    className="sc-bwzfXH hzcxBm"
   >
     <div
-      checked={false}
-      className="sc-uJMKN gEWJmA"
-      disabled={false}
+      className="sc-bwzfXH doEFQb"
     >
-      <input
+      <div
         checked={false}
-        className="sc-jqCOkK koTgrE"
+        className="sc-uJMKN gEWJmA"
         disabled={false}
-        id={undefined}
-        name="Toggle"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        type="checkbox"
-        value="foot"
-      />
+      >
+        <input
+          checked={false}
+          className="sc-jqCOkK koTgrE"
+          disabled={false}
+          id={undefined}
+          name="Toggle"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="checkbox"
+          value="foot"
+        />
+      </div>
     </div>
+    <p
+      className="sc-bxivhb iBTcEE"
+    >
+       
+      Turn me on!
+    </p>
   </div>
-  <p
-    className="sc-bxivhb iBTcEE"
-  >
-     
-    Turn me on!
-  </p>
 </div>
 `;

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -50,31 +50,33 @@ class Toggle extends Component<PropsType, StateType> {
     public render(): JSX.Element {
         return (
             <StyledToggleWrapper onClick={this.handleChange}>
-                <Box margin={trbl(0, 9, 0, 0)}>
-                    <StyledToggleSkin
-                        elementFocus={this.state.focus}
-                        disabled={this.props.disabled}
-                        checked={this.props.checked}
-                        error={this.props.error ? this.props.error : false}
-                    >
-                        <StyledToggle
-                            id={this.props.id}
-                            onFocus={this.toggleFocus}
-                            onBlur={this.toggleFocus}
-                            name={this.props.name}
-                            value={this.props.value}
+                <Box margin={trbl(9, 0)}>
+                    <Box margin={trbl(0, 9, 0, 0)}>
+                        <StyledToggleSkin
+                            elementFocus={this.state.focus}
+                            disabled={this.props.disabled}
                             checked={this.props.checked}
-                            disabled={this.props.disabled ? this.props.disabled : false}
                             error={this.props.error ? this.props.error : false}
-                            type="checkbox"
-                            onChange={this.handleChange}
-                        />
-                    </StyledToggleSkin>
+                        >
+                            <StyledToggle
+                                id={this.props.id}
+                                onFocus={this.toggleFocus}
+                                onBlur={this.toggleFocus}
+                                name={this.props.name}
+                                value={this.props.value}
+                                checked={this.props.checked}
+                                disabled={this.props.disabled ? this.props.disabled : false}
+                                error={this.props.error ? this.props.error : false}
+                                type="checkbox"
+                                onChange={this.handleChange}
+                            />
+                        </StyledToggleSkin>
+                    </Box>
+                    <Text descriptive={this.props.disabled}>
+                        {this.props.disabledIcon && this.props.disabled && <Icon size="medium" icon="locked" />}{' '}
+                        {this.props.label}
+                    </Text>
                 </Box>
-                <Text descriptive={this.props.disabled}>
-                    {this.props.disabledIcon && this.props.disabled && <Icon size="medium" icon="locked" />}{' '}
-                    {this.props.label}
-                </Text>
             </StyledToggleWrapper>
         );
     }


### PR DESCRIPTION
### This PR:

proposed release: `patch`


**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Changes** 🌀
- Form Elements (`TextField`, `CheckBox`, `RadioButton`, `Toggle`) now have an optional `id` prop which can be used to specify labels for them.
- `Toggle`'s margin has been changed to match the rest of the form elements and thus align in the same way.
