### PR TITLE
Doesn't fire onChange when disabled - Fix for #179

### DIFF
--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -38,9 +38,11 @@ class Toggle extends Component<PropsType, StateType> {
     }
 
     public handleChange = (): void => {
-        this.props.onChange({
-            checked: this.props.disabled ? this.props.checked : !this.props.checked,
-        });
+        if (!this.props.disabled) {
+            this.props.onChange({
+                checked: !this.props.checked,
+            });
+        }
     };
 
     public toggleFocus = (): void => {

--- a/src/components/Toggle/test.tsx
+++ b/src/components/Toggle/test.tsx
@@ -154,9 +154,7 @@ describe('Toggle', () => {
 
         toggle.find(StyledToggleWrapper).simulate('click');
 
-        expect(mockHandler).toHaveBeenCalledWith({
-            checked: true,
-        });
+        expect(mockHandler).not.toHaveBeenCalled();
     });
 
     it('should render an icon when the disabledIcon prop is set', () => {
@@ -186,4 +184,5 @@ describe('Toggle', () => {
 
         expect(toggle.find('p').length).toBe(1);
     });
+
 });


### PR DESCRIPTION
### This PR:

proposed release: `patch`
resolves #179 

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Changes** 🌀
- Doesn't fire the `onChange` callback from the Toggle when `disabled` is true.
