### PR TITLE
Added eventlisteners to Popover for optional internal state management

### DIFF
--- a/config/jest/setup.tsx
+++ b/config/jest/setup.tsx
@@ -17,3 +17,8 @@ global.getSelection = jest.fn().mockReturnValue({
 });
 
 global.Intl = intl;
+
+const anchorRef = {
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+};

--- a/src/components/Popover/__snapshots__/story.storyshot
+++ b/src/components/Popover/__snapshots__/story.storyshot
@@ -28,3 +28,61 @@ exports[`Storyshots Popover Default 1`] = `
   </div>
 </div>
 `;
+
+exports[`Storyshots Popover Internal state on click 1`] = `
+<div
+  className="sc-bwzfXH iFCcSe"
+>
+  <div
+    className="sc-bwzfXH hlYRxd"
+  >
+    <div>
+      <div
+        className="sc-Rmtcm fPMxqJ"
+      >
+        <button
+          className="sc-htoDjs ilyuMW"
+          color={undefined}
+          disabled={undefined}
+          icon={undefined}
+          id={undefined}
+          onClick={[Function]}
+          title="Toggle"
+          type="button"
+        >
+          Toggle
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Popover Internal state on hover 1`] = `
+<div
+  className="sc-bwzfXH iFCcSe"
+>
+  <div
+    className="sc-bwzfXH hlYRxd"
+  >
+    <div>
+      <div
+        className="sc-Rmtcm fPMxqJ"
+      >
+        <button
+          className="sc-htoDjs ilyuMW"
+          color={undefined}
+          disabled={undefined}
+          icon={undefined}
+          id={undefined}
+          onClick={[Function]}
+          title="Hover over me"
+          type="button"
+        >
+          Hover over me
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Popover/__snapshots__/story.storyshot
+++ b/src/components/Popover/__snapshots__/story.storyshot
@@ -7,21 +7,23 @@ exports[`Storyshots Popover Default 1`] = `
   <div
     className="sc-bwzfXH kOFNQl"
   >
-    <div
-      className="sc-jhAzac gaRQRf"
-    >
-      <button
-        className="sc-htoDjs ilyuMW"
-        color={undefined}
-        disabled={undefined}
-        icon={undefined}
-        id={undefined}
-        onClick={[Function]}
-        title="Toggle"
-        type="button"
+    <div>
+      <div
+        className="sc-jhAzac gaRQRf"
       >
-        Toggle
-      </button>
+        <button
+          className="sc-htoDjs ilyuMW"
+          color={undefined}
+          disabled={undefined}
+          icon={undefined}
+          id={undefined}
+          onClick={[Function]}
+          title="Toggle"
+          type="button"
+        >
+          Toggle
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/src/components/Popover/__snapshots__/story.storyshot
+++ b/src/components/Popover/__snapshots__/story.storyshot
@@ -31,14 +31,14 @@ exports[`Storyshots Popover Default 1`] = `
 
 exports[`Storyshots Popover Internal state on click 1`] = `
 <div
-  className="sc-bwzfXH iFCcSe"
+  className="sc-bwzfXH fnbwCb"
 >
   <div
-    className="sc-bwzfXH hlYRxd"
+    className="sc-bwzfXH kOFNQl"
   >
     <div>
       <div
-        className="sc-Rmtcm fPMxqJ"
+        className="sc-jhAzac gaRQRf"
       >
         <button
           className="sc-htoDjs ilyuMW"
@@ -60,14 +60,14 @@ exports[`Storyshots Popover Internal state on click 1`] = `
 
 exports[`Storyshots Popover Internal state on hover 1`] = `
 <div
-  className="sc-bwzfXH iFCcSe"
+  className="sc-bwzfXH fnbwCb"
 >
   <div
-    className="sc-bwzfXH hlYRxd"
+    className="sc-bwzfXH kOFNQl"
   >
     <div>
       <div
-        className="sc-Rmtcm fPMxqJ"
+        className="sc-jhAzac gaRQRf"
       >
         <button
           className="sc-htoDjs ilyuMW"

--- a/src/components/Popover/__snapshots__/test.tsx.snap
+++ b/src/components/Popover/__snapshots__/test.tsx.snap
@@ -23,9 +23,11 @@ exports[`Popover should render with defaults 1`] = `
 `;
 
 exports[`Popover should render with defaults 2`] = `
-<styled.div
-  innerRef={null}
-/>
+<div>
+  <styled.div
+    innerRef={null}
+  />
+</div>
 `;
 
 exports[`PopoverAnchor should render block 1`] = `

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -46,7 +46,6 @@ class Popover extends Component<PropsType, StateType> {
     };
 
     private togglePopover = (): void => {
-        console.log('toggle popover');
         this.setState({ isOpen: !this.state.isOpen });
     };
 
@@ -119,6 +118,7 @@ class Popover extends Component<PropsType, StateType> {
                     </Reference>
                     <TransitionAnimation show={this.state.isOpen} animation="fade">
                         <div
+                            id="jemoeder"
                             ref={ref => {
                                 if (ref) this.popoverRef = ref;
                             }}

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -12,8 +12,8 @@ type PropsType = {
     offset?: number;
     distance?: number;
     stretch?: boolean;
-    renderContent(): JSX.Element | string;
     triggerOn?: 'click' | 'hover';
+    renderContent(): JSX.Element | string;
 };
 
 type StateType = {
@@ -30,6 +30,14 @@ class Popover extends Component<PropsType, StateType> {
         this.state = {
             isOpen: false,
         };
+    }
+
+    public static getDerivedStateFromProps(props: PropsType, state: StateType): Partial<StateType> {
+        if (props.isOpen !== undefined && props.isOpen !== state.isOpen) {
+            return { isOpen: props.isOpen };
+        }
+
+        return state;
     }
 
     private mapOffset = (props: PropsType): string => {
@@ -61,14 +69,6 @@ class Popover extends Component<PropsType, StateType> {
         }
     };
 
-    static getDerivedStateFromProps(props: PropsType, state: StateType) {
-        if (props.isOpen !== undefined && props.isOpen !== state.isOpen) {
-            return { isOpen: props.isOpen };
-        }
-
-        return state;
-    }
-
     public componentDidMount(): void {
         if (this.props.isOpen === undefined) {
             if (this.anchorRef) {
@@ -99,14 +99,14 @@ class Popover extends Component<PropsType, StateType> {
         }
     }
 
-    public render() {
+    public render(): JSX.Element {
         return (
             <>
                 <Manager>
                     <Reference>
                         {({ ref }: ReferenceChildrenProps): JSX.Element => (
                             <div
-                                ref={ref => {
+                                ref={(ref): void => {
                                     if (ref) this.anchorRef = ref;
                                 }}
                             >
@@ -119,7 +119,7 @@ class Popover extends Component<PropsType, StateType> {
                     <TransitionAnimation show={this.state.isOpen} animation="fade">
                         <div
                             id="jemoeder"
-                            ref={ref => {
+                            ref={(ref): void => {
                                 if (ref) this.popoverRef = ref;
                             }}
                         >

--- a/src/components/Popover/story.tsx
+++ b/src/components/Popover/story.tsx
@@ -39,7 +39,6 @@ class Demo extends Component<PropsType, StateType> {
     }
 
     private toggle = (): void => {
-        console.log('TOGGLE ZE POPOVER');
         this.setState({
             isOpen: !this.state.isOpen,
         });

--- a/src/components/Popover/story.tsx
+++ b/src/components/Popover/story.tsx
@@ -39,6 +39,7 @@ class Demo extends Component<PropsType, StateType> {
     }
 
     private toggle = (): void => {
+        console.log('TOGGLE ZE POPOVER');
         this.setState({
             isOpen: !this.state.isOpen,
         });
@@ -64,35 +65,112 @@ class Demo extends Component<PropsType, StateType> {
     }
 }
 
-storiesOf('Popover', module).add('Default', () => (
-    /* tslint:disable */
-    <Demo
-        placement={
-            select(
-                'placement',
-                [
-                    'auto-start',
-                    'auto',
-                    'auto-end',
-                    'top-start',
-                    'top',
-                    'top-end',
-                    'right-start',
-                    'right',
-                    'right-end',
-                    'bottom-end',
+storiesOf('Popover', module)
+    .add('Default', () => (
+        /* tslint:disable */
+        <Demo
+            placement={
+                select(
+                    'placement',
+                    [
+                        'auto-start',
+                        'auto',
+                        'auto-end',
+                        'top-start',
+                        'top',
+                        'top-end',
+                        'right-start',
+                        'right',
+                        'right-end',
+                        'bottom-end',
+                        'bottom',
+                        'bottom-start',
+                        'left-end',
+                        'left',
+                        'left-start',
+                    ],
                     'bottom',
-                    'bottom-start',
-                    'left-end',
-                    'left',
-                    'left-start',
-                ],
-                'bottom',
-            ) as PlacementType
-        }
-        fixed={boolean('fixed', false)}
-        offset={number('offset', 0)}
-        distance={number('distance', 16)}
-    />
-    /* tslint:enable */
-));
+                ) as PlacementType
+            }
+            fixed={boolean('fixed', false)}
+            offset={number('offset', 0)}
+            distance={number('distance', 16)}
+        />
+        /* tslint:enable */
+    ))
+    .add('Internal state on hover', () => (
+        <Box height="90vh" justifyContent="center" alignItems="center">
+            <Box margin={trbl(48)}>
+                <Popover
+                    triggerOn={'hover'}
+                    renderContent={(): JSX.Element => <DemoContent />}
+                    placement={
+                        select(
+                            'placement',
+                            [
+                                'auto-start',
+                                'auto',
+                                'auto-end',
+                                'top-start',
+                                'top',
+                                'top-end',
+                                'right-start',
+                                'right',
+                                'right-end',
+                                'bottom-end',
+                                'bottom',
+                                'bottom-start',
+                                'left-end',
+                                'left',
+                                'left-start',
+                            ],
+                            'bottom',
+                        ) as PlacementType
+                    }
+                    fixed={boolean('fixed', false)}
+                    offset={number('offset', 0)}
+                    distance={number('distance', 16)}
+                >
+                    <Button variant="primary" title="Hover over me" />
+                </Popover>
+            </Box>
+        </Box>
+    ))
+    .add('Internal state on click', () => (
+        <Box height="90vh" justifyContent="center" alignItems="center">
+            <Box margin={trbl(48)}>
+                <Popover
+                    triggerOn={'click'}
+                    renderContent={(): JSX.Element => <DemoContent />}
+                    placement={
+                        select(
+                            'placement',
+                            [
+                                'auto-start',
+                                'auto',
+                                'auto-end',
+                                'top-start',
+                                'top',
+                                'top-end',
+                                'right-start',
+                                'right',
+                                'right-end',
+                                'bottom-end',
+                                'bottom',
+                                'bottom-start',
+                                'left-end',
+                                'left',
+                                'left-start',
+                            ],
+                            'bottom',
+                        ) as PlacementType
+                    }
+                    fixed={boolean('fixed', false)}
+                    offset={number('offset', 0)}
+                    distance={number('distance', 16)}
+                >
+                    <Button variant="primary" title="Toggle" />
+                </Popover>
+            </Box>
+        </Box>
+    ));

--- a/src/components/Popover/test.tsx
+++ b/src/components/Popover/test.tsx
@@ -1,15 +1,11 @@
 import toJson from 'enzyme-to-json';
 import React from 'react';
-import ReactDOM from 'react-dom';
-import renderer from 'react-test-renderer';
-import ReactTestUtils from 'react-dom/test-utils';
-import { Popper, Reference, Manager } from 'react-popper';
+import { Popper, Reference } from 'react-popper';
 import Popover from '.';
 import Button from '../Button';
 import { shallowWithTheme, mountWithTheme } from '../../utility/styled/testing';
 import TransitionAnimation from '../TransitionAnimation';
-import { PopoverAnchor, PopoverArrow, PopoverBackground, PopoverWindow } from './style';
-import ButtonGroup from '../ButtonGroup';
+import { PopoverAnchor, PopoverArrow, PopoverBackground } from './style';
 
 describe('Popover', () => {
     it('should render with defaults', () => {
@@ -92,25 +88,6 @@ describe('Popover', () => {
             },
         });
     });
-
-    // it('should render on click when triggerOn is defined test-renderer', () => {
-    //     const mockButton = <Button variant="primary" title="anchor" />;
-    //     const togglePopover = jest.fn();
-
-    //     const component = renderer.create(
-    //         <Popover triggerOn={'click'} distance={6} renderContent={(): string => 'Mock content'}>
-    //             {mockButton}
-    //         </Popover>,
-    //         {
-    //             createNodeMock: (): Object => ({
-    //                 addEventListener: togglePopover,
-    //                 removeEventListener: jest.fn(),
-    //             }),
-    //         },
-    //     );
-
-    //     //component.find(Button).simulate('click');
-    // });
 
     it('should render on click when triggerOn is defined', () => {
         const component = mountWithTheme(

--- a/src/components/Popover/test.tsx
+++ b/src/components/Popover/test.tsx
@@ -89,38 +89,6 @@ describe('Popover', () => {
         });
     });
 
-    it('should render on click when triggerOn is defined', () => {
-        const component = mountWithTheme(
-            <Popover triggerOn={'click'} distance={6} renderContent={(): string => 'Mock content'}>
-                <Button variant="primary" title="Hover over me" />
-            </Popover>,
-        );
-
-        const button = component.find(Button);
-
-        button.simulate('click');
-
-        component.update();
-
-        expect(button).toHaveLength(1);
-
-        expect(component.state('isOpen')).toBe(true);
-    });
-
-    it('should render on hover when triggerOn is defined', () => {
-        const component = mountWithTheme(
-            <Popover triggerOn={'hover'} distance={6} renderContent={(): string => 'Mock content'}>
-                <Button variant="primary" title="Hover over me" />
-            </Popover>,
-        );
-
-        component.find(Button).simulate('mouseenter');
-
-        component.update();
-
-        expect(component.state('isOpen')).toBe(true);
-    });
-
     it('should close when clicked outside the popover window', () => {
         const callbackMap: { [key: string]: Function } = {};
 

--- a/src/components/Popover/test.tsx
+++ b/src/components/Popover/test.tsx
@@ -2,7 +2,6 @@ import toJson from 'enzyme-to-json';
 import React from 'react';
 import { Popper, Reference } from 'react-popper';
 import Popover from '.';
-import Button from '../Button';
 import { shallowWithTheme, mountWithTheme } from '../../utility/styled/testing';
 import TransitionAnimation from '../TransitionAnimation';
 import { PopoverAnchor, PopoverArrow, PopoverBackground } from './style';

--- a/src/components/Popover/test.tsx
+++ b/src/components/Popover/test.tsx
@@ -1,10 +1,15 @@
 import toJson from 'enzyme-to-json';
 import React from 'react';
-import { Popper, Reference } from 'react-popper';
+import ReactDOM from 'react-dom';
+import renderer from 'react-test-renderer';
+import ReactTestUtils from 'react-dom/test-utils';
+import { Popper, Reference, Manager } from 'react-popper';
 import Popover from '.';
-import { shallowWithTheme } from '../../utility/styled/testing';
+import Button from '../Button';
+import { shallowWithTheme, mountWithTheme } from '../../utility/styled/testing';
 import TransitionAnimation from '../TransitionAnimation';
-import { PopoverAnchor, PopoverArrow, PopoverBackground } from './style';
+import { PopoverAnchor, PopoverArrow, PopoverBackground, PopoverWindow } from './style';
+import ButtonGroup from '../ButtonGroup';
 
 describe('Popover', () => {
     it('should render with defaults', () => {
@@ -86,6 +91,87 @@ describe('Popover', () => {
                 enabled: false,
             },
         });
+    });
+
+    // it('should render on click when triggerOn is defined test-renderer', () => {
+    //     const mockButton = <Button variant="primary" title="anchor" />;
+    //     const togglePopover = jest.fn();
+
+    //     const component = renderer.create(
+    //         <Popover triggerOn={'click'} distance={6} renderContent={(): string => 'Mock content'}>
+    //             {mockButton}
+    //         </Popover>,
+    //         {
+    //             createNodeMock: (): Object => ({
+    //                 addEventListener: togglePopover,
+    //                 removeEventListener: jest.fn(),
+    //             }),
+    //         },
+    //     );
+
+    //     //component.find(Button).simulate('click');
+    // });
+
+    it('should render on click when triggerOn is defined', () => {
+        const component = mountWithTheme(
+            <Popover triggerOn={'click'} distance={6} renderContent={(): string => 'Mock content'}>
+                <Button variant="primary" title="Hover over me" />
+            </Popover>,
+        );
+
+        const button = component.find(Button);
+
+        button.simulate('click');
+
+        component.update();
+
+        expect(button).toHaveLength(1);
+
+        expect(component.state('isOpen')).toBe(true);
+    });
+
+    it('should render on hover when triggerOn is defined', () => {
+        const component = mountWithTheme(
+            <Popover triggerOn={'hover'} distance={6} renderContent={(): string => 'Mock content'}>
+                <Button variant="primary" title="Hover over me" />
+            </Popover>,
+        );
+
+        component.find(Button).simulate('mouseenter');
+
+        component.update();
+
+        expect(component.state('isOpen')).toBe(true);
+    });
+
+    it('should close when clicked outside the popover window', () => {
+        const callbackMap: { [key: string]: Function } = {};
+
+        document.addEventListener = jest.fn((event, callback) => (callbackMap[event] = callback));
+
+        const component = mountWithTheme(
+            <Popover isOpen={true} distance={6} renderContent={(): string => 'Mock content'} />,
+        );
+
+        callbackMap.mousedown({
+            target: document.createElement('div'),
+        });
+
+        component.update();
+
+        expect(component.state('isOpen')).toBe(false);
+    });
+
+    it('adds and removes eventListeners', () => {
+        const component = mountWithTheme(
+            <Popover isOpen={true} distance={6} renderContent={(): string => 'Mock content'} />,
+        );
+        component.unmount();
+
+        /* tslint:disable */
+        expect((global as any).addEventListener).toBeCalled();
+        expect((global as any).removeEventListener).toBeCalled();
+        /* tslint:enable */
     });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -16,6 +16,8 @@ initStoryshots({
             offsetWidth: 900,
             offsetHeight: 900,
             focus: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
         }),
     }),
 });


### PR DESCRIPTION
### This PR:

proposed release: `minor`
resolves #196

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable) 

**Changes** 🌀
- There is now optional internal state management for `Popover`. A method for triggering the Popover can be passed using the new `triggerOn` prop allowing `Popover` to be triggered by hovering or click it's children.
- `Popover` can now be closed by click outside.
