### PR TITLE
Added alternative input rendering option to Select 

### DIFF
--- a/src/components/Modal/__snapshots__/story.storyshot
+++ b/src/components/Modal/__snapshots__/story.storyshot
@@ -53,7 +53,7 @@ exports[`Storyshots Modal Default 1`] = `
           </div>
         </div>
         <div
-          className="sc-brqgnP hfUywI"
+          className="sc-brqgnP jEhxYZ"
         >
           <div
             className="sc-cMljjf krgCXT"
@@ -180,7 +180,7 @@ exports[`Storyshots Modal Without closeAction 1`] = `
           </div>
         </div>
         <div
-          className="sc-brqgnP hfUywI"
+          className="sc-brqgnP jEhxYZ"
         >
           <div
             className="sc-cMljjf krgCXT"

--- a/src/components/ScrollBox/__snapshots__/story.storyshot
+++ b/src/components/ScrollBox/__snapshots__/story.storyshot
@@ -9,7 +9,7 @@ Array [
       className="sc-bwzfXH kbuYXZ"
     >
       <div
-        className="sc-brqgnP hfUywI"
+        className="sc-brqgnP jEhxYZ"
       >
         <div
           className="sc-cMljjf krgCXT"

--- a/src/components/ScrollBox/style.tsx
+++ b/src/components/ScrollBox/style.tsx
@@ -27,6 +27,7 @@ const StyledWrapper = styled.div`
     position: relative;
     flex-grow: 1;
     display: flex;
+    max-height: inherit;
 
     ${simplebarStyles}
 `;

--- a/src/components/Select/__snapshots__/story.storyshot
+++ b/src/components/Select/__snapshots__/story.storyshot
@@ -2,25 +2,30 @@
 
 exports[`Storyshots Select Custom rendering 1`] = `
 <div
-  className="sc-kjoXOD jELVFZ"
+  className="sc-kgAjT ciiNMD"
   onKeyDownCapture={[Function]}
   tabIndex={0}
 >
   <div
-    className="sc-TOsTZ cnlTxH"
+    className="sc-ksYbfQ bABYTq"
     disabled={false}
   >
     <div
       className="sc-bwzfXH jlwOxs"
     >
       <div
-        className="sc-bwzfXH eSqaig"
+        className="sc-bwzfXH emfJtP"
+        onClick={[Function]}
       >
-        <p
-          className="sc-bxivhb kOPFRV"
+        <div
+          className="sc-bwzfXH ctFMhT"
         >
-          Select a value
-        </p>
+          <p
+            className="sc-bxivhb jVDCXG"
+          >
+            Select a value
+          </p>
+        </div>
       </div>
       <button
         className="sc-htoDjs TzVGU"
@@ -47,33 +52,33 @@ exports[`Storyshots Select Custom rendering 1`] = `
   </div>
   <MockPortal>
     <div
-      className="sc-cHGsZl zDQN"
+      className="sc-cJSrbW rQyzh"
     >
       <div
-        className="sc-eHgmQL bNASzp"
+        className="sc-brqgnP jEhxYZ"
       >
         <div
-          className="sc-cvbbAY hPPoNG"
+          className="sc-cMljjf krgCXT"
         >
           <div
             className="sc-chPdSV kiPOer"
           >
             <div>
               <div
-                className="sc-caSCKo jtbUen"
+                className="sc-cHGsZl hvaami"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
               >
                 <div
                   className="sc-bwzfXH jMGuhn"
                 >
-                  <p
-                    className="sc-bxivhb iBTcEE"
+                  <span
+                    className="sc-htpNat gyldUw"
                   >
                     <span
                       className="sc-htpNat bCblnl"
                     />
-                    <span>
+                    <div>
                       <div
                         className="sc-bwzfXH eSqaig"
                       >
@@ -85,30 +90,30 @@ exports[`Storyshots Select Custom rendering 1`] = `
                           />
                         </div>
                         <p
-                          className="sc-bxivhb kDWgYC"
+                          className="sc-bxivhb dMWGdr"
                         >
                           Bar A
                         </p>
                       </div>
-                    </span>
-                  </p>
+                    </div>
+                  </span>
                 </div>
               </div>
               <div
-                className="sc-caSCKo jtbUen"
+                className="sc-cHGsZl hvaami"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
               >
                 <div
                   className="sc-bwzfXH jMGuhn"
                 >
-                  <p
-                    className="sc-bxivhb iBTcEE"
+                  <span
+                    className="sc-htpNat gyldUw"
                   >
                     <span
                       className="sc-htpNat bCblnl"
                     />
-                    <span>
+                    <div>
                       <div
                         className="sc-bwzfXH eSqaig"
                       >
@@ -120,30 +125,30 @@ exports[`Storyshots Select Custom rendering 1`] = `
                           />
                         </div>
                         <p
-                          className="sc-bxivhb kDWgYC"
+                          className="sc-bxivhb dMWGdr"
                         >
                           Foo B
                         </p>
                       </div>
-                    </span>
-                  </p>
+                    </div>
+                  </span>
                 </div>
               </div>
               <div
-                className="sc-caSCKo jtbUen"
+                className="sc-cHGsZl hvaami"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
               >
                 <div
                   className="sc-bwzfXH jMGuhn"
                 >
-                  <p
-                    className="sc-bxivhb iBTcEE"
+                  <span
+                    className="sc-htpNat gyldUw"
                   >
                     <span
                       className="sc-htpNat bCblnl"
                     />
-                    <span>
+                    <div>
                       <div
                         className="sc-bwzfXH eSqaig"
                       >
@@ -155,30 +160,30 @@ exports[`Storyshots Select Custom rendering 1`] = `
                           />
                         </div>
                         <p
-                          className="sc-bxivhb kDWgYC"
+                          className="sc-bxivhb dMWGdr"
                         >
                           Bar C
                         </p>
                       </div>
-                    </span>
-                  </p>
+                    </div>
+                  </span>
                 </div>
               </div>
               <div
-                className="sc-caSCKo jtbUen"
+                className="sc-cHGsZl hvaami"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
               >
                 <div
                   className="sc-bwzfXH jMGuhn"
                 >
-                  <p
-                    className="sc-bxivhb iBTcEE"
+                  <span
+                    className="sc-htpNat gyldUw"
                   >
                     <span
                       className="sc-htpNat bCblnl"
                     />
-                    <span>
+                    <div>
                       <div
                         className="sc-bwzfXH eSqaig"
                       >
@@ -190,30 +195,30 @@ exports[`Storyshots Select Custom rendering 1`] = `
                           />
                         </div>
                         <p
-                          className="sc-bxivhb kDWgYC"
+                          className="sc-bxivhb dMWGdr"
                         >
                           Foo D
                         </p>
                       </div>
-                    </span>
-                  </p>
+                    </div>
+                  </span>
                 </div>
               </div>
               <div
-                className="sc-caSCKo jtbUen"
+                className="sc-cHGsZl hvaami"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
               >
                 <div
                   className="sc-bwzfXH jMGuhn"
                 >
-                  <p
-                    className="sc-bxivhb iBTcEE"
+                  <span
+                    className="sc-htpNat gyldUw"
                   >
                     <span
                       className="sc-htpNat bCblnl"
                     />
-                    <span>
+                    <div>
                       <div
                         className="sc-bwzfXH eSqaig"
                       >
@@ -225,30 +230,30 @@ exports[`Storyshots Select Custom rendering 1`] = `
                           />
                         </div>
                         <p
-                          className="sc-bxivhb kDWgYC"
+                          className="sc-bxivhb dMWGdr"
                         >
                           Bar E
                         </p>
                       </div>
-                    </span>
-                  </p>
+                    </div>
+                  </span>
                 </div>
               </div>
               <div
-                className="sc-caSCKo jtbUen"
+                className="sc-cHGsZl hvaami"
                 onClick={[Function]}
                 onMouseEnter={[Function]}
               >
                 <div
                   className="sc-bwzfXH jMGuhn"
                 >
-                  <p
-                    className="sc-bxivhb iBTcEE"
+                  <span
+                    className="sc-htpNat gyldUw"
                   >
                     <span
                       className="sc-htpNat bCblnl"
                     />
-                    <span>
+                    <div>
                       <div
                         className="sc-bwzfXH eSqaig"
                       >
@@ -260,13 +265,13 @@ exports[`Storyshots Select Custom rendering 1`] = `
                           />
                         </div>
                         <p
-                          className="sc-bxivhb kDWgYC"
+                          className="sc-bxivhb dMWGdr"
                         >
                           Bar F
                         </p>
                       </div>
-                    </span>
-                  </p>
+                    </div>
+                  </span>
                 </div>
               </div>
             </div>
@@ -330,10 +335,10 @@ exports[`Storyshots Select Default 1`] = `
   </div>
   <MockPortal>
     <div
-      className="sc-cJSrbW KBEED"
+      className="sc-cJSrbW rQyzh"
     >
       <div
-        className="sc-brqgnP hfUywI"
+        className="sc-brqgnP jEhxYZ"
       >
         <div
           className="sc-cMljjf krgCXT"
@@ -350,16 +355,20 @@ exports[`Storyshots Select Default 1`] = `
                 <div
                   className="sc-bwzfXH jMGuhn"
                 >
-                  <p
-                    className="sc-bxivhb jpexxn"
+                  <span
+                    className="sc-htpNat gyldUw"
                   >
                     <span
                       className="sc-htpNat bCblnl"
                     />
-                    <span>
-                      Bar A
-                    </span>
-                  </p>
+                    <div>
+                      <span
+                        className="sc-ifAKCX kRfhnK"
+                      >
+                        Bar A
+                      </span>
+                    </div>
+                  </span>
                 </div>
               </div>
               <div
@@ -370,16 +379,20 @@ exports[`Storyshots Select Default 1`] = `
                 <div
                   className="sc-bwzfXH jMGuhn"
                 >
-                  <p
-                    className="sc-bxivhb jpexxn"
+                  <span
+                    className="sc-htpNat gyldUw"
                   >
                     <span
                       className="sc-htpNat bCblnl"
                     />
-                    <span>
-                      Foo B
-                    </span>
-                  </p>
+                    <div>
+                      <span
+                        className="sc-ifAKCX kRfhnK"
+                      >
+                        Foo B
+                      </span>
+                    </div>
+                  </span>
                 </div>
               </div>
               <div
@@ -390,16 +403,20 @@ exports[`Storyshots Select Default 1`] = `
                 <div
                   className="sc-bwzfXH jMGuhn"
                 >
-                  <p
-                    className="sc-bxivhb jpexxn"
+                  <span
+                    className="sc-htpNat gyldUw"
                   >
                     <span
                       className="sc-htpNat bCblnl"
                     />
-                    <span>
-                      Bar C
-                    </span>
-                  </p>
+                    <div>
+                      <span
+                        className="sc-ifAKCX kRfhnK"
+                      >
+                        Bar C
+                      </span>
+                    </div>
+                  </span>
                 </div>
               </div>
               <div
@@ -410,16 +427,20 @@ exports[`Storyshots Select Default 1`] = `
                 <div
                   className="sc-bwzfXH jMGuhn"
                 >
-                  <p
-                    className="sc-bxivhb jpexxn"
+                  <span
+                    className="sc-htpNat gyldUw"
                   >
                     <span
                       className="sc-htpNat bCblnl"
                     />
-                    <span>
-                      Foo D
-                    </span>
-                  </p>
+                    <div>
+                      <span
+                        className="sc-ifAKCX kRfhnK"
+                      >
+                        Foo D
+                      </span>
+                    </div>
+                  </span>
                 </div>
               </div>
               <div
@@ -430,16 +451,20 @@ exports[`Storyshots Select Default 1`] = `
                 <div
                   className="sc-bwzfXH jMGuhn"
                 >
-                  <p
-                    className="sc-bxivhb jpexxn"
+                  <span
+                    className="sc-htpNat gyldUw"
                   >
                     <span
                       className="sc-htpNat bCblnl"
                     />
-                    <span>
-                      Bar E
-                    </span>
-                  </p>
+                    <div>
+                      <span
+                        className="sc-ifAKCX kRfhnK"
+                      >
+                        Bar E
+                      </span>
+                    </div>
+                  </span>
                 </div>
               </div>
               <div
@@ -450,16 +475,20 @@ exports[`Storyshots Select Default 1`] = `
                 <div
                   className="sc-bwzfXH jMGuhn"
                 >
-                  <p
-                    className="sc-bxivhb jpexxn"
+                  <span
+                    className="sc-htpNat gyldUw"
                   >
                     <span
                       className="sc-htpNat bCblnl"
                     />
-                    <span>
-                      Bar F
-                    </span>
-                  </p>
+                    <div>
+                      <span
+                        className="sc-ifAKCX kRfhnK"
+                      >
+                        Bar F
+                      </span>
+                    </div>
+                  </span>
                 </div>
               </div>
             </div>

--- a/src/components/Select/__snapshots__/story.storyshot
+++ b/src/components/Select/__snapshots__/story.storyshot
@@ -1,5 +1,283 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots Select Custom rendering 1`] = `
+<div
+  className="sc-kjoXOD jELVFZ"
+  onKeyDownCapture={[Function]}
+  tabIndex={0}
+>
+  <div
+    className="sc-TOsTZ cnlTxH"
+    disabled={false}
+  >
+    <div
+      className="sc-bwzfXH jlwOxs"
+    >
+      <div
+        className="sc-bwzfXH eSqaig"
+      >
+        <p
+          className="sc-bxivhb kOPFRV"
+        >
+          Select a value
+        </p>
+      </div>
+      <button
+        className="sc-htoDjs TzVGU"
+        color={undefined}
+        disabled={false}
+        icon={undefined}
+        id={undefined}
+        onClick={[Function]}
+        title="open"
+        type="button"
+      >
+        <span
+          aria-hidden={true}
+          className="sc-iwsKbI MOBcS"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "test-file-stub",
+            }
+          }
+          role="img"
+        />
+      </button>
+    </div>
+  </div>
+  <MockPortal>
+    <div
+      className="sc-cHGsZl zDQN"
+    >
+      <div
+        className="sc-eHgmQL bNASzp"
+      >
+        <div
+          className="sc-cvbbAY hPPoNG"
+        >
+          <div
+            className="sc-chPdSV kiPOer"
+          >
+            <div>
+              <div
+                className="sc-caSCKo jtbUen"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                <div
+                  className="sc-bwzfXH jMGuhn"
+                >
+                  <p
+                    className="sc-bxivhb iBTcEE"
+                  >
+                    <span
+                      className="sc-htpNat bCblnl"
+                    />
+                    <span>
+                      <div
+                        className="sc-bwzfXH eSqaig"
+                      >
+                        <div
+                          className="sc-bwzfXH doEFQb"
+                        >
+                          <img
+                            src="http://via.placeholder.com/100x100"
+                          />
+                        </div>
+                        <p
+                          className="sc-bxivhb kDWgYC"
+                        >
+                          Bar A
+                        </p>
+                      </div>
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                className="sc-caSCKo jtbUen"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                <div
+                  className="sc-bwzfXH jMGuhn"
+                >
+                  <p
+                    className="sc-bxivhb iBTcEE"
+                  >
+                    <span
+                      className="sc-htpNat bCblnl"
+                    />
+                    <span>
+                      <div
+                        className="sc-bwzfXH eSqaig"
+                      >
+                        <div
+                          className="sc-bwzfXH doEFQb"
+                        >
+                          <img
+                            src="http://via.placeholder.com/100x100"
+                          />
+                        </div>
+                        <p
+                          className="sc-bxivhb kDWgYC"
+                        >
+                          Foo B
+                        </p>
+                      </div>
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                className="sc-caSCKo jtbUen"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                <div
+                  className="sc-bwzfXH jMGuhn"
+                >
+                  <p
+                    className="sc-bxivhb iBTcEE"
+                  >
+                    <span
+                      className="sc-htpNat bCblnl"
+                    />
+                    <span>
+                      <div
+                        className="sc-bwzfXH eSqaig"
+                      >
+                        <div
+                          className="sc-bwzfXH doEFQb"
+                        >
+                          <img
+                            src="http://via.placeholder.com/100x100"
+                          />
+                        </div>
+                        <p
+                          className="sc-bxivhb kDWgYC"
+                        >
+                          Bar C
+                        </p>
+                      </div>
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                className="sc-caSCKo jtbUen"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                <div
+                  className="sc-bwzfXH jMGuhn"
+                >
+                  <p
+                    className="sc-bxivhb iBTcEE"
+                  >
+                    <span
+                      className="sc-htpNat bCblnl"
+                    />
+                    <span>
+                      <div
+                        className="sc-bwzfXH eSqaig"
+                      >
+                        <div
+                          className="sc-bwzfXH doEFQb"
+                        >
+                          <img
+                            src="http://via.placeholder.com/100x100"
+                          />
+                        </div>
+                        <p
+                          className="sc-bxivhb kDWgYC"
+                        >
+                          Foo D
+                        </p>
+                      </div>
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                className="sc-caSCKo jtbUen"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                <div
+                  className="sc-bwzfXH jMGuhn"
+                >
+                  <p
+                    className="sc-bxivhb iBTcEE"
+                  >
+                    <span
+                      className="sc-htpNat bCblnl"
+                    />
+                    <span>
+                      <div
+                        className="sc-bwzfXH eSqaig"
+                      >
+                        <div
+                          className="sc-bwzfXH doEFQb"
+                        >
+                          <img
+                            src="http://via.placeholder.com/100x100"
+                          />
+                        </div>
+                        <p
+                          className="sc-bxivhb kDWgYC"
+                        >
+                          Bar E
+                        </p>
+                      </div>
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div
+                className="sc-caSCKo jtbUen"
+                onClick={[Function]}
+                onMouseEnter={[Function]}
+              >
+                <div
+                  className="sc-bwzfXH jMGuhn"
+                >
+                  <p
+                    className="sc-bxivhb iBTcEE"
+                  >
+                    <span
+                      className="sc-htpNat bCblnl"
+                    />
+                    <span>
+                      <div
+                        className="sc-bwzfXH eSqaig"
+                      >
+                        <div
+                          className="sc-bwzfXH doEFQb"
+                        >
+                          <img
+                            src="http://via.placeholder.com/100x100"
+                          />
+                        </div>
+                        <p
+                          className="sc-bxivhb kDWgYC"
+                        >
+                          Bar F
+                        </p>
+                      </div>
+                    </span>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </MockPortal>
+</div>
+`;
+
 exports[`Storyshots Select Default 1`] = `
 <div
   className="sc-kgAjT ciiNMD"

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -32,7 +32,7 @@ type PropsType<GenericOption extends OptionBase> = {
     disabled?: boolean;
     onChange(value: string): void;
     renderOption?(option: GenericOption): JSX.Element;
-    renderInput?(isOpen: boolean, inputOption: OptionBase, placeholder?: string): JSX.Element;
+    renderInput?(inputOption: OptionBase, placeholder?: string): JSX.Element;
 };
 class Select<GenericOption extends OptionBase> extends Component<PropsType<GenericOption>, StateType> {
     private readonly inputRef: RefObject<HTMLInputElement>;
@@ -155,27 +155,23 @@ class Select<GenericOption extends OptionBase> extends Component<PropsType<Gener
             >
                 <StyledInput disabled={!this.props.disabled ? false : this.props.disabled}>
                     <Box alignItems="stretch">
-                        {this.props.renderInput !== undefined &&
-                            this.props.renderInput(this.state.isOpen, selectedOption, this.props.placeholder)}
+                        {(this.state.isOpen && (
+                            <>
+                                <Box alignItems="center" margin={trbl(0, 6, 0, 0)}>
+                                    <Icon icon="search" size="small" color={'#d2d7e0'} />
+                                </Box>
 
-                        {(this.props.renderInput === undefined &&
-                            (this.state.isOpen && (
-                                <>
-                                    <Box alignItems="center" margin={trbl(0, 6, 0, 0)}>
-                                        <Icon icon="search" size="small" color={'#d2d7e0'} />
-                                    </Box>
-
-                                    <input
-                                        ref={this.inputRef}
-                                        type="text"
-                                        placeholder={this.props.placeholder}
-                                        value={this.state.input}
-                                        onChange={(event: ChangeEvent<HTMLInputElement>): void =>
-                                            this.handleInput(event.target.value)
-                                        }
-                                    />
-                                </>
-                            ))) ||
+                                <input
+                                    ref={this.inputRef}
+                                    type="text"
+                                    placeholder={this.props.placeholder}
+                                    value={this.state.input}
+                                    onChange={(event: ChangeEvent<HTMLInputElement>): void =>
+                                        this.handleInput(event.target.value)
+                                    }
+                                />
+                            </>
+                        )) ||
                             (this.props.renderInput === undefined && (
                                 <Box alignItems="center" grow={1} onClick={this.open}>
                                     {(this.props.value !== '' && <Text>{selectedOption.label}</Text>) || (
@@ -184,7 +180,13 @@ class Select<GenericOption extends OptionBase> extends Component<PropsType<Gener
                                         </Text>
                                     )}
                                 </Box>
+                            )) ||
+                            (this.props.renderInput !== undefined && (
+                                <Box alignItems="center" grow={1} onClick={this.open}>
+                                    {this.props.renderInput(selectedOption, this.props.placeholder)}
+                                </Box>
                             ))}
+
                         <Button
                             compact
                             flat
@@ -230,18 +232,23 @@ class Select<GenericOption extends OptionBase> extends Component<PropsType<Gener
                                                 this.handleChange(option.value);
                                             }}
                                         >
-                                            <Text descriptive={option.value === this.props.value}>
+                                            <Box alignItems="center" inline>
                                                 <Box margin={trbl(0, 6, 0, 0)} inline>
                                                     {option.value === this.props.value && (
-                                                        <Icon size="small" icon="checkmark" />
+                                                        <Text descriptive={option.value === this.props.value}>
+                                                            <Icon size="small" icon="checkmark" />
+                                                        </Text>
                                                     )}
                                                 </Box>
-                                                <span>
+                                                <div>
                                                     {(this.props.renderOption !== undefined &&
-                                                        this.props.renderOption(option)) ||
-                                                        option.label}
-                                                </span>
-                                            </Text>
+                                                        this.props.renderOption(option)) || (
+                                                        <Text descriptive={option.value === this.props.value} inline>
+                                                            {option.label}
+                                                        </Text>
+                                                    )}
+                                                </div>
+                                            </Box>
                                         </Option>
                                     ))}
                             </FoldOut>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -32,8 +32,8 @@ type PropsType<GenericOption extends OptionBase> = {
     disabled?: boolean;
     onChange(value: string): void;
     renderOption?(option: GenericOption): JSX.Element;
+    renderInput?(isOpen: boolean, inputOption: OptionBase, placeholder?: string): JSX.Element;
 };
-
 class Select<GenericOption extends OptionBase> extends Component<PropsType<GenericOption>, StateType> {
     private readonly inputRef: RefObject<HTMLInputElement>;
     private wrapperRef: HTMLDivElement;
@@ -155,30 +155,36 @@ class Select<GenericOption extends OptionBase> extends Component<PropsType<Gener
             >
                 <StyledInput disabled={!this.props.disabled ? false : this.props.disabled}>
                     <Box alignItems="stretch">
-                        {(this.state.isOpen && (
-                            <>
-                                <Box alignItems="center" margin={trbl(0, 6, 0, 0)}>
-                                    <Icon icon="search" size="small" color={'#d2d7e0'} />
+                        {this.props.renderInput !== undefined &&
+                            this.props.renderInput(this.state.isOpen, selectedOption, this.props.placeholder)}
+
+                        {(this.props.renderInput === undefined &&
+                            (this.state.isOpen && (
+                                <>
+                                    <Box alignItems="center" margin={trbl(0, 6, 0, 0)}>
+                                        <Icon icon="search" size="small" color={'#d2d7e0'} />
+                                    </Box>
+
+                                    <input
+                                        ref={this.inputRef}
+                                        type="text"
+                                        placeholder={this.props.placeholder}
+                                        value={this.state.input}
+                                        onChange={(event: ChangeEvent<HTMLInputElement>): void =>
+                                            this.handleInput(event.target.value)
+                                        }
+                                    />
+                                </>
+                            ))) ||
+                            (this.props.renderInput === undefined && (
+                                <Box alignItems="center" grow={1} onClick={this.open}>
+                                    {(this.props.value !== '' && <Text>{selectedOption.label}</Text>) || (
+                                        <Text descriptive>
+                                            <StyledPlaceholder>{this.props.placeholder}</StyledPlaceholder>
+                                        </Text>
+                                    )}
                                 </Box>
-                                <input
-                                    ref={this.inputRef}
-                                    type="text"
-                                    placeholder={this.props.placeholder}
-                                    value={this.state.input}
-                                    onChange={(event: ChangeEvent<HTMLInputElement>): void =>
-                                        this.handleInput(event.target.value)
-                                    }
-                                />
-                            </>
-                        )) || (
-                            <Box alignItems="center" grow={1} onClick={this.open}>
-                                {(this.props.value !== '' && <Text>{selectedOption.label}</Text>) || (
-                                    <Text descriptive>
-                                        <StyledPlaceholder>{this.props.placeholder}</StyledPlaceholder>
-                                    </Text>
-                                )}
-                            </Box>
-                        )}
+                            ))}
                         <Button
                             compact
                             flat

--- a/src/components/Select/story.tsx
+++ b/src/components/Select/story.tsx
@@ -1,7 +1,10 @@
 import { storiesOf } from '@storybook/react';
 import React, { Component } from 'react';
-import Select from '.';
+import Select, { OptionBase } from '.';
 import { object, text, boolean } from '@storybook/addon-knobs/react';
+import Box from '../Box';
+import Text from '../Text';
+import trbl from '../../utility/trbl';
 
 const options = [
     {
@@ -42,8 +45,13 @@ const options = [
     },
 ];
 
-class Demo extends Component<{}, { value: string }> {
-    public constructor(props: {}) {
+type PropsType = {};
+
+type StateType = {
+    value: string;
+};
+class Demo extends Component<PropsType, StateType> {
+    public constructor(props: PropsType) {
         super(props);
 
         this.state = {
@@ -69,6 +77,71 @@ class Demo extends Component<{}, { value: string }> {
     }
 }
 
-storiesOf('Select', module).add('Default', () => {
-    return <Demo />;
-});
+const renderInput = (isOpen: boolean, inputOption: OptionBase, placeholder?: string): JSX.Element => {
+    if (inputOption.label !== '') {
+        return (
+            <Box margin={trbl(6)} grow={1} width="100%" direction="row" alignItems="center">
+                <Box margin={trbl(0, 9, 0, 0)}>
+                    <img src="http://via.placeholder.com/100x100" />
+                </Box>
+                <Text variant="large"> {inputOption.label}</Text>
+            </Box>
+        );
+    } else {
+        return (
+            <Box margin={trbl(6)} grow={1} width="100%" direction="row" alignItems="center">
+                <Text descriptive>{placeholder ? placeholder : 'Make a selection'}</Text>
+            </Box>
+        );
+    }
+};
+
+const renderOption = (option: OptionBase): JSX.Element => {
+    return (
+        <Box margin={trbl(6)} grow={1} width="100%" direction="row" alignItems="center">
+            <Box margin={trbl(0, 9, 0, 0)}>
+                <img src="http://via.placeholder.com/100x100" />
+            </Box>
+            <Text variant="large">{option.label}</Text>
+        </Box>
+    );
+};
+
+/*tslint:disable*/
+class RenderInputDemo extends Component<PropsType, StateType> {
+    public constructor(props: PropsType) {
+        super(props);
+
+        this.state = {
+            value: '',
+        };
+    }
+
+    public handleChange = (value: string): void => {
+        this.setState({ value });
+    };
+
+    public render(): JSX.Element {
+        return (
+            <Select
+                placeholder={text('placeholder', 'Select a value')}
+                value={this.state.value}
+                emptyText={text('emptyText', 'No results')}
+                onChange={this.handleChange}
+                disabled={boolean('disabled', false)}
+                options={object('options', options)}
+                renderInput={renderInput}
+                renderOption={renderOption}
+            />
+        );
+    }
+}
+/*tslint:enable*/
+
+storiesOf('Select', module)
+    .add('Default', () => {
+        return <Demo />;
+    })
+    .add('Custom rendering', () => {
+        return <RenderInputDemo />;
+    });

--- a/src/components/Select/story.tsx
+++ b/src/components/Select/story.tsx
@@ -77,10 +77,10 @@ class Demo extends Component<PropsType, StateType> {
     }
 }
 
-const renderInput = (isOpen: boolean, inputOption: OptionBase, placeholder?: string): JSX.Element => {
+const renderInput = (inputOption: OptionBase, placeholder?: string): JSX.Element => {
     if (inputOption.label !== '') {
         return (
-            <Box margin={trbl(6)} grow={1} width="100%" direction="row" alignItems="center">
+            <Box margin={trbl(6)} direction="row" alignItems="center">
                 <Box margin={trbl(0, 9, 0, 0)}>
                     <img src="http://via.placeholder.com/100x100" />
                 </Box>
@@ -89,7 +89,7 @@ const renderInput = (isOpen: boolean, inputOption: OptionBase, placeholder?: str
         );
     } else {
         return (
-            <Box margin={trbl(6)} grow={1} width="100%" direction="row" alignItems="center">
+            <Box margin={trbl(6)} direction="row" alignItems="center">
                 <Text descriptive>{placeholder ? placeholder : 'Make a selection'}</Text>
             </Box>
         );

--- a/src/components/Select/story.tsx
+++ b/src/components/Select/story.tsx
@@ -50,6 +50,7 @@ type PropsType = {};
 type StateType = {
     value: string;
 };
+
 class Demo extends Component<PropsType, StateType> {
     public constructor(props: PropsType) {
         super(props);

--- a/src/components/Select/style.tsx
+++ b/src/components/Select/style.tsx
@@ -96,7 +96,6 @@ const StyledWindow = withProps<WindowProps, HTMLDivElement>(styled.div)`
     box-sizing: border-box;
     position: absolute;
     max-height: 240px;
-    overflow: hidden;
     margin-top: 6px;
     left: ${({ rect }): string => (rect !== undefined ? `${rect.left - INNER_OFFSET}px` : '')};
     width: ${({ rect }): string => (rect !== undefined ? `${rect.width + INNER_OFFSET + 6}px` : '')};

--- a/src/components/Select/style.tsx
+++ b/src/components/Select/style.tsx
@@ -97,7 +97,7 @@ const StyledWindow = withProps<WindowProps, HTMLDivElement>(styled.div)`
     position: absolute;
     max-height: 240px;
     overflow: hidden;
-    top: ${({ rect }): string => (rect !== undefined ? `${rect.top + rect.height + INNER_OFFSET}px` : '')};
+    margin-top: 6px;
     left: ${({ rect }): string => (rect !== undefined ? `${rect.left - INNER_OFFSET}px` : '')};
     width: ${({ rect }): string => (rect !== undefined ? `${rect.width + INNER_OFFSET + 6}px` : '')};
     padding-top: ${({ isOpen }): string => (isOpen ? '6px' : '0')};
@@ -118,9 +118,7 @@ const StyledInput = withProps<InputProps>(styled.div)`
     padding: 0 0 0 12px;
     border: solid 1px ${({ theme }): string => theme.Select.input.borderColor};
     background: ${({ theme, disabled }): string =>
-        disabled
-            ? theme.Select.disabled.background
-            : theme.Select.input.background};
+        disabled ? theme.Select.disabled.background : theme.Select.input.background};
     border-radius: ${({ theme }): string => theme.Select.common.borderRadius};
     opacity: ${({ disabled }): string => (disabled ? '0.7' : '1')};
 

--- a/src/components/Select/test.tsx
+++ b/src/components/Select/test.tsx
@@ -320,6 +320,22 @@ describe('Select', () => {
         expect(renderOption).toHaveBeenCalledTimes(options.length);
     });
 
+    it('should render an alternative input rendering', () => {
+        const renderInput = jest.fn();
+
+        mountWithTheme(
+            <Select
+                onChange={(): void => undefined}
+                value=""
+                emptyText="empty"
+                options={options}
+                renderInput={renderInput}
+            />,
+        );
+
+        expect(renderInput).toHaveBeenCalledTimes(1);
+    });
+
     it('should show an empty state', () => {
         const emptyText = 'mock empty text';
 


### PR DESCRIPTION
### This PR:

proposed release: `minor`


**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Changes** 🌀
- `Select` now supports alternative input rendering. Added a story showing alternative input and option rendering.
- Fixes broken scroll in `Select`
