### PR TITLE
Added z-index to Scrollbox shadows

### DIFF
--- a/src/components/Modal/__snapshots__/story.storyshot
+++ b/src/components/Modal/__snapshots__/story.storyshot
@@ -59,7 +59,7 @@ exports[`Storyshots Modal Default 1`] = `
             className="sc-cMljjf krgCXT"
           >
             <div
-              className="sc-jAaTju cirfDK"
+              className="sc-jAaTju fzRTCD"
             />
             <div
               className="sc-bwzfXH fiOUi"
@@ -90,7 +90,7 @@ pharetra. Duis sed magna vel odio ullamcorper gravida eu et nibh.
               </p>
             </div>
             <div
-              className="sc-jDwBTQ gosvOi"
+              className="sc-jDwBTQ cXRqdb"
             />
           </div>
         </div>
@@ -186,7 +186,7 @@ exports[`Storyshots Modal Without closeAction 1`] = `
             className="sc-cMljjf krgCXT"
           >
             <div
-              className="sc-jAaTju cirfDK"
+              className="sc-jAaTju fzRTCD"
             />
             <div
               className="sc-bwzfXH fiOUi"
@@ -217,7 +217,7 @@ pharetra. Duis sed magna vel odio ullamcorper gravida eu et nibh.
               </p>
             </div>
             <div
-              className="sc-jDwBTQ gosvOi"
+              className="sc-jDwBTQ cXRqdb"
             />
           </div>
         </div>

--- a/src/components/ScrollBox/__snapshots__/story.storyshot
+++ b/src/components/ScrollBox/__snapshots__/story.storyshot
@@ -15,7 +15,7 @@ Array [
           className="sc-cMljjf krgCXT"
         >
           <div
-            className="sc-jAaTju cirfDK"
+            className="sc-jAaTju fzRTCD"
           />
           <div
             className="sc-bwzfXH gAalro"
@@ -71,7 +71,7 @@ Array [
             </p>
           </div>
           <div
-            className="sc-jDwBTQ gosvOi"
+            className="sc-jDwBTQ cXRqdb"
           />
         </div>
       </div>

--- a/src/components/ScrollBox/style.tsx
+++ b/src/components/ScrollBox/style.tsx
@@ -61,6 +61,7 @@ const StyledTop = withProps<effectPropsType, HTMLDivElement>(styled.div)`
     top: 0;
     left: 0;
     right: 0;
+    z-index: 1;
 `;
 
 const StyledBottom = withProps<effectPropsType, HTMLDivElement>(styled.div)`
@@ -72,6 +73,7 @@ const StyledBottom = withProps<effectPropsType, HTMLDivElement>(styled.div)`
     bottom: 0;
     left: 0;
     right: 0;
+    z-index: 1;
 `;
 
 export default StyledScrollBox;


### PR DESCRIPTION
### This PR:

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Adds** ✨
- A z-index to the top/bottom shadows in the `ScrollBox` component.
