### PR TITLE
Inputfield - improved focus and feedback

### DIFF
--- a/src/components/FormRow/__snapshots__/story.storyshot
+++ b/src/components/FormRow/__snapshots__/story.storyshot
@@ -38,7 +38,7 @@ exports[`Storyshots FormRow Default 1`] = `
             className="sc-bwzfXH kxsXCq"
           >
             <div
-              className="sc-eNQAEJ lhLkZ"
+              className="sc-eNQAEJ bdGfQx"
               disabled={undefined}
               onBlurCapture={[Function]}
               onClick={[Function]}
@@ -71,7 +71,7 @@ exports[`Storyshots FormRow Default 1`] = `
             className="sc-bwzfXH fkLxMw"
           >
             <div
-              className="sc-eNQAEJ lhLkZ"
+              className="sc-eNQAEJ bdGfQx"
               disabled={undefined}
               onBlurCapture={[Function]}
               onClick={[Function]}
@@ -105,7 +105,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ lhLkZ"
+            className="sc-eNQAEJ bdGfQx"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -170,7 +170,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ lhLkZ"
+            className="sc-eNQAEJ bdGfQx"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -203,7 +203,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ lhLkZ"
+            className="sc-eNQAEJ bdGfQx"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -410,7 +410,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           className="sc-bwzfXH iFjvZT"
         >
           <div
-            className="sc-eNQAEJ lhLkZ"
+            className="sc-eNQAEJ bdGfQx"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -466,7 +466,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           className="sc-bwzfXH iFjvZT"
         >
           <div
-            className="sc-eNQAEJ lhLkZ"
+            className="sc-eNQAEJ bdGfQx"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}

--- a/src/components/FormRow/__snapshots__/story.storyshot
+++ b/src/components/FormRow/__snapshots__/story.storyshot
@@ -38,7 +38,7 @@ exports[`Storyshots FormRow Default 1`] = `
             className="sc-bwzfXH kxsXCq"
           >
             <div
-              className="sc-eNQAEJ hRGSZC"
+              className="sc-eNQAEJ ajvZf"
               disabled={undefined}
               onBlurCapture={[Function]}
               onClick={[Function]}
@@ -71,7 +71,7 @@ exports[`Storyshots FormRow Default 1`] = `
             className="sc-bwzfXH fkLxMw"
           >
             <div
-              className="sc-eNQAEJ hRGSZC"
+              className="sc-eNQAEJ ajvZf"
               disabled={undefined}
               onBlurCapture={[Function]}
               onClick={[Function]}
@@ -105,7 +105,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ hRGSZC"
+            className="sc-eNQAEJ ajvZf"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -170,7 +170,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ hRGSZC"
+            className="sc-eNQAEJ ajvZf"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -203,7 +203,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ hRGSZC"
+            className="sc-eNQAEJ ajvZf"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -410,7 +410,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           className="sc-bwzfXH iFjvZT"
         >
           <div
-            className="sc-eNQAEJ hRGSZC"
+            className="sc-eNQAEJ ajvZf"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -466,7 +466,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           className="sc-bwzfXH iFjvZT"
         >
           <div
-            className="sc-eNQAEJ hRGSZC"
+            className="sc-eNQAEJ ajvZf"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}

--- a/src/components/FormRow/__snapshots__/story.storyshot
+++ b/src/components/FormRow/__snapshots__/story.storyshot
@@ -38,7 +38,7 @@ exports[`Storyshots FormRow Default 1`] = `
             className="sc-bwzfXH kxsXCq"
           >
             <div
-              className="sc-eNQAEJ bdGfQx"
+              className="sc-eNQAEJ hRGSZC"
               disabled={undefined}
               onBlurCapture={[Function]}
               onClick={[Function]}
@@ -55,7 +55,7 @@ exports[`Storyshots FormRow Default 1`] = `
                 </span>
               </div>
               <input
-                className="sc-dxgOiQ jLQDMB"
+                className="sc-dxgOiQ cNbhAj"
                 disabled={undefined}
                 id={undefined}
                 name="Initials"
@@ -71,7 +71,7 @@ exports[`Storyshots FormRow Default 1`] = `
             className="sc-bwzfXH fkLxMw"
           >
             <div
-              className="sc-eNQAEJ bdGfQx"
+              className="sc-eNQAEJ hRGSZC"
               disabled={undefined}
               onBlurCapture={[Function]}
               onClick={[Function]}
@@ -88,7 +88,7 @@ exports[`Storyshots FormRow Default 1`] = `
                 </span>
               </div>
               <input
-                className="sc-dxgOiQ jLQDMB"
+                className="sc-dxgOiQ cNbhAj"
                 disabled={undefined}
                 id={undefined}
                 name="First name"
@@ -105,7 +105,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ bdGfQx"
+            className="sc-eNQAEJ hRGSZC"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -122,7 +122,7 @@ exports[`Storyshots FormRow Default 1`] = `
               </span>
             </div>
             <input
-              className="sc-dxgOiQ jLQDMB"
+              className="sc-dxgOiQ cNbhAj"
               disabled={undefined}
               id={undefined}
               name="Surname"
@@ -170,7 +170,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ bdGfQx"
+            className="sc-eNQAEJ hRGSZC"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -187,7 +187,7 @@ exports[`Storyshots FormRow Default 1`] = `
               </span>
             </div>
             <input
-              className="sc-dxgOiQ jLQDMB"
+              className="sc-dxgOiQ cNbhAj"
               disabled={undefined}
               id={undefined}
               name="Country"
@@ -203,7 +203,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ bdGfQx"
+            className="sc-eNQAEJ hRGSZC"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -220,7 +220,7 @@ exports[`Storyshots FormRow Default 1`] = `
               </span>
             </div>
             <input
-              className="sc-dxgOiQ jLQDMB"
+              className="sc-dxgOiQ cNbhAj"
               disabled={undefined}
               id={undefined}
               name="City"
@@ -410,7 +410,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           className="sc-bwzfXH iFjvZT"
         >
           <div
-            className="sc-eNQAEJ bdGfQx"
+            className="sc-eNQAEJ hRGSZC"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -427,7 +427,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
               </span>
             </div>
             <input
-              className="sc-dxgOiQ jLQDMB"
+              className="sc-dxgOiQ cNbhAj"
               disabled={undefined}
               id={undefined}
               name="Name"
@@ -466,7 +466,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           className="sc-bwzfXH iFjvZT"
         >
           <div
-            className="sc-eNQAEJ bdGfQx"
+            className="sc-eNQAEJ hRGSZC"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -483,7 +483,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
               </span>
             </div>
             <input
-              className="sc-dxgOiQ jLQDMB"
+              className="sc-dxgOiQ cNbhAj"
               disabled={undefined}
               id={undefined}
               name="Country"

--- a/src/components/FormRow/__snapshots__/story.storyshot
+++ b/src/components/FormRow/__snapshots__/story.storyshot
@@ -38,7 +38,7 @@ exports[`Storyshots FormRow Default 1`] = `
             className="sc-bwzfXH kxsXCq"
           >
             <div
-              className="sc-eNQAEJ ajvZf"
+              className="sc-eNQAEJ iYCWTZ"
               disabled={undefined}
               onBlurCapture={[Function]}
               onClick={[Function]}
@@ -71,7 +71,7 @@ exports[`Storyshots FormRow Default 1`] = `
             className="sc-bwzfXH fkLxMw"
           >
             <div
-              className="sc-eNQAEJ ajvZf"
+              className="sc-eNQAEJ iYCWTZ"
               disabled={undefined}
               onBlurCapture={[Function]}
               onClick={[Function]}
@@ -105,7 +105,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ ajvZf"
+            className="sc-eNQAEJ iYCWTZ"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -170,7 +170,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ ajvZf"
+            className="sc-eNQAEJ iYCWTZ"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -203,7 +203,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ ajvZf"
+            className="sc-eNQAEJ iYCWTZ"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -410,7 +410,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           className="sc-bwzfXH iFjvZT"
         >
           <div
-            className="sc-eNQAEJ ajvZf"
+            className="sc-eNQAEJ iYCWTZ"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
@@ -466,7 +466,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           className="sc-bwzfXH iFjvZT"
         >
           <div
-            className="sc-eNQAEJ ajvZf"
+            className="sc-eNQAEJ iYCWTZ"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}

--- a/src/components/Range/__snapshots__/story.storyshot
+++ b/src/components/Range/__snapshots__/story.storyshot
@@ -14,7 +14,7 @@ exports[`Storyshots Range Default 1`] = `
         className="sc-bwzfXH jtHmcE"
       >
         <div
-          className="sc-eNQAEJ hRGSZC"
+          className="sc-eNQAEJ ajvZf"
           disabled={false}
           onBlurCapture={[Function]}
           onClick={[Function]}
@@ -47,7 +47,7 @@ exports[`Storyshots Range Default 1`] = `
         className="sc-bwzfXH jtHmcE"
       >
         <div
-          className="sc-eNQAEJ hRGSZC"
+          className="sc-eNQAEJ ajvZf"
           disabled={false}
           onBlurCapture={[Function]}
           onClick={[Function]}

--- a/src/components/Range/__snapshots__/story.storyshot
+++ b/src/components/Range/__snapshots__/story.storyshot
@@ -14,14 +14,14 @@ exports[`Storyshots Range Default 1`] = `
         className="sc-bwzfXH jtHmcE"
       >
         <div
-          className="sc-eNQAEJ lhLkZ"
+          className="sc-eNQAEJ hRGSZC"
           disabled={false}
           onBlurCapture={[Function]}
           onClick={[Function]}
           onFocusCapture={[Function]}
         >
           <input
-            className="sc-dxgOiQ jLQDMB"
+            className="sc-dxgOiQ cNbhAj"
             disabled={false}
             id={undefined}
             name="minimum"
@@ -47,14 +47,14 @@ exports[`Storyshots Range Default 1`] = `
         className="sc-bwzfXH jtHmcE"
       >
         <div
-          className="sc-eNQAEJ lhLkZ"
+          className="sc-eNQAEJ hRGSZC"
           disabled={false}
           onBlurCapture={[Function]}
           onClick={[Function]}
           onFocusCapture={[Function]}
         >
           <input
-            className="sc-dxgOiQ jLQDMB"
+            className="sc-dxgOiQ cNbhAj"
             disabled={false}
             id={undefined}
             name="maximum"

--- a/src/components/Range/__snapshots__/story.storyshot
+++ b/src/components/Range/__snapshots__/story.storyshot
@@ -14,7 +14,7 @@ exports[`Storyshots Range Default 1`] = `
         className="sc-bwzfXH jtHmcE"
       >
         <div
-          className="sc-eNQAEJ ajvZf"
+          className="sc-eNQAEJ iYCWTZ"
           disabled={false}
           onBlurCapture={[Function]}
           onClick={[Function]}
@@ -47,7 +47,7 @@ exports[`Storyshots Range Default 1`] = `
         className="sc-bwzfXH jtHmcE"
       >
         <div
-          className="sc-eNQAEJ ajvZf"
+          className="sc-eNQAEJ iYCWTZ"
           disabled={false}
           onBlurCapture={[Function]}
           onClick={[Function]}

--- a/src/components/TextField/formatters/withCurrencyFormatting/__snapshots__/story.storyshot
+++ b/src/components/TextField/formatters/withCurrencyFormatting/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots TextField Default 1`] = `
 <div
-  className="sc-eNQAEJ ajvZf"
+  className="sc-eNQAEJ iYCWTZ"
   disabled={false}
   onBlurCapture={[Function]}
   onClick={[Function]}
@@ -45,7 +45,7 @@ exports[`Storyshots TextField Default 1`] = `
 exports[`Storyshots TextField With Currency formatting 1`] = `
 Array [
   <div
-    className="sc-eNQAEJ ajvZf"
+    className="sc-eNQAEJ iYCWTZ"
     disabled={false}
     onBlurCapture={[Function]}
     onClick={[Function]}
@@ -110,7 +110,7 @@ Array [
 exports[`Storyshots TextField With Feedback 1`] = `
 Array [
   <div
-    className="sc-eNQAEJ ajvZf"
+    className="sc-eNQAEJ iYCWTZ"
     disabled={false}
     onBlurCapture={[Function]}
     onClick={[Function]}
@@ -184,7 +184,7 @@ Array [
 
 exports[`Storyshots TextField With Number formatting 1`] = `
 <div
-  className="sc-eNQAEJ ajvZf"
+  className="sc-eNQAEJ iYCWTZ"
   disabled={undefined}
   onBlurCapture={[Function]}
   onClick={[Function]}

--- a/src/components/TextField/formatters/withCurrencyFormatting/__snapshots__/story.storyshot
+++ b/src/components/TextField/formatters/withCurrencyFormatting/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots TextField Default 1`] = `
 <div
-  className="sc-eNQAEJ hRGSZC"
+  className="sc-eNQAEJ ajvZf"
   disabled={false}
   onBlurCapture={[Function]}
   onClick={[Function]}
@@ -45,7 +45,7 @@ exports[`Storyshots TextField Default 1`] = `
 exports[`Storyshots TextField With Currency formatting 1`] = `
 Array [
   <div
-    className="sc-eNQAEJ hRGSZC"
+    className="sc-eNQAEJ ajvZf"
     disabled={false}
     onBlurCapture={[Function]}
     onClick={[Function]}
@@ -110,7 +110,7 @@ Array [
 exports[`Storyshots TextField With Feedback 1`] = `
 Array [
   <div
-    className="sc-eNQAEJ hRGSZC"
+    className="sc-eNQAEJ ajvZf"
     disabled={false}
     onBlurCapture={[Function]}
     onClick={[Function]}
@@ -184,7 +184,7 @@ Array [
 
 exports[`Storyshots TextField With Number formatting 1`] = `
 <div
-  className="sc-eNQAEJ hRGSZC"
+  className="sc-eNQAEJ ajvZf"
   disabled={undefined}
   onBlurCapture={[Function]}
   onClick={[Function]}

--- a/src/components/TextField/formatters/withCurrencyFormatting/__snapshots__/story.storyshot
+++ b/src/components/TextField/formatters/withCurrencyFormatting/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots TextField Default 1`] = `
 <div
-  className="sc-eNQAEJ lhLkZ"
+  className="sc-eNQAEJ bdGfQx"
   disabled={false}
   onBlurCapture={[Function]}
   onClick={[Function]}
@@ -45,7 +45,7 @@ exports[`Storyshots TextField Default 1`] = `
 exports[`Storyshots TextField With Currency formatting 1`] = `
 Array [
   <div
-    className="sc-eNQAEJ lhLkZ"
+    className="sc-eNQAEJ dJFNrt"
     disabled={false}
     onBlurCapture={[Function]}
     onClick={[Function]}
@@ -110,7 +110,7 @@ Array [
 exports[`Storyshots TextField With Feedback 1`] = `
 Array [
   <div
-    className="sc-eNQAEJ eTWvPu"
+    className="sc-eNQAEJ ewhTPW"
     disabled={false}
     onBlurCapture={[Function]}
     onClick={[Function]}

--- a/src/components/TextField/formatters/withCurrencyFormatting/__snapshots__/story.storyshot
+++ b/src/components/TextField/formatters/withCurrencyFormatting/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots TextField Default 1`] = `
 <div
-  className="sc-eNQAEJ bdGfQx"
+  className="sc-eNQAEJ hRGSZC"
   disabled={false}
   onBlurCapture={[Function]}
   onClick={[Function]}
@@ -19,7 +19,7 @@ exports[`Storyshots TextField Default 1`] = `
     </span>
   </div>
   <input
-    className="sc-dxgOiQ jLQDMB"
+    className="sc-dxgOiQ cNbhAj"
     disabled={false}
     id={undefined}
     name="firstname"
@@ -45,7 +45,7 @@ exports[`Storyshots TextField Default 1`] = `
 exports[`Storyshots TextField With Currency formatting 1`] = `
 Array [
   <div
-    className="sc-eNQAEJ dJFNrt"
+    className="sc-eNQAEJ hRGSZC"
     disabled={false}
     onBlurCapture={[Function]}
     onClick={[Function]}
@@ -62,7 +62,7 @@ Array [
       </span>
     </div>
     <input
-      className="sc-dxgOiQ jLQDMB"
+      className="sc-dxgOiQ cNbhAj"
       disabled={false}
       id={undefined}
       name="first name"
@@ -110,7 +110,7 @@ Array [
 exports[`Storyshots TextField With Feedback 1`] = `
 Array [
   <div
-    className="sc-eNQAEJ ewhTPW"
+    className="sc-eNQAEJ hRGSZC"
     disabled={false}
     onBlurCapture={[Function]}
     onClick={[Function]}
@@ -127,7 +127,7 @@ Array [
       </span>
     </div>
     <input
-      className="sc-dxgOiQ jLQDMB"
+      className="sc-dxgOiQ cNbhAj"
       disabled={false}
       id={undefined}
       name="firstname"
@@ -184,14 +184,14 @@ Array [
 
 exports[`Storyshots TextField With Number formatting 1`] = `
 <div
-  className="sc-eNQAEJ lhLkZ"
+  className="sc-eNQAEJ hRGSZC"
   disabled={undefined}
   onBlurCapture={[Function]}
   onClick={[Function]}
   onFocusCapture={[Function]}
 >
   <input
-    className="sc-dxgOiQ jLQDMB"
+    className="sc-dxgOiQ cNbhAj"
     disabled={undefined}
     id={undefined}
     name="min value"

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -70,7 +70,7 @@ class TextField extends Component<PropsType, StateType> {
                 <StyledWrapper
                     focus={this.state.focus}
                     disabled={this.props.disabled}
-                    feedback={this.props.feedback}
+                    feedback={this.props.feedback ? this.props.feedback : { severity: 'success', message: '' }}
                     onFocusCapture={this.handleFocus}
                     onBlurCapture={this.handleBlur}
                     onClick={this.handleFocus}
@@ -84,6 +84,7 @@ class TextField extends Component<PropsType, StateType> {
                         type={this.props.type ? this.props.type : 'text'}
                         name={this.props.name}
                         disabled={this.props.disabled}
+                        feedback={this.props.feedback ? this.props.feedback : { severity: 'success', message: '' }}
                         value={this.props.value}
                         id={this.props.id}
                         focus={this.state.focus}
@@ -103,15 +104,16 @@ class TextField extends Component<PropsType, StateType> {
                         </StyledAffixWrapper>
                     )}
                 </StyledWrapper>
-                {this.props.feedback && (
-                    <Box margin={trbl(6, 0, 0, 12)}>
-                        <InlineNotification
-                            icon={this.props.feedback.severity === 'info' ? 'questionCircle' : 'dangerCircle'}
-                            message={this.props.feedback.message}
-                            severity={this.props.feedback.severity}
-                        />
-                    </Box>
-                )}
+                {this.props.feedback &&
+                    this.props.feedback.message !== '' && (
+                        <Box margin={trbl(6, 0, 0, 12)}>
+                            <InlineNotification
+                                icon={this.props.feedback.severity === 'info' ? 'questionCircle' : 'dangerCircle'}
+                                message={this.props.feedback.message}
+                                severity={this.props.feedback.severity}
+                            />
+                        </Box>
+                    )}
             </>
         );
     }

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -61,7 +61,7 @@ class TextField extends Component<PropsType, StateType> {
                 <StyledWrapper
                     focus={this.state.focus}
                     disabled={this.props.disabled}
-                    feedback={this.props.feedback ? this.props.feedback : { severity: 'success' }}
+                    feedback={this.props.feedback ? this.props.feedback.severity : 'success'}
                     onFocusCapture={this.handleFocus}
                     onBlurCapture={this.handleBlur}
                     onClick={this.handleFocus}
@@ -75,7 +75,7 @@ class TextField extends Component<PropsType, StateType> {
                         type={this.props.type ? this.props.type : 'text'}
                         name={this.props.name}
                         disabled={this.props.disabled}
-                        feedback={this.props.feedback ? this.props.feedback : { severity: 'success' }}
+                        feedback={this.props.feedback ? this.props.feedback.severity : 'success'}
                         value={this.props.value}
                         id={this.props.id}
                         focus={this.state.focus}

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -61,7 +61,7 @@ class TextField extends Component<PropsType, StateType> {
                 <StyledWrapper
                     focus={this.state.focus}
                     disabled={this.props.disabled}
-                    feedback={this.props.feedback ? this.props.feedback.severity : 'success'}
+                    severity={this.props.feedback ? this.props.feedback.severity : 'success'}
                     onFocusCapture={this.handleFocus}
                     onBlurCapture={this.handleBlur}
                     onClick={this.handleFocus}
@@ -75,7 +75,7 @@ class TextField extends Component<PropsType, StateType> {
                         type={this.props.type ? this.props.type : 'text'}
                         name={this.props.name}
                         disabled={this.props.disabled}
-                        feedback={this.props.feedback ? this.props.feedback.severity : 'success'}
+                        severity={this.props.feedback ? this.props.feedback.severity : 'success'}
                         value={this.props.value}
                         id={this.props.id}
                         focus={this.state.focus}

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -38,25 +38,16 @@ class TextField extends Component<PropsType, StateType> {
     public constructor(props: PropsType) {
         super(props);
 
-        this.state = {
-            focus: false,
-        };
+        this.state = { focus: false };
     }
 
     public handleFocus = (): void => {
-        this.setState({
-            focus: true,
-        });
-        this.inputRef.focus();
-
+        this.setState({ focus: true }, () => this.inputRef.focus());
         if (this.props.onFocus !== undefined) this.props.onFocus();
     };
 
     public handleBlur = (): void => {
-        this.setState({
-            focus: false,
-        });
-
+        this.setState({ focus: false });
         if (this.props.onBlur !== undefined) this.props.onBlur();
     };
 
@@ -70,7 +61,7 @@ class TextField extends Component<PropsType, StateType> {
                 <StyledWrapper
                     focus={this.state.focus}
                     disabled={this.props.disabled}
-                    feedback={this.props.feedback ? this.props.feedback : { severity: 'success', message: '' }}
+                    feedback={this.props.feedback ? this.props.feedback : { severity: 'success' }}
                     onFocusCapture={this.handleFocus}
                     onBlurCapture={this.handleBlur}
                     onClick={this.handleFocus}
@@ -84,7 +75,7 @@ class TextField extends Component<PropsType, StateType> {
                         type={this.props.type ? this.props.type : 'text'}
                         name={this.props.name}
                         disabled={this.props.disabled}
-                        feedback={this.props.feedback ? this.props.feedback : { severity: 'success', message: '' }}
+                        feedback={this.props.feedback ? this.props.feedback : { severity: 'success' }}
                         value={this.props.value}
                         id={this.props.id}
                         focus={this.state.focus}
@@ -93,9 +84,7 @@ class TextField extends Component<PropsType, StateType> {
                         onBlur={this.handleBlur}
                         innerRef={(ref): void => {
                             this.inputRef = ref;
-                            if (this.props.extractRef !== undefined) {
-                                this.props.extractRef(ref);
-                            }
+                            if (this.props.extractRef !== undefined) this.props.extractRef(ref);
                         }}
                     />
                     {this.props.suffix && (

--- a/src/components/TextField/style.tsx
+++ b/src/components/TextField/style.tsx
@@ -21,7 +21,12 @@ type TextFieldThemeType = {
     };
     focus: {
         borderColor: string;
-        boxShadow: string;
+    };
+    severity: {
+        error: { boxShadow: string };
+        success: { boxShadow: string };
+        info: { boxShadow: string };
+        warning: { boxShadow: string };
     };
     disabled: {
         color: string;
@@ -36,9 +41,9 @@ type AffixProps = {
 type WrapperProps = {
     focus: boolean;
     disabled?: boolean;
-    feedback?: {
+    feedback: {
         severity: SeverityType;
-        message: string;
+        message?: string;
     };
 };
 
@@ -84,9 +89,8 @@ const StyledAffix = styled.span`
 
 const StyledWrapper = withProps<WrapperProps, HTMLDivElement>(styled.div)`
     transition: border-color 100ms, box-shadow 100ms;
-    border: solid 1px ${({ focus, theme, disabled }): string =>
-        focus && !disabled ? theme.TextField.focus.borderColor : theme.TextField.idle.common.borderColor};
-    box-shadow: ${({ focus, theme, disabled }): string => (focus && !disabled ? theme.TextField.focus.boxShadow : '')};
+    box-shadow: ${({ focus, theme, disabled }): string =>
+        focus && !disabled ? theme.TextField.severity.success.boxShadow : ''};
     font-size: ${({ theme }): string => theme.TextField.idle.common.fontSize};
     font-family: ${({ theme }): string => theme.TextField.idle.common.fontFamily};
     border-radius: ${({ theme }): string => theme.TextField.idle.common.borderRadius};
@@ -97,10 +101,10 @@ const StyledWrapper = withProps<WrapperProps, HTMLDivElement>(styled.div)`
     width: 100%;
     box-sizing: border-box;
 
-    ${({ feedback, theme, focus }): string =>
-        feedback !== undefined && feedback.severity !== 'info' && !focus
-            ? `border: solid 1px ${theme.Text.severity[feedback.severity].color};`
-            : ''};
+    ${({ feedback, theme }): string => `border: solid 1px ${theme.Text.severity[feedback.severity].color}`};
+
+    ${({ feedback, focus, theme, disabled }): string =>
+        focus && !disabled ? `box-shadow: ${theme.TextField.severity[feedback.severity].boxShadow} ` : ''};
 
     * {
         cursor: text;

--- a/src/components/TextField/style.tsx
+++ b/src/components/TextField/style.tsx
@@ -41,10 +41,7 @@ type AffixProps = {
 type WrapperProps = {
     focus: boolean;
     disabled?: boolean;
-    feedback: {
-        severity: SeverityType;
-        message?: string;
-    };
+    feedback: SeverityType;
 };
 
 const StyledInput = withProps<WrapperProps, HTMLInputElement>(styled.input)`
@@ -88,8 +85,6 @@ const StyledAffix = styled.span`
 
 const StyledWrapper = withProps<WrapperProps, HTMLDivElement>(styled.div)`
     transition: border-color 100ms, box-shadow 100ms;
-    box-shadow: ${({ focus, theme, disabled }): string =>
-        focus && !disabled ? theme.TextField.severity.success.boxShadow : ''};
     font-size: ${({ theme }): string => theme.TextField.idle.common.fontSize};
     font-family: ${({ theme }): string => theme.TextField.idle.common.fontFamily};
     border-radius: ${({ theme }): string => theme.TextField.idle.common.borderRadius};
@@ -99,13 +94,11 @@ const StyledWrapper = withProps<WrapperProps, HTMLDivElement>(styled.div)`
     width: 100%;
     box-sizing: border-box;
 
-    ${({ focus, feedback, theme }): string =>
-        focus
-            ? `border: solid 1px ${theme.Text.severity[feedback.severity].color}`
+    ${({ focus, disabled, feedback, theme }): string =>
+        focus && !disabled
+            ? `box-shadow: ${theme.TextField.severity[feedback].boxShadow}
+            border: solid 1px ${theme.Text.severity[feedback].color}`
             : `border: solid 1px ${theme.TextField.idle.common.borderColor}`};
-
-    ${({ feedback, focus, theme, disabled }): string =>
-        focus && !disabled ? `box-shadow: ${theme.TextField.severity[feedback.severity].boxShadow} ` : ''};
 
     * {
         cursor: text;

--- a/src/components/TextField/style.tsx
+++ b/src/components/TextField/style.tsx
@@ -53,7 +53,6 @@ const StyledInput = withProps<WrapperProps, HTMLInputElement>(styled.input)`
     background: ${({ theme, disabled }): string =>
         disabled ? theme.TextField.disabled.background : theme.TextField.idle.common.background};
     font-size: inherit;
-    display: block;
     padding: 6px 12px;
     line-height: 1.572;
     outline: none;
@@ -95,13 +94,15 @@ const StyledWrapper = withProps<WrapperProps, HTMLDivElement>(styled.div)`
     font-family: ${({ theme }): string => theme.TextField.idle.common.fontFamily};
     border-radius: ${({ theme }): string => theme.TextField.idle.common.borderRadius};
     display: flex;
-    position: relative;
     cursor: text;
     overflow: hidden;
     width: 100%;
     box-sizing: border-box;
 
-    ${({ feedback, theme }): string => `border: solid 1px ${theme.Text.severity[feedback.severity].color}`};
+    ${({ focus, feedback, theme }): string =>
+        focus
+            ? `border: solid 1px ${theme.Text.severity[feedback.severity].color}`
+            : `border: solid 1px ${theme.TextField.idle.common.borderColor}`};
 
     ${({ feedback, focus, theme, disabled }): string =>
         focus && !disabled ? `box-shadow: ${theme.TextField.severity[feedback.severity].boxShadow} ` : ''};

--- a/src/components/TextField/style.tsx
+++ b/src/components/TextField/style.tsx
@@ -41,7 +41,7 @@ type AffixProps = {
 type WrapperProps = {
     focus: boolean;
     disabled?: boolean;
-    feedback: SeverityType;
+    severity: SeverityType;
 };
 
 const StyledInput = withProps<WrapperProps, HTMLInputElement>(styled.input)`
@@ -94,11 +94,13 @@ const StyledWrapper = withProps<WrapperProps, HTMLDivElement>(styled.div)`
     width: 100%;
     box-sizing: border-box;
 
-    ${({ focus, disabled, feedback, theme }): string =>
-        focus && !disabled
-            ? `box-shadow: ${theme.TextField.severity[feedback].boxShadow}
-            border: solid 1px ${theme.Text.severity[feedback].color}`
+    ${({ focus, severity, theme }): string =>
+        focus
+            ? `border: solid 1px ${theme.Text.severity[severity].color}`
             : `border: solid 1px ${theme.TextField.idle.common.borderColor}`};
+
+    ${({ focus, disabled, severity, theme }): string =>
+        focus && !disabled ? `box-shadow: ${theme.TextField.severity[severity].boxShadow}` : ''};
 
     * {
         cursor: text;

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -742,8 +742,15 @@ const theme: ThemeType = {
         },
         focus: {
             borderColor: green.darker2,
-            boxShadow: '0 0 0 4px rgba(107,222,120,0.4)',
         },
+
+        severity: {
+            error: { boxShadow: '0 0 0 4px rgba(200,23,70,0.4)' },
+            success: { boxShadow: '0 0 0 4px rgba(107,222,120,0.4)' },
+            info: { boxShadow: '0 0 0 4px rgba(107,222,120,0.4)' },
+            warning: { boxShadow: '0 0 0 4px rgba(237,177,7,0.4)' },
+        },
+
         disabled: {
             color: grey.lighter2,
             background: `repeating-linear-gradient( -45deg,${silver.base},${silver.base} 10px,${silver.darker1} 10px,${


### PR DESCRIPTION
### This PR:

When the Inputfield has feedback the severity color will be used as box-shadow. 
Also the icon wil only be shown if there's a feedback message. 

proposed release: `minor`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Changes** 🌀
- Inputfield severity color used as box-shadow. 
- Feedback icon wil only be shown if there's a feedback message. 

**Breaking changes** 🔥
- Inputfield theme changes. 
