### PR TITLE
replaced StatelessComponent identifiers with SFC

### DIFF
--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -1,4 +1,4 @@
-import React, { StatelessComponent } from 'react';
+import React, { SFC } from 'react';
 import { TrblType } from '../../utility/trbl';
 import { StyledDiv, StyledSpan } from './style';
 
@@ -36,7 +36,7 @@ type PropsType = JSX.IntrinsicElements['div'] & {
     left?: string;
 };
 
-const Box: StatelessComponent<PropsType> = (props): JSX.Element => {
+const Box: SFC<PropsType> = (props): JSX.Element => {
     const {
         order,
         direction,

--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -1,9 +1,9 @@
-import React, { Children, StatelessComponent } from 'react';
+import React, { Children, SFC } from 'react';
 import trbl from '../../utility/trbl';
 import Box from '../Box';
 import BreakpointProvider from '../BreakpointProvider';
 
-const ButtonGroup: StatelessComponent = (props): JSX.Element => {
+const ButtonGroup: SFC = (props): JSX.Element => {
     return (
         <BreakpointProvider
             breakpoints={{

--- a/src/components/Contrast/index.tsx
+++ b/src/components/Contrast/index.tsx
@@ -1,5 +1,5 @@
 import deepmerge from 'deepmerge';
-import React, { StatelessComponent } from 'react';
+import React, { SFC } from 'react';
 import ThemeType from '../../types/ThemeType';
 import { ThemeProvider } from '../../utility/styled';
 import StyledContrast from './style';
@@ -12,11 +12,11 @@ const contrastTheme = (theme: ThemeType): ThemeType => {
     return deepmerge(theme, theme.Contrast.overides as Partial<ThemeType>);
 };
 
-const ContrastThemeProvider: StatelessComponent<{ enable?: boolean }> = ({ enable, children }): JSX.Element => (
+const ContrastThemeProvider: SFC<{ enable?: boolean }> = ({ enable, children }): JSX.Element => (
     <ThemeProvider theme={!enable ? (theme): ThemeType => theme : contrastTheme}>{children}</ThemeProvider>
 );
 
-const Contrast: StatelessComponent<PropsType> = (props): JSX.Element => (
+const Contrast: SFC<PropsType> = (props): JSX.Element => (
     <StyledContrast>
         <ContrastThemeProvider enable={props.enable !== false}>{props.children}</ContrastThemeProvider>
     </StyledContrast>

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -1,4 +1,4 @@
-import React, { StatelessComponent } from 'react';
+import React, { SFC } from 'react';
 import { StyledComponentClass as _S } from 'styled-components';
 import _T from '../../types/ThemeType';
 import styled from '../../utility/styled';
@@ -14,7 +14,7 @@ type EmptyStatePropsType = {
     message: string;
 };
 
-const EmptyStateElement: StatelessComponent<EmptyStatePropsType> = (props): JSX.Element => (
+const EmptyStateElement: SFC<EmptyStatePropsType> = (props): JSX.Element => (
     <Box direction="column" alignItems="center" justifyContent="space-around">
         <Illustration illustration={'cactus'} />
         <Box padding={trbl(18, 0, 0, 0)}>

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -1,4 +1,4 @@
-import React, { StatelessComponent } from 'react';
+import React, { SFC } from 'react';
 import { StyledComponentClass as _S } from 'styled-components';
 import _T from '../../types/ThemeType';
 import styled, { StyledType } from '../../utility/styled';
@@ -38,7 +38,7 @@ type PropsType = StyledType & {
     textAlign?: 'left' | 'right' | 'center' | 'justify';
 };
 
-const HeadingElement: StatelessComponent<PropsType> = (props): JSX.Element => {
+const HeadingElement: SFC<PropsType> = (props): JSX.Element => {
     const Element = props.element !== undefined ? `${props.element}` : 'div';
 
     return (

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -1,4 +1,4 @@
-import React, { StatelessComponent } from 'react';
+import React, { SFC } from 'react';
 import { StyledType } from '../../utility/styled';
 import StyledIcon from './style';
 import { LargeIcons, MediumIcons, SmallIcons } from './types';
@@ -24,7 +24,7 @@ type LargePropsType = BasePropsType & {
 
 type PropsType = SmallPropsType | MediumPropsType | LargePropsType;
 
-const Icon: StatelessComponent<PropsType> = (props): JSX.Element => {
+const Icon: SFC<PropsType> = (props): JSX.Element => {
     const icon = ((props: PropsType): SmallIcons | MediumIcons | LargeIcons => {
         switch (props.size) {
             case 'large':

--- a/src/components/Illustration/index.tsx
+++ b/src/components/Illustration/index.tsx
@@ -1,4 +1,4 @@
-import React, { StatelessComponent } from 'react';
+import React, { SFC } from 'react';
 import { StyledType } from '../../utility/styled';
 import { StyledIllustration } from './style';
 import { Illustrations } from './types';
@@ -7,7 +7,7 @@ type IllustrationPropsType = StyledType & {
     illustration: keyof typeof Illustrations;
 };
 
-const IllustrationElement: StatelessComponent<IllustrationPropsType> = (props): JSX.Element => {
+const IllustrationElement: SFC<IllustrationPropsType> = (props): JSX.Element => {
     const illustration = Illustrations[props.illustration];
 
     /* tslint:disable */

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,4 +1,4 @@
-import React, { Children, StatelessComponent } from 'react';
+import React, { Children, SFC } from 'react';
 import StyledLink, { StyledButton } from './style';
 
 type PropsType = {
@@ -8,7 +8,7 @@ type PropsType = {
     action?(): void;
 };
 
-const Link: StatelessComponent<PropsType> = (props): JSX.Element => {
+const Link: SFC<PropsType> = (props): JSX.Element => {
     const isLink = props.href !== undefined;
 
     const clickAction = (): void => {

--- a/src/components/MessageStream/index.tsx
+++ b/src/components/MessageStream/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, StatelessComponent } from 'react';
+import React, { Fragment, SFC } from 'react';
 import { StyledType } from '../../utility/styled';
 import trbl from '../../utility/trbl';
 import Box from '../Box';
@@ -35,7 +35,7 @@ const mapVariant = (severity: MessagePropsType['severity']): ButtonPropsType['va
     }
 };
 
-const Message: StatelessComponent<MessagePropsType> = (props): JSX.Element => {
+const Message: SFC<MessagePropsType> = (props): JSX.Element => {
     const variant = mapVariant(props.severity);
 
     return (
@@ -76,7 +76,7 @@ const Message: StatelessComponent<MessagePropsType> = (props): JSX.Element => {
     );
 };
 
-const MessageStream: StatelessComponent<PropsType> = (props): JSX.Element => (
+const MessageStream: SFC<PropsType> = (props): JSX.Element => (
     <StyledMessageStream>
         {props.messages.map((message: MessagePropsType, index: number): JSX.Element => (
             <Fragment key={`${message.date}-${message.title}`}>

--- a/src/components/Notification/index.tsx
+++ b/src/components/Notification/index.tsx
@@ -1,4 +1,4 @@
-import React, { StatelessComponent } from 'react';
+import React, { SFC } from 'react';
 import { StyledType } from '../../utility/styled';
 import trbl from '../../utility/trbl';
 import Icon, { MediumIcons } from '../Icon';
@@ -12,7 +12,7 @@ type PropsType = StyledType & {
     icon?: keyof typeof MediumIcons;
 };
 
-const Notification: StatelessComponent<PropsType> = (props): JSX.Element => {
+const Notification: SFC<PropsType> = (props): JSX.Element => {
     const icon = props.icon !== undefined ? props.icon : SeverityIcons[props.severity];
 
     return (

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -1,4 +1,4 @@
-import React, { StatelessComponent } from 'react';
+import React, { SFC } from 'react';
 import { Manager, Popper, PopperChildrenProps, Reference, ReferenceChildrenProps } from 'react-popper';
 import TransitionAnimation from '../TransitionAnimation';
 import { PopoverAnchor, PopoverArrow, PopoverBackground, PopoverContent, PopoverWindow } from './style';
@@ -15,7 +15,7 @@ type PropsType = {
     renderContent(): JSX.Element | string;
 };
 
-const Popover: StatelessComponent<PropsType> = (props): JSX.Element => {
+const Popover: SFC<PropsType> = (props): JSX.Element => {
     const mapOffset = (props: PropsType): string => {
         switch (true) {
             case props.offset === undefined && props.distance === undefined:

--- a/src/components/PriceTag/index.tsx
+++ b/src/components/PriceTag/index.tsx
@@ -1,5 +1,4 @@
-import { StatelessComponent } from 'enzyme';
-import React from 'react';
+import React, { SFC } from 'react';
 import { StyledType } from '../../utility/styled';
 import formatCurrency from './formatters/formatCurrency';
 import formatDecimalSeperator from './formatters/formatDecimalSeperator';
@@ -49,7 +48,7 @@ const deriveStatsFromPart = (initialStats: StatsType, part: PartType): StatsType
     isFree: isFree(part) ? false : initialStats.isFree,
 });
 
-const PriceTag: StatelessComponent<PropsType> = (props): JSX.Element => {
+const PriceTag: SFC<PropsType> = (props): JSX.Element => {
     const stats = props.parts.reduce(deriveStatsFromPart, {
         isRound: false,
         isFree: true,

--- a/src/components/Raised/index.tsx
+++ b/src/components/Raised/index.tsx
@@ -1,8 +1,8 @@
-import React, { StatelessComponent } from 'react';
+import React, { SFC } from 'react';
 import { StyledComponentClass as _S } from 'styled-components';
 import StyledRaised, { RaisedPropsType } from './style';
 
-const RaisedElement: StatelessComponent<RaisedPropsType> = (props): JSX.Element => (
+const RaisedElement: SFC<RaisedPropsType> = (props): JSX.Element => (
     <StyledRaised level={props.level}>
         {props.children}
     </StyledRaised>

--- a/src/components/Spacer/index.tsx
+++ b/src/components/Spacer/index.tsx
@@ -1,4 +1,4 @@
-import React, { StatelessComponent } from 'react';
+import React, { SFC } from 'react';
 import { TrblType } from '../../utility/trbl';
 import StyledSpacer from './style';
 
@@ -7,7 +7,7 @@ type PropsType = JSX.IntrinsicElements['div'] & {
     offsetType?: 'inner' | 'outer';
 };
 
-const Spacer: StatelessComponent<PropsType> = (props): JSX.Element => {
+const Spacer: SFC<PropsType> = (props): JSX.Element => {
     const { offset, offsetType, ref, ...filteredProps } = props;
 
     return (

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -1,4 +1,4 @@
-import React, { StatelessComponent } from 'react';
+import React, { SFC } from 'react';
 import { StyledType } from '../../utility/styled';
 import { StyledSpan, StyledParagraph } from './style';
 import SeverityType from '../../types/SeverityType';
@@ -13,7 +13,7 @@ type PropsType = StyledType & {
     severity?: SeverityType;
 };
 
-const Text: StatelessComponent<PropsType> = (props): JSX.Element => {
+const Text: SFC<PropsType> = (props): JSX.Element => {
     const Element = props.inline !== undefined && props.inline ? StyledSpan : StyledParagraph;
 
     return (

--- a/src/components/TransitionAnimation/index.tsx
+++ b/src/components/TransitionAnimation/index.tsx
@@ -1,4 +1,4 @@
-import React, { StatelessComponent } from 'react';
+import React, { SFC } from 'react';
 import { Transition } from 'react-transition-group';
 import StyledAnimation, { StyledPropsType } from './style';
 
@@ -8,7 +8,7 @@ type PropsType = {
     stayMounted?: boolean;
 };
 
-const TransitionAnimation: StatelessComponent<PropsType> = (props): JSX.Element => {
+const TransitionAnimation: SFC<PropsType> = (props): JSX.Element => {
     const unmount = props.stayMounted !== undefined ? !props.stayMounted : true;
 
     return (


### PR DESCRIPTION
### This PR:

This PR is the result of a codeMod. It replaced StatelessComponent identifiers with SFC.

proposed release: [`patch`]

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)

**Changes** 🌀
- StatelessComponent not used anymore, only SFC. 
