### PR TITLE
Fixed range padding

### DIFF
--- a/src/components/Range/__snapshots__/story.storyshot
+++ b/src/components/Range/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Range Default 1`] = `
 <div
-  className="sc-bwzfXH feFEoj"
+  className="sc-bwzfXH bQfpwP"
 >
   <div
     className="sc-bwzfXH eoNmRC"
@@ -11,7 +11,7 @@ exports[`Storyshots Range Default 1`] = `
       className="sc-bwzfXH jccLEp"
     >
       <div
-        className="sc-bwzfXH fVrGOf"
+        className="sc-bwzfXH jtHmcE"
       >
         <div
           className="sc-eNQAEJ lhLkZ"
@@ -44,7 +44,7 @@ exports[`Storyshots Range Default 1`] = `
         </div>
       </div>
       <div
-        className="sc-bwzfXH fVrGOf"
+        className="sc-bwzfXH jtHmcE"
       >
         <div
           className="sc-eNQAEJ lhLkZ"

--- a/src/components/Range/index.tsx
+++ b/src/components/Range/index.tsx
@@ -114,10 +114,10 @@ class Range extends Component<PropsType, StateType> {
 
     public render(): JSX.Element {
         return (
-            <Box padding={trbl(12)} direction="column">
+            <Box direction="column">
                 <Box justifyContent="space-between">
                     <Box wrap justifyContent="space-between" width="100%">
-                        <Box width="136px" shrink={0}>
+                        <Box width="136px" shrink={0} padding={trbl(0, 0, 12, 0)}>
                             <TextField.Number
                                 feedback={this.state.hasError.min ? { severity: 'error', message: '' } : undefined}
                                 value={this.state.inputValues.min}
@@ -131,7 +131,7 @@ class Range extends Component<PropsType, StateType> {
                                 }}
                             />
                         </Box>
-                        <Box width="136px" shrink={0}>
+                        <Box width="136px" shrink={0} padding={trbl(0, 0, 12, 0)}>
                             <TextField.Number
                                 onBlur={this.onBlurMaximumValue}
                                 suffix={this.props.label}


### PR DESCRIPTION
### This PR:
Adds padding between textfields and Range after mistakingly removing them in a previous pr 🤐 

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)
- [x] Appropriate tests have been added for my functionality (check if not applicable)
