### PR TITLE
Added severity prop to the badge component

### DIFF
--- a/config/typescript/tslint.json
+++ b/config/typescript/tslint.json
@@ -105,7 +105,6 @@
       "no-unnecessary-type-assertion": true,
       "no-unsafe-finally": true,
       "no-unused-expression": true,
-      "no-unused-variable": [true, {"ignore-pattern": "^_"}],
       "no-use-before-declare": true,
       "no-var-keyword": true,
   

--- a/src/components/Badge/__snapshots__/story.storyshot
+++ b/src/components/Badge/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Badge Default 1`] = `
 <div
-  className="sc-bdVaJa rdHsy"
+  className="sc-bdVaJa iubOzp"
 >
   1
 </div>

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -1,27 +1,42 @@
 import _R from 'react';
 import { StyledComponentClass as _S } from 'styled-components';
 import _T from '../../types/ThemeType';
-import styled from '../../utility/styled';
+import styled, { withProps } from '../../utility/styled';
+import SeverityType from '../../types/SeverityType';
+
+type BadgePropsType = {
+    severity?: SeverityType;
+};
 
 type BadgeThemeType = {
+    severity: {
+        error: VariantStyleType;
+        success: VariantStyleType;
+        warning: VariantStyleType;
+        info: VariantStyleType;
+        [key: string]: VariantStyleType;
+    };
+};
+
+type VariantStyleType = {
     backgroundColor: string;
     color: string;
 };
 
-const StyledBadge = styled.div`
+const StyledBadge = withProps<BadgePropsType>(styled.div)`
     display: inline-block;
     box-sizing: border-box;
     min-width: 18px;
     min-height: 18px;
     padding: 3px 6px;
     border-radius: 9px;
-    background: ${({ theme }): string => theme.Badge.backgroundColor};
+    background: ${({ theme, severity }): string => !severity ? theme.Badge.severity.error.backgroundColor : theme.Badge.severity[severity].backgroundColor};
     font-family: ${({ theme }): string => theme.Text.default.fontFamily};
     font-size: 12px;
     line-height: 1;
-    color: ${({ theme }): string => theme.Badge.color};
+    color: ${({ theme, severity }): string => !severity ? theme.Badge.severity.error.color : theme.Badge.severity[severity].color};
     white-space: nowrap;
 `;
 
 export default StyledBadge;
-export { BadgeThemeType };
+export { BadgePropsType , BadgeThemeType };

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -9,6 +9,9 @@ type BadgePropsType = {
 };
 
 type BadgeThemeType = {
+    default: {
+        color: string;
+    };
     severity: {
         error: VariantStyleType;
         success: VariantStyleType;
@@ -19,7 +22,6 @@ type BadgeThemeType = {
 
 type VariantStyleType = {
     backgroundColor: string;
-    color: string;
 };
 
 const StyledBadge = withProps<BadgePropsType>(styled.div)`
@@ -33,7 +35,7 @@ const StyledBadge = withProps<BadgePropsType>(styled.div)`
     font-family: ${({ theme }): string => theme.Text.default.fontFamily};
     font-size: 12px;
     line-height: 1;
-    color: ${({ theme, severity }): string => !severity ? theme.Badge.severity.error.color : theme.Badge.severity[severity].color};
+    color: ${({ theme }): string => theme.Badge.default.color};
     white-space: nowrap;
 `;
 

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -14,7 +14,6 @@ type BadgeThemeType = {
         success: VariantStyleType;
         warning: VariantStyleType;
         info: VariantStyleType;
-        [key: string]: VariantStyleType;
     };
 };
 
@@ -39,4 +38,4 @@ const StyledBadge = withProps<BadgePropsType>(styled.div)`
 `;
 
 export default StyledBadge;
-export { BadgePropsType , BadgeThemeType };
+export { BadgePropsType, BadgeThemeType };

--- a/src/components/Badge/story.tsx
+++ b/src/components/Badge/story.tsx
@@ -5,7 +5,6 @@ import Badge, { BadgePropsType } from '.';
 
 storiesOf('Badge', module).add('Default', () => {
     return (
-        // <Badge severity={select('severity', ['success', 'warning', 'error', 'info'], 'success') as BadgePropsType['severity']}>
         <Badge severity={select('severity', ['success', 'warning', 'error', 'info'], 'success') as BadgePropsType['severity']}>
             {text('text', '1')}
         </Badge>

--- a/src/components/Badge/story.tsx
+++ b/src/components/Badge/story.tsx
@@ -1,6 +1,13 @@
-import { text } from '@storybook/addon-knobs/react';
+import { text, select } from '@storybook/addon-knobs/react';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
-import Badge from '.';
+import Badge, { BadgePropsType } from '.';
 
-storiesOf('Badge', module).add('Default', () => <Badge>{text('text', '1')}</Badge>);
+storiesOf('Badge', module).add('Default', () => {
+    return (
+        // <Badge severity={select('severity', ['success', 'warning', 'error', 'info'], 'success') as BadgePropsType['severity']}>
+        <Badge severity={select('severity', ['success', 'warning', 'error', 'info'], 'success') as BadgePropsType['severity']}>
+            {text('text', '1')}
+        </Badge>
+    );
+});

--- a/src/components/MultiButton/story.tsx
+++ b/src/components/MultiButton/story.tsx
@@ -32,6 +32,7 @@ const options = [
 ];
 
 const Demo: SFC = (): JSX.Element => {
+    /* tslint:disable */
     return (
         <Box height="90vh" justifyContent="center" alignItems="center">
             <Box margin={trbl(48)}>
@@ -71,6 +72,7 @@ const Demo: SFC = (): JSX.Element => {
             </Box>
         </Box>
     );
+    /* tslint:enable */
 };
 
 storiesOf('MultiButton', module).add('Default', () => <Demo />);

--- a/src/components/Select/__snapshots__/story.storyshot
+++ b/src/components/Select/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Select Custom rendering 1`] = `
 <div
-  className="sc-cJSrbW kfGOJd"
+  className="sc-cJSrbW gsVfEA"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDownCapture={[Function]}
@@ -291,7 +291,7 @@ exports[`Storyshots Select Custom rendering 1`] = `
 
 exports[`Storyshots Select Default 1`] = `
 <div
-  className="sc-cJSrbW kfGOJd"
+  className="sc-cJSrbW gsVfEA"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDownCapture={[Function]}

--- a/src/components/Select/style.tsx
+++ b/src/components/Select/style.tsx
@@ -82,11 +82,11 @@ const StyledWrapper = withProps<WrapperProps, HTMLDivElement>(styled.div)`
     }
 
     ${({ theme, isDisabled, isOpen }): string => {
-        return isDisabled === true || isOpen === true
-            ? ''
-            : `&:focus {
-                box-shadow: ${theme.Select.wrapper.focus.boxShadow};
-            }`;
+        return !isDisabled  || !isOpen
+        ? `&:focus {
+            box-shadow: ${theme.Select.wrapper.focus.boxShadow};
+        }`
+        : '';
     }}
 `;
 

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -57,8 +57,24 @@ const roundness = {
 
 const theme: ThemeType = {
     Badge: {
-        backgroundColor: red.base,
-        color: silver.lighter1,
+        severity: {
+            success: {
+                backgroundColor: green.darker1,
+                color: silver.lighter1,
+            },
+            warning: {
+                backgroundColor: yellow.darker1,
+                color: silver.lighter1,
+            },
+            error: {
+                backgroundColor: red.base,
+                color: silver.lighter1,
+            },
+            info: {
+                backgroundColor: grey.lighter2,
+                color: silver.lighter1,
+            },
+        },
     },
     Button: {
         common: {

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -57,22 +57,21 @@ const roundness = {
 
 const theme: ThemeType = {
     Badge: {
+        default: {
+            color: silver.lighter1,
+        },
         severity: {
             success: {
                 backgroundColor: green.darker1,
-                color: silver.lighter1,
             },
             warning: {
                 backgroundColor: yellow.darker1,
-                color: silver.lighter1,
             },
             error: {
                 backgroundColor: red.base,
-                color: silver.lighter1,
             },
             info: {
                 backgroundColor: grey.lighter2,
-                color: silver.lighter1,
             },
         },
     },


### PR DESCRIPTION
### This PR:

Added a `severity`-prop to the badge component, to give the possibility to use the badge component with more colors.

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)
- [x] Appropriate tests have been added for my functionality (check if not applicable)


**Adds** ✨
- Component `Badge` has now an optional `severity` prop. Default severity is `error`.
