### PR TITLE
Fixed Modal height/fixed button row issues

### DIFF
--- a/src/components/Modal/__snapshots__/story.storyshot
+++ b/src/components/Modal/__snapshots__/story.storyshot
@@ -15,7 +15,7 @@ exports[`Storyshots Modal Default 1`] = `
       }
     >
       <div
-        className="sc-jlyJG bhQyKQ"
+        className="sc-jlyJG cZkCvT"
       >
         <div
           className="sc-bwzfXH jTCciZ"
@@ -53,7 +53,7 @@ exports[`Storyshots Modal Default 1`] = `
           </div>
         </div>
         <div
-          className="sc-brqgnP jEhxYZ"
+          className="sc-brqgnP jwrNlU"
         >
           <div
             className="sc-cMljjf krgCXT"
@@ -167,7 +167,7 @@ exports[`Storyshots Modal Without closeAction 1`] = `
       }
     >
       <div
-        className="sc-jlyJG bhQyKQ"
+        className="sc-jlyJG cZkCvT"
       >
         <div
           className="sc-bwzfXH jTCciZ"
@@ -180,7 +180,7 @@ exports[`Storyshots Modal Without closeAction 1`] = `
           </div>
         </div>
         <div
-          className="sc-brqgnP jEhxYZ"
+          className="sc-brqgnP jwrNlU"
         >
           <div
             className="sc-cMljjf krgCXT"

--- a/src/components/Modal/style.tsx
+++ b/src/components/Modal/style.tsx
@@ -51,7 +51,7 @@ const StyledModal = withProps<ModalPropsType>(styled.div)`
     width: ${({ modalSize }): string => ModalSizes[modalSize]};
     display: flex;
     flex-direction: column;
-    height: calc(100% - 24px);
+    height: 100vh;
     overflow: hidden;
     max-height: calc(300px + (600 - 300) * (100vh - 300px) / (900 - 300));
     background: ${({ theme }): string => theme.Modal.backgroundColor};

--- a/src/components/ScrollBox/__snapshots__/story.storyshot
+++ b/src/components/ScrollBox/__snapshots__/story.storyshot
@@ -9,7 +9,7 @@ Array [
       className="sc-bwzfXH chAuJL"
     >
       <div
-        className="sc-brqgnP jEhxYZ"
+        className="sc-brqgnP jwrNlU"
       >
         <div
           className="sc-cMljjf krgCXT"

--- a/src/components/ScrollBox/style.tsx
+++ b/src/components/ScrollBox/style.tsx
@@ -28,6 +28,7 @@ const StyledWrapper = styled.div`
     flex-grow: 1;
     display: flex;
     max-height: inherit;
+    overflow: hidden;
 
     ${simplebarStyles}
 `;

--- a/src/components/Select/__snapshots__/story.storyshot
+++ b/src/components/Select/__snapshots__/story.storyshot
@@ -57,7 +57,7 @@ exports[`Storyshots Select Custom rendering 1`] = `
       className="sc-ksYbfQ pMeUU"
     >
       <div
-        className="sc-brqgnP jEhxYZ"
+        className="sc-brqgnP jwrNlU"
       >
         <div
           className="sc-cMljjf krgCXT"
@@ -346,7 +346,7 @@ exports[`Storyshots Select Default 1`] = `
       className="sc-ksYbfQ pMeUU"
     >
       <div
-        className="sc-brqgnP jEhxYZ"
+        className="sc-brqgnP jwrNlU"
       >
         <div
           className="sc-cMljjf krgCXT"


### PR DESCRIPTION
### This PR:

resolves #222 

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)
- [x] Appropriate tests have been added for my functionality (check if not applicable)


**Adds** ✨
- `overflow` to ScrollBox to fix disappearing button row in Modal

**Changes**
- `height` to `100vh` to fix height issue in IE11