### PR TITLE
refactored the Text Component to the size-steps according to design

### DIFF
--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -16,7 +16,7 @@ const StyledBadge = styled.div`
     padding: 3px 6px;
     border-radius: 9px;
     background: ${({ theme }): string => theme.Badge.backgroundColor};
-    font-family: ${({ theme }): string => theme.Text.default.fontFamily};
+    font-family: ${({ theme }): string => theme.Text.variant.regular.fontFamily};
     font-size: 12px;
     line-height: 1;
     color: ${({ theme }): string => theme.Badge.color};

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -6,6 +6,7 @@ import styled from '../../utility/styled';
 type BadgeThemeType = {
     backgroundColor: string;
     color: string;
+    fontFamily: string;
 };
 
 const StyledBadge = styled.div`
@@ -16,7 +17,7 @@ const StyledBadge = styled.div`
     padding: 3px 6px;
     border-radius: 9px;
     background: ${({ theme }): string => theme.Badge.backgroundColor};
-    font-family: ${({ theme }): string => theme.Text.variant.regular.fontFamily};
+    font-family: ${({ theme }): string => theme.Badge.fontFamily};
     font-size: 12px;
     line-height: 1;
     color: ${({ theme }): string => theme.Badge.color};

--- a/src/components/Box/__snapshots__/story.storyshot
+++ b/src/components/Box/__snapshots__/story.storyshot
@@ -17,7 +17,7 @@ exports[`Storyshots Box Default 1`] = `
           className="sc-bwzfXH cFJdBG"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             Box 
             1
@@ -35,7 +35,7 @@ exports[`Storyshots Box Default 1`] = `
           className="sc-bwzfXH cFJdBG"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             Box 
             2
@@ -53,7 +53,7 @@ exports[`Storyshots Box Default 1`] = `
           className="sc-bwzfXH cFJdBG"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             Box 
             3
@@ -71,7 +71,7 @@ exports[`Storyshots Box Default 1`] = `
           className="sc-bwzfXH cFJdBG"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             Box 
             4
@@ -89,7 +89,7 @@ exports[`Storyshots Box Default 1`] = `
           className="sc-bwzfXH cFJdBG"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             Box 
             5
@@ -107,7 +107,7 @@ exports[`Storyshots Box Default 1`] = `
           className="sc-bwzfXH cFJdBG"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             Box 
             6

--- a/src/components/Branch/__snapshots__/story.storyshot
+++ b/src/components/Branch/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Branch Default 1`] = `
 <p
-  className="sc-bxivhb jpexxn"
+  className="sc-bxivhb fpMQQD"
 >
   This is shown when condition is true. 
   This line is shared whether the condition is true or not.

--- a/src/components/BreakpointProvider/__snapshots__/story.storyshot
+++ b/src/components/BreakpointProvider/__snapshots__/story.storyshot
@@ -12,7 +12,7 @@ exports[`Storyshots BreakpointProvider Default 1`] = `
     className="sc-gzVnrw eSDhrQ"
   >
     <p
-      className="sc-bxivhb jpexxn"
+      className="sc-bxivhb fpMQQD"
     >
       Current breakpoint is 
       large

--- a/src/components/EmptyState/__snapshots__/story.storyshot
+++ b/src/components/EmptyState/__snapshots__/story.storyshot
@@ -31,7 +31,7 @@ exports[`Storyshots EmptyState Default 1`] = `
       className="sc-bwzfXH eTHzfe"
     >
       <p
-        className="sc-bxivhb cFaXyW"
+        className="sc-bxivhb ieDGhz"
       >
         ..A tumbleweed passes by
       </p>
@@ -71,7 +71,7 @@ exports[`Storyshots EmptyState With button (as children) 1`] = `
       className="sc-bwzfXH eTHzfe"
     >
       <p
-        className="sc-bxivhb cFaXyW"
+        className="sc-bxivhb ieDGhz"
       >
         There are no filters applied yet. Use the button below to apply a filter.
       </p>

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -23,7 +23,7 @@ const EmptyStateElement: SFC<EmptyStatePropsType> = (props): JSX.Element => (
             </Heading>
         </Box>
         <Box margin={trbl(12, 0, 24, 0)}>
-            <Text textAlign="center" descriptive>
+            <Text textAlign="center" severity="info">
                 {props.message}
             </Text>
         </Box>

--- a/src/components/ErrorBoundary/__snapshots__/story.storyshot
+++ b/src/components/ErrorBoundary/__snapshots__/story.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots ErrorBoundary Default 1`] = `
 <div>
   <p
-    className="sc-bxivhb jpexxn"
+    className="sc-bxivhb fpMQQD"
   >
     This does not have an error.
   </p>

--- a/src/components/FoldOut/__snapshots__/story.storyshot
+++ b/src/components/FoldOut/__snapshots__/story.storyshot
@@ -10,7 +10,7 @@ exports[`Storyshots FoldOut With a toggle 1`] = `
         className="sc-bwzfXH ebfsxO"
       >
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb fpMQQD"
         >
           
     Now this is the story all about how

--- a/src/components/FormRow/__snapshots__/story.storyshot
+++ b/src/components/FormRow/__snapshots__/story.storyshot
@@ -13,13 +13,13 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH cAZkVZ"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             What is your name?
           </p>
         </div>
         <p
-          className="sc-bxivhb jVDCXG"
+          className="sc-bxivhb jpeJmp"
         >
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus, corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
         </p>
@@ -148,13 +148,13 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH cAZkVZ"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             Where do you live?
           </p>
         </div>
         <p
-          className="sc-bxivhb jVDCXG"
+          className="sc-bxivhb jpeJmp"
         >
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus, corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
         </p>
@@ -246,13 +246,13 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH cAZkVZ"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             Can a boolean only be either true or false?
           </p>
         </div>
         <p
-          className="sc-bxivhb jVDCXG"
+          className="sc-bxivhb jpeJmp"
         >
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus, corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
         </p>
@@ -292,7 +292,7 @@ exports[`Storyshots FormRow Default 1`] = `
               </div>
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               <label
                 htmlFor="bool"
@@ -330,7 +330,7 @@ exports[`Storyshots FormRow Default 1`] = `
               </div>
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               <label
                 htmlFor="bool"
@@ -368,7 +368,7 @@ exports[`Storyshots FormRow Default 1`] = `
               </div>
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               <label
                 htmlFor="bool"
@@ -394,7 +394,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     >
       <label>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb fpMQQD"
         >
           What is your name?
         </p>
@@ -450,7 +450,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     >
       <label>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb fpMQQD"
         >
           Where do you live?
         </p>
@@ -506,7 +506,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     >
       <label>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb fpMQQD"
         >
           Can a boolean only be true or false?
         </p>
@@ -546,7 +546,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
               </div>
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               <label
                 htmlFor="bool"
@@ -584,7 +584,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
               </div>
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               <label
                 htmlFor="bool"
@@ -622,7 +622,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
               </div>
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               <label
                 htmlFor="bool"
@@ -643,7 +643,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     >
       <label>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb fpMQQD"
         >
           Do you like toggles?
         </p>
@@ -685,7 +685,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
             className="sc-bwzfXH fmiztD"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
                
               Toggle to indicate your preference!
@@ -703,7 +703,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     >
       <label>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb fpMQQD"
         >
           Do you like checkboxes
         </p>

--- a/src/components/FormRow/story.tsx
+++ b/src/components/FormRow/story.tsx
@@ -52,7 +52,7 @@ class DemoComponent extends Component<PropsType, StateType> {
                                 <Box>
                                     <Text>What is your name?</Text>
                                 </Box>
-                                <Text descriptive>
+                                <Text severity="info">
                                     Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
                                     similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
                                     corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
@@ -96,7 +96,7 @@ class DemoComponent extends Component<PropsType, StateType> {
                                 <Box>
                                     <Text>Where do you live?</Text>
                                 </Box>
-                                <Text descriptive>
+                                <Text severity="info">
                                     Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
                                     similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
                                     corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
@@ -130,7 +130,7 @@ class DemoComponent extends Component<PropsType, StateType> {
                                 <Box>
                                     <Text>Can a boolean only be either true or false?</Text>
                                 </Box>
-                                <Text descriptive>
+                                <Text severity="info">
                                     Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
                                     similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
                                     corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.

--- a/src/components/InlineNotification/__snapshots__/story.storyshot
+++ b/src/components/InlineNotification/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots InlineNotification Default 1`] = `
 <p
-  className="sc-bxivhb eEGBVx"
+  className="sc-bxivhb jNLkvd"
 >
   <span
     className="sc-htpNat frObKr"
@@ -32,7 +32,7 @@ exports[`Storyshots InlineNotification Default 1`] = `
 
 exports[`Storyshots InlineNotification With children 1`] = `
 <p
-  className="sc-bxivhb fhwEDr"
+  className="sc-bxivhb bgphtb"
 >
   <span
     className="sc-htpNat frObKr"
@@ -71,7 +71,7 @@ exports[`Storyshots InlineNotification With children 1`] = `
 
 exports[`Storyshots InlineNotification With overwritten Icon 1`] = `
 <p
-  className="sc-bxivhb eEGBVx"
+  className="sc-bxivhb jNLkvd"
 >
   <span
     className="sc-htpNat frObKr"

--- a/src/components/Link/__snapshots__/story.storyshot
+++ b/src/components/Link/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Link Action with child element 1`] = `
 <p
-  className="sc-bxivhb jpexxn"
+  className="sc-bxivhb fpMQQD"
 >
   <button
     className="sc-jWBwVP ieZLxK"
@@ -19,7 +19,7 @@ exports[`Storyshots Link Action with child element 1`] = `
 
 exports[`Storyshots Link Default 1`] = `
 <p
-  className="sc-bxivhb jpexxn"
+  className="sc-bxivhb fpMQQD"
 >
   <a
     className="sc-cvbbAY jqqzQW"

--- a/src/components/MessageStream/__snapshots__/story.storyshot
+++ b/src/components/MessageStream/__snapshots__/story.storyshot
@@ -18,12 +18,12 @@ exports[`Storyshots MessageStream Default 1`] = `
           className="sc-bwzfXH injrXU"
         >
           <p
-            className="sc-bxivhb gTyNSX"
+            className="sc-bxivhb gAVOHP"
           >
             Sit Inceptos Magna
           </p>
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             <span
               dangerouslySetInnerHTML={
@@ -34,7 +34,7 @@ exports[`Storyshots MessageStream Default 1`] = `
             />
           </p>
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             Today 12:00
           </p>
@@ -59,12 +59,12 @@ exports[`Storyshots MessageStream Default 1`] = `
           className="sc-bwzfXH injrXU"
         >
           <p
-            className="sc-bxivhb gTyNSX"
+            className="sc-bxivhb gAVOHP"
           >
             Aenean Dapibus Vulputate Tortor Magna
           </p>
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             <span
               dangerouslySetInnerHTML={
@@ -76,7 +76,7 @@ exports[`Storyshots MessageStream Default 1`] = `
             />
           </p>
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             Today 10:00
           </p>
@@ -101,12 +101,12 @@ exports[`Storyshots MessageStream Default 1`] = `
           className="sc-bwzfXH injrXU"
         >
           <p
-            className="sc-bxivhb gTyNSX"
+            className="sc-bxivhb gAVOHP"
           >
             Vestibulum Dapibus
           </p>
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             <span
               dangerouslySetInnerHTML={
@@ -117,7 +117,7 @@ exports[`Storyshots MessageStream Default 1`] = `
             />
           </p>
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             Yesterday 12:00
           </p>
@@ -156,12 +156,12 @@ exports[`Storyshots MessageStream Default 1`] = `
           className="sc-bwzfXH injrXU"
         >
           <p
-            className="sc-bxivhb gTyNSX"
+            className="sc-bxivhb gAVOHP"
           >
             Parturient Euismod Mollis Fringilla
           </p>
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             <span
               dangerouslySetInnerHTML={
@@ -173,7 +173,7 @@ exports[`Storyshots MessageStream Default 1`] = `
             />
           </p>
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             12-12-2012 12:00
           </p>
@@ -212,12 +212,12 @@ exports[`Storyshots MessageStream Default 1`] = `
           className="sc-bwzfXH injrXU"
         >
           <p
-            className="sc-bxivhb gTyNSX"
+            className="sc-bxivhb gAVOHP"
           >
             Tortor Cursus
           </p>
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             <span
               dangerouslySetInnerHTML={
@@ -228,7 +228,7 @@ exports[`Storyshots MessageStream Default 1`] = `
             />
           </p>
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             12-12-2012 12:00
           </p>
@@ -267,12 +267,12 @@ exports[`Storyshots MessageStream Default 1`] = `
           className="sc-bwzfXH injrXU"
         >
           <p
-            className="sc-bxivhb gTyNSX"
+            className="sc-bxivhb gAVOHP"
           >
             Euismod Dolor Consectetur
           </p>
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb fpMQQD"
           >
             <span
               dangerouslySetInnerHTML={
@@ -283,7 +283,7 @@ exports[`Storyshots MessageStream Default 1`] = `
             />
           </p>
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           />
         </div>
         <div

--- a/src/components/MessageStream/index.tsx
+++ b/src/components/MessageStream/index.tsx
@@ -47,7 +47,7 @@ const Message: SFC<MessagePropsType> = (props): JSX.Element => {
                         <Text>
                             <span dangerouslySetInnerHTML={{ __html: props.message }} />
                         </Text>
-                        <Text descriptive>{props.date}</Text>
+                        <Text severity="info">{props.date}</Text>
                     </Box>
                     {props.onClick !== undefined && props.buttonLabel !== undefined && props.buttonLabel.length > 0 ? (
                         <Box

--- a/src/components/Modal/__snapshots__/story.storyshot
+++ b/src/components/Modal/__snapshots__/story.storyshot
@@ -63,7 +63,7 @@ exports[`Storyshots Modal Default 1`] = `
               className="sc-bwzfXH fiOUi"
             >
               <p
-                className="sc-bxivhb jpexxn"
+                className="sc-bxivhb fpMQQD"
               >
                 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut mi ligula. Phasellus tellus nulla,
@@ -186,7 +186,7 @@ exports[`Storyshots Modal Without closeAction 1`] = `
               className="sc-bwzfXH fiOUi"
             >
               <p
-                className="sc-bxivhb jpexxn"
+                className="sc-bxivhb fpMQQD"
               >
                 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut mi ligula. Phasellus tellus nulla,

--- a/src/components/MultiButton/index.tsx
+++ b/src/components/MultiButton/index.tsx
@@ -190,13 +190,10 @@ class MultiButton extends Component<PropsType, StateType> {
                                                         <div>
                                                             <Text
                                                                 inline
-                                                                descriptive
+                                                                severity="info"
                                                                 strong={index === this.state.selectedIndex}
                                                             >
-                                                                <Text
-                                                                    descriptive={false}
-                                                                    strong={index === this.state.selectedIndex}
-                                                                >
+                                                                <Text strong={index === this.state.selectedIndex}>
                                                                     {option.label}
                                                                 </Text>
                                                                 <span>{option.description}</span>

--- a/src/components/RadioButton/__snapshots__/story.storyshot
+++ b/src/components/RadioButton/__snapshots__/story.storyshot
@@ -26,7 +26,7 @@ exports[`Storyshots RadioButton Default 1`] = `
     </div>
   </div>
   <p
-    className="sc-bxivhb jpexxn"
+    className="sc-bxivhb fpMQQD"
   >
     <label
       htmlFor="demo"

--- a/src/components/RadioButtonGroup/__snapshots__/story.storyshot
+++ b/src/components/RadioButtonGroup/__snapshots__/story.storyshot
@@ -35,7 +35,7 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
           </div>
         </div>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb fpMQQD"
         >
           <label
             htmlFor="demo"
@@ -73,7 +73,7 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
           </div>
         </div>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb fpMQQD"
         >
           <label
             htmlFor="demo"
@@ -111,7 +111,7 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
           </div>
         </div>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb fpMQQD"
         >
           <label
             htmlFor="demo"

--- a/src/components/ScrollBox/__snapshots__/story.storyshot
+++ b/src/components/ScrollBox/__snapshots__/story.storyshot
@@ -27,7 +27,7 @@ Array [
               They see me scrollin'
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut mi ligula. Phasellus tellus nulla,
@@ -88,7 +88,7 @@ Array [
     </div>
   </div>,
   <p
-    className="sc-bxivhb jpexxn"
+    className="sc-bxivhb fpMQQD"
   >
     scrollTop: 
     0

--- a/src/components/Select/Option/index.tsx
+++ b/src/components/Select/Option/index.tsx
@@ -31,12 +31,12 @@ const Option: SFC<PropsType> = (props): JSX.Element => {
                     <Box padding={trbl(6, 18)} alignItems="center" inline>
                         {props.isSelected && (
                             <Box margin={trbl(0, 6, 0, 0)} inline>
-                                <Text severity={props.isSelected ? 'info' : 'default'}>
+                                <Text severity={props.isSelected ? 'info' : undefined}>
                                     <Icon size="small" icon="checkmark" />
                                 </Text>
                             </Box>
                         )}
-                        <Text severity={props.isSelected ? 'info' : 'default'}>{props.label}</Text>
+                        <Text severity={props.isSelected ? 'info' : undefined}>{props.label}</Text>
                     </Box>
                 )}
             </Box>

--- a/src/components/Select/Option/index.tsx
+++ b/src/components/Select/Option/index.tsx
@@ -31,14 +31,12 @@ const Option: SFC<PropsType> = (props): JSX.Element => {
                     <Box padding={trbl(6, 18)} alignItems="center" inline>
                         {props.isSelected && (
                             <Box margin={trbl(0, 6, 0, 0)} inline>
-                                <Text descriptive={props.isSelected}>
+                                <Text severity={props.isSelected ? 'info' : 'default'}>
                                     <Icon size="small" icon="checkmark" />
                                 </Text>
                             </Box>
                         )}
-                        <Text descriptive={props.isSelected} inline>
-                            {props.label}
-                        </Text>
+                        <Text severity={props.isSelected ? 'info' : 'default'}>{props.label}</Text>
                     </Box>
                 )}
             </Box>

--- a/src/components/Select/__snapshots__/story.storyshot
+++ b/src/components/Select/__snapshots__/story.storyshot
@@ -2,11 +2,7 @@
 
 exports[`Storyshots Select Custom rendering 1`] = `
 <div
-<<<<<<< HEAD
   className="sc-frDJqD knwbUz"
-=======
-  className="sc-cJSrbW iWiqVx"
->>>>>>> 7b7db1d... refactored the Text Component to the size-steps according to design
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDownCapture={[Function]}
@@ -293,11 +289,7 @@ exports[`Storyshots Select Custom rendering 1`] = `
 
 exports[`Storyshots Select Default 1`] = `
 <div
-<<<<<<< HEAD
   className="sc-frDJqD knwbUz"
-=======
-  className="sc-cJSrbW iWiqVx"
->>>>>>> 7b7db1d... refactored the Text Component to the size-steps according to design
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDownCapture={[Function]}

--- a/src/components/Select/__snapshots__/story.storyshot
+++ b/src/components/Select/__snapshots__/story.storyshot
@@ -2,7 +2,11 @@
 
 exports[`Storyshots Select Custom rendering 1`] = `
 <div
+<<<<<<< HEAD
   className="sc-frDJqD knwbUz"
+=======
+  className="sc-cJSrbW iWiqVx"
+>>>>>>> 7b7db1d... refactored the Text Component to the size-steps according to design
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDownCapture={[Function]}
@@ -23,7 +27,7 @@ exports[`Storyshots Select Custom rendering 1`] = `
           className="sc-bwzfXH fsbcIX"
         >
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             Make a selection
           </p>
@@ -91,12 +95,12 @@ exports[`Storyshots Select Custom rendering 1`] = `
                     className="sc-bwzfXH bQfpwP"
                   >
                     <p
-                      className="sc-bxivhb jpexxn"
+                      className="sc-bxivhb fpMQQD"
                     >
                       Bar A
                     </p>
                     <p
-                      className="sc-bxivhb jVDCXG"
+                      className="sc-bxivhb jpeJmp"
                     >
                       Lorem ipsum dolor sit amet.
                     </p>
@@ -126,12 +130,12 @@ exports[`Storyshots Select Custom rendering 1`] = `
                     className="sc-bwzfXH bQfpwP"
                   >
                     <p
-                      className="sc-bxivhb jpexxn"
+                      className="sc-bxivhb fpMQQD"
                     >
                       Foo B
                     </p>
                     <p
-                      className="sc-bxivhb jVDCXG"
+                      className="sc-bxivhb jpeJmp"
                     >
                       Lorem ipsum dolor sit amet.
                     </p>
@@ -161,12 +165,12 @@ exports[`Storyshots Select Custom rendering 1`] = `
                     className="sc-bwzfXH bQfpwP"
                   >
                     <p
-                      className="sc-bxivhb jpexxn"
+                      className="sc-bxivhb fpMQQD"
                     >
                       Bar C
                     </p>
                     <p
-                      className="sc-bxivhb jVDCXG"
+                      className="sc-bxivhb jpeJmp"
                     >
                       Lorem ipsum dolor sit amet.
                     </p>
@@ -196,12 +200,12 @@ exports[`Storyshots Select Custom rendering 1`] = `
                     className="sc-bwzfXH bQfpwP"
                   >
                     <p
-                      className="sc-bxivhb jpexxn"
+                      className="sc-bxivhb fpMQQD"
                     >
                       Foo D
                     </p>
                     <p
-                      className="sc-bxivhb jVDCXG"
+                      className="sc-bxivhb jpeJmp"
                     >
                       Lorem ipsum dolor sit amet.
                     </p>
@@ -231,12 +235,12 @@ exports[`Storyshots Select Custom rendering 1`] = `
                     className="sc-bwzfXH bQfpwP"
                   >
                     <p
-                      className="sc-bxivhb jpexxn"
+                      className="sc-bxivhb fpMQQD"
                     >
                       Bar E
                     </p>
                     <p
-                      className="sc-bxivhb jVDCXG"
+                      className="sc-bxivhb jpeJmp"
                     >
                       Lorem ipsum dolor sit amet.
                     </p>
@@ -266,12 +270,12 @@ exports[`Storyshots Select Custom rendering 1`] = `
                     className="sc-bwzfXH bQfpwP"
                   >
                     <p
-                      className="sc-bxivhb jpexxn"
+                      className="sc-bxivhb fpMQQD"
                     >
                       Bar F
                     </p>
                     <p
-                      className="sc-bxivhb jVDCXG"
+                      className="sc-bxivhb jpeJmp"
                     >
                       Lorem ipsum dolor sit amet.
                     </p>
@@ -289,7 +293,11 @@ exports[`Storyshots Select Custom rendering 1`] = `
 
 exports[`Storyshots Select Default 1`] = `
 <div
+<<<<<<< HEAD
   className="sc-frDJqD knwbUz"
+=======
+  className="sc-cJSrbW iWiqVx"
+>>>>>>> 7b7db1d... refactored the Text Component to the size-steps according to design
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDownCapture={[Function]}
@@ -307,7 +315,7 @@ exports[`Storyshots Select Default 1`] = `
         onClick={[Function]}
       >
         <p
-          className="sc-bxivhb jVDCXG"
+          className="sc-bxivhb jpeJmp"
         >
           <span
             className="sc-hmzhuo hgIEwm"
@@ -367,11 +375,11 @@ exports[`Storyshots Select Default 1`] = `
                 <span
                   className="sc-htpNat kTMegb"
                 >
-                  <span
-                    className="sc-ifAKCX kRfhnK"
+                  <p
+                    className="sc-bxivhb fpMQQD"
                   >
                     Bar A
-                  </span>
+                  </p>
                 </span>
               </div>
             </div>
@@ -386,11 +394,11 @@ exports[`Storyshots Select Default 1`] = `
                 <span
                   className="sc-htpNat kTMegb"
                 >
-                  <span
-                    className="sc-ifAKCX kRfhnK"
+                  <p
+                    className="sc-bxivhb fpMQQD"
                   >
                     Foo B
-                  </span>
+                  </p>
                 </span>
               </div>
             </div>
@@ -405,11 +413,11 @@ exports[`Storyshots Select Default 1`] = `
                 <span
                   className="sc-htpNat kTMegb"
                 >
-                  <span
-                    className="sc-ifAKCX kRfhnK"
+                  <p
+                    className="sc-bxivhb fpMQQD"
                   >
                     Bar C
-                  </span>
+                  </p>
                 </span>
               </div>
             </div>
@@ -424,11 +432,11 @@ exports[`Storyshots Select Default 1`] = `
                 <span
                   className="sc-htpNat kTMegb"
                 >
-                  <span
-                    className="sc-ifAKCX kRfhnK"
+                  <p
+                    className="sc-bxivhb fpMQQD"
                   >
                     Foo D
-                  </span>
+                  </p>
                 </span>
               </div>
             </div>
@@ -443,11 +451,11 @@ exports[`Storyshots Select Default 1`] = `
                 <span
                   className="sc-htpNat kTMegb"
                 >
-                  <span
-                    className="sc-ifAKCX kRfhnK"
+                  <p
+                    className="sc-bxivhb fpMQQD"
                   >
                     Bar E
-                  </span>
+                  </p>
                 </span>
               </div>
             </div>
@@ -462,11 +470,11 @@ exports[`Storyshots Select Default 1`] = `
                 <span
                   className="sc-htpNat kTMegb"
                 >
-                  <span
-                    className="sc-ifAKCX kRfhnK"
+                  <p
+                    className="sc-bxivhb fpMQQD"
                   >
                     Bar F
-                  </span>
+                  </p>
                 </span>
               </div>
             </div>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -212,7 +212,7 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
                             )) || (
                                 <Box alignItems="center" padding={trbl(6, 12)} grow={1} onClick={this.open}>
                                     {(this.props.value !== '' && <Text>{selectedOption.label}</Text>) || (
-                                        <Text descriptive>
+                                        <Text severity="info">
                                             <StyledPlaceholder>{this.props.placeholder}</StyledPlaceholder>
                                         </Text>
                                     )}

--- a/src/components/Select/story.tsx
+++ b/src/components/Select/story.tsx
@@ -95,14 +95,14 @@ const renderSelected = (option: DemoOptionType): JSX.Element => {
                 </Box>
                 <Box direction="column">
                     <Text>{option.label}</Text>
-                    <Text descriptive>{option.description}</Text>
+                    <Text severity="info">{option.description}</Text>
                 </Box>
             </Box>
         );
     } else {
         return (
             <Box direction="row" alignItems="center">
-                <Text descriptive>{'Make a selection'}</Text>
+                <Text severity="info">{'Make a selection'}</Text>
             </Box>
         );
     }
@@ -115,16 +115,16 @@ const renderOption = (option: DemoOptionType, optionState: OptionStateType): JSX
                 <img src={option.image} />
             </Box>
             <Box direction="column">
-                <Text descriptive={optionState.isSelected}>
+                <Text severity={optionState.isSelected ? 'info' : 'default'}>
                     {optionState.isSelected && (
-                        <Text inline descriptive>
+                        <Text inline severity="info">
                             <Icon size="small" icon="checkmark" />
                             &nbsp;&nbsp;
                         </Text>
                     )}
                     {option.label}
                 </Text>
-                <Text descriptive>{option.description}</Text>
+                <Text severity="info">{option.description}</Text>
             </Box>
         </Box>
     );

--- a/src/components/Select/story.tsx
+++ b/src/components/Select/story.tsx
@@ -115,7 +115,7 @@ const renderOption = (option: DemoOptionType, optionState: OptionStateType): JSX
                 <img src={option.image} />
             </Box>
             <Box direction="column">
-                <Text severity={optionState.isSelected ? 'info' : 'default'}>
+                <Text severity={optionState.isSelected ? 'info' : undefined}>
                     {optionState.isSelected && (
                         <Text inline severity="info">
                             <Icon size="small" icon="checkmark" />

--- a/src/components/Spacer/__snapshots__/story.storyshot
+++ b/src/components/Spacer/__snapshots__/story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots Spacer ⚠️  With margin 1`] = `
     className="sc-ktHwxA geMWbx"
   >
     <p
-      className="sc-bxivhb jpexxn"
+      className="sc-bxivhb fpMQQD"
     >
       This has a margin.
     </p>
@@ -24,7 +24,7 @@ exports[`Storyshots Spacer ⚠️  With padding 1`] = `
     className="sc-jqCOkK jMfdRS"
   >
     <p
-      className="sc-bxivhb jpexxn"
+      className="sc-bxivhb fpMQQD"
     >
       This has padding.
     </p>

--- a/src/components/Table/Row/index.tsx
+++ b/src/components/Table/Row/index.tsx
@@ -82,7 +82,7 @@ class Row extends Component<PropsType, StateType> {
                                                 onBlur={this.handleBlur}
                                                 onFocus={this.handleFocus}
                                             >
-                                                <Text descriptive={!hasHover}>
+                                                <Text severity={!hasHover ? 'info' : 'default'}>
                                                     <Icon size="medium" icon="bars" />
                                                 </Text>
                                             </Cell>

--- a/src/components/Table/Row/index.tsx
+++ b/src/components/Table/Row/index.tsx
@@ -82,7 +82,7 @@ class Row extends Component<PropsType, StateType> {
                                                 onBlur={this.handleBlur}
                                                 onFocus={this.handleFocus}
                                             >
-                                                <Text severity={!hasHover ? 'info' : 'default'}>
+                                                <Text severity={!hasHover ? 'info' : undefined}>
                                                     <Icon size="medium" icon="bars" />
                                                 </Text>
                                             </Cell>

--- a/src/components/Table/__snapshots__/story.storyshot
+++ b/src/components/Table/__snapshots__/story.storyshot
@@ -17,7 +17,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb gTyNSX"
+              className="sc-bxivhb gAVOHP"
             >
               <span
                 aria-hidden={true}
@@ -40,7 +40,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb gTyNSX"
+              className="sc-bxivhb gAVOHP"
             >
               Header B
             </p>
@@ -53,7 +53,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb gTyNSX"
+              className="sc-bxivhb gAVOHP"
             >
               Header C
             </p>
@@ -66,7 +66,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH eFkGjS"
           >
             <p
-              className="sc-bxivhb gTyNSX"
+              className="sc-bxivhb gAVOHP"
             >
               Actions
             </p>
@@ -86,7 +86,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             <span
               aria-hidden={true}
@@ -109,7 +109,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               A1
             </p>
@@ -124,7 +124,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               B1
             </p>
@@ -139,7 +139,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               C1
             </p>
@@ -205,7 +205,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             <span
               aria-hidden={true}
@@ -228,7 +228,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               A2
             </p>
@@ -243,7 +243,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               B2
             </p>
@@ -258,7 +258,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               C2
             </p>
@@ -324,7 +324,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             <span
               aria-hidden={true}
@@ -347,7 +347,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               A3
             </p>
@@ -362,7 +362,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               B3
             </p>
@@ -377,7 +377,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               C3
             </p>
@@ -443,7 +443,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             <span
               aria-hidden={true}
@@ -466,7 +466,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               A4
             </p>
@@ -481,7 +481,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               B4
             </p>
@@ -496,7 +496,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               C4
             </p>
@@ -562,7 +562,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             <span
               aria-hidden={true}
@@ -585,7 +585,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               A5
             </p>
@@ -600,7 +600,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               B5
             </p>
@@ -615,7 +615,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               C5
             </p>
@@ -681,7 +681,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             <span
               aria-hidden={true}
@@ -704,7 +704,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               A6
             </p>
@@ -719,7 +719,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               B6
             </p>
@@ -734,7 +734,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               C6
             </p>
@@ -800,7 +800,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             <span
               aria-hidden={true}
@@ -823,7 +823,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               A7
             </p>
@@ -838,7 +838,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               B7
             </p>
@@ -853,7 +853,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               C7
             </p>
@@ -919,7 +919,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             <span
               aria-hidden={true}
@@ -942,7 +942,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               A8
             </p>
@@ -957,7 +957,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               B8
             </p>
@@ -972,7 +972,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               C8
             </p>
@@ -1038,7 +1038,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             <span
               aria-hidden={true}
@@ -1061,7 +1061,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               A9
             </p>
@@ -1076,7 +1076,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               B9
             </p>
@@ -1091,7 +1091,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               C9
             </p>
@@ -1157,7 +1157,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb jVDCXG"
+            className="sc-bxivhb jpeJmp"
           >
             <span
               aria-hidden={true}
@@ -1180,7 +1180,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               A10
             </p>
@@ -1195,7 +1195,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               B10
             </p>
@@ -1210,7 +1210,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb fpMQQD"
             >
               C10
             </p>

--- a/src/components/Text/__snapshots__/story.storyshot
+++ b/src/components/Text/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Text Default 1`] = `
 <p
-  className="sc-bxivhb gfECsG"
+  className="sc-bxivhb fYSYyq"
 >
   
     Now this is the story all about how

--- a/src/components/Text/__snapshots__/test.tsx.snap
+++ b/src/components/Text/__snapshots__/test.tsx.snap
@@ -4,9 +4,9 @@ exports[`Text should render text with default styling 1`] = `
 .c0 {
   color: #333740;
   font-family: Source Sans Pro,sans-serif;
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 1.5;
+  font-size: 15px;
+  font-weight: 300;
+  line-height: 21px;
   margin: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -1,16 +1,14 @@
 import React, { SFC } from 'react';
 import { StyledType } from '../../utility/styled';
 import { StyledSpan, StyledParagraph } from './style';
-import SeverityType from '../../types/SeverityType';
 
 type PropsType = StyledType & {
+    variant?: 'small' | 'regular' | 'large' | 'XL' | 'display';
+    severity?: 'default' | 'error' | 'success' | 'info' | 'warning';
+    textAlign?: 'left' | 'right' | 'center' | 'justify';
     compact?: boolean;
-    descriptive?: boolean;
     strong?: boolean;
     inline?: boolean;
-    variant?: 'small' | 'base' | 'large';
-    textAlign?: 'left' | 'right' | 'center' | 'justify';
-    severity?: SeverityType;
 };
 
 const Text: SFC<PropsType> = (props): JSX.Element => {
@@ -19,11 +17,11 @@ const Text: SFC<PropsType> = (props): JSX.Element => {
     return (
         <Element
             variant={props.variant}
-            descriptive={props.descriptive}
-            strong={props.strong}
-            compact={props.compact}
-            textAlign={props.textAlign}
             severity={props.severity}
+            textAlign={props.textAlign}
+            compact={props.compact}
+            strong={props.strong}
+            inline={props.inline}
         >
             {props.children}
         </Element>

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -1,10 +1,11 @@
 import React, { SFC } from 'react';
 import { StyledType } from '../../utility/styled';
 import { StyledSpan, StyledParagraph } from './style';
+import SeverityType from '../../types/SeverityType';
 
 type PropsType = StyledType & {
     variant?: 'small' | 'regular' | 'large' | 'extraLarge' | 'display';
-    severity?: 'default' | 'error' | 'success' | 'info' | 'warning';
+    severity?: SeverityType;
     textAlign?: 'left' | 'right' | 'center' | 'justify';
     compact?: boolean;
     strong?: boolean;

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -3,7 +3,7 @@ import { StyledType } from '../../utility/styled';
 import { StyledSpan, StyledParagraph } from './style';
 
 type PropsType = StyledType & {
-    variant?: 'small' | 'regular' | 'large' | 'XL' | 'display';
+    variant?: 'small' | 'regular' | 'large' | 'extraLarge' | 'display';
     severity?: 'default' | 'error' | 'success' | 'info' | 'warning';
     textAlign?: 'left' | 'right' | 'center' | 'justify';
     compact?: boolean;

--- a/src/components/Text/story.tsx
+++ b/src/components/Text/story.tsx
@@ -32,7 +32,7 @@ const demoContent = `
 storiesOf('Text', module).add('Default', () => (
     <Text
         variant={select('variant', ['small', 'regular', 'large', 'extraLarge', 'display'], 'regular') as PropsType['variant']}
-        severity={select('severity', ['default', 'error', 'success', 'info', 'warning'], 'default') as PropsType['severity']}
+        severity={select('severity', [undefined, 'error', 'success', 'info', 'warning'], undefined) as PropsType['severity']}
         textAlign={select('text-align', ['left', 'right', 'center', 'justify'], 'center') as PropsType['textAlign']}
         compact={boolean('compact', false)}
         strong={boolean('strong', false)}

--- a/src/components/Text/story.tsx
+++ b/src/components/Text/story.tsx
@@ -31,13 +31,12 @@ const demoContent = `
 
 storiesOf('Text', module).add('Default', () => (
     <Text
-        strong={boolean('strong', false)}
-        descriptive={boolean('descriptive', false)}
-        compact={boolean('compact', false)}
-        inline={boolean('inline', false)}
-        variant={select('variant', ['small', 'base', 'large'], 'base') as PropsType['variant']}
+        variant={select('variant', ['small', 'regular', 'large', 'XL', 'display'], 'regular') as PropsType['variant']}
+        severity={select('severity', ['default', 'error', 'success', 'info', 'warning'], 'default') as PropsType['severity']}
         textAlign={select('text-align', ['left', 'right', 'center', 'justify'], 'center') as PropsType['textAlign']}
-        severity={select('severity', ['', 'success', 'warning', 'error'], '') as PropsType['severity']}
+        compact={boolean('compact', false)}
+        strong={boolean('strong', false)}
+        inline={boolean('inline', false)}
     >
         {demoContent}
     </Text>

--- a/src/components/Text/story.tsx
+++ b/src/components/Text/story.tsx
@@ -31,7 +31,7 @@ const demoContent = `
 
 storiesOf('Text', module).add('Default', () => (
     <Text
-        variant={select('variant', ['small', 'regular', 'large', 'XL', 'display'], 'regular') as PropsType['variant']}
+        variant={select('variant', ['small', 'regular', 'large', 'extraLarge', 'display'], 'regular') as PropsType['variant']}
         severity={select('severity', ['default', 'error', 'success', 'info', 'warning'], 'default') as PropsType['severity']}
         textAlign={select('text-align', ['left', 'right', 'center', 'justify'], 'center') as PropsType['textAlign']}
         compact={boolean('compact', false)}

--- a/src/components/Text/style.tsx
+++ b/src/components/Text/style.tsx
@@ -15,6 +15,9 @@ type TextVariantStyleType = {
 };
 
 type TextThemeType = {
+    default: {
+        color: string;
+    };
     variant: {
         small: TextVariantStyleType;
         regular: TextVariantStyleType;
@@ -26,7 +29,6 @@ type TextThemeType = {
         fontWeight: string;
     };
     severity: {
-        default: string;
         error: string;
         success: string;
         info: string;
@@ -36,7 +38,7 @@ type TextThemeType = {
 
 const StyledParagraph = withProps<PropsType, HTMLParagraphElement>(styled.p)`
     color: ${({ severity, theme }): string =>
-        !severity ? theme.Text.severity.default : theme.Text.severity[severity]};
+        severity ? theme.Text.severity[severity] : theme.Text.default.color};
     font-family: ${({ variant, theme }): string =>
         !variant ? theme.Text.variant.regular.fontFamily : theme.Text.variant[variant].fontFamily};
     font-size: ${({ variant, theme }): string =>

--- a/src/components/Text/style.tsx
+++ b/src/components/Text/style.tsx
@@ -2,66 +2,65 @@ import _R from 'react';
 import { StyledComponentClass as _S } from 'styled-components';
 import _T from '../../types/ThemeType';
 import styled, { withProps } from '../../utility/styled';
-import SeverityType from '../../types/SeverityType';
+import { PropsType } from '.';
 
 type TextVariantStyleType = {
+    fontFamily: string;
     fontSize: string;
-};
-
-type SeverityStyleType = {
-    color: string;
+    fontWeight: string;
+    lineHeight: {
+        default: string;
+        compact: string;
+    };
 };
 
 type TextThemeType = {
-    default: {
-        color: string;
-        fontFamily: string;
-        fontSize: string;
-        fontWeight: string;
-    };
-    descriptive: {
-        color: string;
+    variant: {
+        small: TextVariantStyleType;
+        regular: TextVariantStyleType;
+        large: TextVariantStyleType;
+        XL: TextVariantStyleType;
+        display: TextVariantStyleType;
     };
     strong: {
         fontWeight: string;
     };
     severity: {
-        success: SeverityStyleType;
-        warning: SeverityStyleType;
-        error: SeverityStyleType;
-        info: SeverityStyleType;
+        default: string;
+        error: string;
+        success: string;
+        info: string;
+        warning: string;
     };
-    small: TextVariantStyleType;
-    base: TextVariantStyleType;
-    large: TextVariantStyleType;
 };
 
-type TextPropsType = {
-    compact?: boolean;
-    descriptive?: boolean;
-    strong?: boolean;
-    variant?: 'small' | 'base' | 'large';
-    textAlign?: 'left' | 'right' | 'center' | 'justify';
-    severity?: SeverityType | '';
-};
-
-const StyledParagraph = withProps<TextPropsType, HTMLParagraphElement>(styled.p)`
-    color: ${({ descriptive, severity, theme }): string => {
-        if (descriptive !== undefined && descriptive) {
-            return theme.Text.descriptive.color;
+const StyledParagraph = withProps<PropsType, HTMLParagraphElement>(styled.p)`
+    color: ${({ severity, theme }): string =>
+        !severity ? theme.Text.severity.default : theme.Text.severity[severity]};
+    font-family: ${({ variant, theme }): string =>
+        !variant ? theme.Text.variant.regular.fontFamily : theme.Text.variant[variant].fontFamily};
+    font-size: ${({ variant, theme }): string =>
+        !variant ? theme.Text.variant.regular.fontSize : theme.Text.variant[variant].fontSize};
+    font-weight: ${({ variant, strong, theme }): string => {
+        if (strong) {
+            return theme.Text.strong.fontWeight;
+        } else if (variant && !strong) {
+            return theme.Text.variant[variant].fontWeight;
+        } else {
+            return theme.Text.variant.regular.fontWeight;
         }
-
-        if (severity !== undefined && severity !== '') {
-            return theme.Text.severity[severity].color;
+    }};
+    line-height: ${({ variant, compact, theme }): string => {
+        if (compact && variant) {
+            return theme.Text.variant[variant].lineHeight.compact;
+        } else if (!compact && variant) {
+            return theme.Text.variant[variant].lineHeight.default;
+        } else if (compact && !variant) {
+            return theme.Text.variant.regular.lineHeight.compact;
+        } else {
+            return theme.Text.variant.regular.lineHeight.default;
         }
-
-        return theme.Text.default.color;
-    }}
-    font-family: ${({ theme }): string => theme.Text.default.fontFamily};
-    font-size: ${({ variant, theme }): string => (variant ? theme.Text[variant].fontSize : theme.Text.base.fontSize)};
-    font-weight: ${({ strong, theme }): string =>
-        strong ? theme.Text.strong.fontWeight : theme.Text.default.fontWeight};
-    line-height: ${({ compact }): string => (compact ? '1.25' : '1.5')};
+    }};
     text-align: ${({ textAlign }): string => (textAlign ? textAlign : '')};
     margin: 0;
     -webkit-font-smoothing: antialiased;
@@ -73,4 +72,4 @@ const StyledParagraph = withProps<TextPropsType, HTMLParagraphElement>(styled.p)
 
 const StyledSpan = StyledParagraph.withComponent('span');
 
-export { StyledSpan, StyledParagraph, TextThemeType, TextVariantStyleType, SeverityStyleType };
+export { StyledSpan, StyledParagraph, TextThemeType, TextVariantStyleType };

--- a/src/components/Text/style.tsx
+++ b/src/components/Text/style.tsx
@@ -19,7 +19,7 @@ type TextThemeType = {
         small: TextVariantStyleType;
         regular: TextVariantStyleType;
         large: TextVariantStyleType;
-        XL: TextVariantStyleType;
+        extraLarge: TextVariantStyleType;
         display: TextVariantStyleType;
     };
     strong: {
@@ -46,9 +46,9 @@ const StyledParagraph = withProps<PropsType, HTMLParagraphElement>(styled.p)`
             return theme.Text.strong.fontWeight;
         } else if (variant && !strong) {
             return theme.Text.variant[variant].fontWeight;
-        } else {
-            return theme.Text.variant.regular.fontWeight;
         }
+
+        return theme.Text.variant.regular.fontWeight;
     }};
     line-height: ${({ variant, compact, theme }): string => {
         if (compact && variant) {
@@ -57,9 +57,9 @@ const StyledParagraph = withProps<PropsType, HTMLParagraphElement>(styled.p)`
             return theme.Text.variant[variant].lineHeight.default;
         } else if (compact && !variant) {
             return theme.Text.variant.regular.lineHeight.compact;
-        } else {
-            return theme.Text.variant.regular.lineHeight.default;
         }
+
+        return theme.Text.variant.regular.lineHeight.default;
     }};
     text-align: ${({ textAlign }): string => (textAlign ? textAlign : '')};
     margin: 0;

--- a/src/components/Text/test.tsx
+++ b/src/components/Text/test.tsx
@@ -2,6 +2,7 @@ import toJson from 'enzyme-to-json';
 import React from 'react';
 import Text from '.';
 import { shallowWithTheme } from '../../utility/styled/testing';
+import MosTheme from '../../themes/MosTheme/MosTheme.theme';
 
 describe('Text', () => {
     it('should render text with default styling', () => {
@@ -18,27 +19,27 @@ describe('Text', () => {
         const displayText = shallowWithTheme(<Text variant="display">Display text</Text>);
 
         /* tslint:disable */
-        (expect(toJson(smallText.dive())) as any).toHaveStyleRule('font-size', '12px');
-        (expect(toJson(regularText.dive())) as any).toHaveStyleRule('font-size', '15px');
-        (expect(toJson(largeText.dive())) as any).toHaveStyleRule('font-size', '18px');
-        (expect(toJson(extraLargeText.dive())) as any).toHaveStyleRule('font-size', '21px');
-        (expect(toJson(displayText.dive())) as any).toHaveStyleRule('font-size', '60px');
+        (expect(toJson(smallText.dive())) as any).toHaveStyleRule('font-size', MosTheme.Text.variant.small.fontSize);
+        (expect(toJson(regularText.dive())) as any).toHaveStyleRule('font-size', MosTheme.Text.variant.regular.fontSize);
+        (expect(toJson(largeText.dive())) as any).toHaveStyleRule('font-size', MosTheme.Text.variant.large.fontSize);
+        (expect(toJson(extraLargeText.dive())) as any).toHaveStyleRule('font-size', MosTheme.Text.variant.extraLarge.fontSize);
+        (expect(toJson(displayText.dive())) as any).toHaveStyleRule('font-size', MosTheme.Text.variant.display.fontSize);
         /* tslint:enable */
     });
 
     it('should render text with different severities', () => {
-        const defaultText = shallowWithTheme(<Text severity="default">Descriptive text</Text>);
+        const defaultText = shallowWithTheme(<Text>Descriptive text</Text>);
         const errorText = shallowWithTheme(<Text severity="error">Descriptive text</Text>);
         const successText = shallowWithTheme(<Text severity="success">Descriptive text</Text>);
         const infoText = shallowWithTheme(<Text severity="info">Descriptive text</Text>);
         const warningText = shallowWithTheme(<Text severity="warning">Descriptive text</Text>);
 
         /* tslint:disable */
-        (expect(toJson(defaultText.dive())) as any).toHaveStyleRule('color', '#333740');
-        (expect(toJson(errorText.dive())) as any).toHaveStyleRule('color', '#c81746');
-        (expect(toJson(successText.dive())) as any).toHaveStyleRule('color', '#4cc55b');
-        (expect(toJson(infoText.dive())) as any).toHaveStyleRule('color', '#a6aab3');
-        (expect(toJson(warningText.dive())) as any).toHaveStyleRule('color', '#edb107');
+        (expect(toJson(defaultText.dive())) as any).toHaveStyleRule('color', MosTheme.Text.default.color);
+        (expect(toJson(errorText.dive())) as any).toHaveStyleRule('color', MosTheme.Text.severity.error);
+        (expect(toJson(successText.dive())) as any).toHaveStyleRule('color', MosTheme.Text.severity.success);
+        (expect(toJson(infoText.dive())) as any).toHaveStyleRule('color', MosTheme.Text.severity.info);
+        (expect(toJson(warningText.dive())) as any).toHaveStyleRule('color', MosTheme.Text.severity.warning);
         /* tslint:enable */
     });
 
@@ -47,8 +48,8 @@ describe('Text', () => {
         const extraLargeCompact = shallowWithTheme(<Text variant="extraLarge" compact>Descriptive text</Text>);
 
         /* tslint:disable */
-        (expect(toJson(defaultCompact.dive())) as any).toHaveStyleRule('line-height', '18px');
-        (expect(toJson(extraLargeCompact.dive())) as any).toHaveStyleRule('line-height', '27px');
+        (expect(toJson(defaultCompact.dive())) as any).toHaveStyleRule('line-height', MosTheme.Text.variant.regular.lineHeight.compact);
+        (expect(toJson(extraLargeCompact.dive())) as any).toHaveStyleRule('line-height', MosTheme.Text.variant.extraLarge.lineHeight.compact);
         /* tslint:enable */
     });
 
@@ -56,7 +57,7 @@ describe('Text', () => {
         const component = shallowWithTheme(<Text strong>Strong text</Text>);
 
         /* tslint:disable */
-        (expect(toJson(component.dive())) as any).toHaveStyleRule('font-weight', '700');
+        (expect(toJson(component.dive())) as any).toHaveStyleRule('font-weight', MosTheme.Text.strong.fontWeight);
         /* tslint:enable */
     });
 

--- a/src/components/Text/test.tsx
+++ b/src/components/Text/test.tsx
@@ -10,27 +10,53 @@ describe('Text', () => {
         expect(toJson(component.dive())).toMatchSnapshot();
     });
 
+    it('should render text with different variants', () => {
+        const smallText = shallowWithTheme(<Text variant="small">Small text</Text>);
+        const regularText = shallowWithTheme(<Text variant="regular">Regular text</Text>);
+        const largeText = shallowWithTheme(<Text variant="large">Large text</Text>);
+        const XLText = shallowWithTheme(<Text variant="XL">XL text</Text>);
+        const displayText = shallowWithTheme(<Text variant="display">Display text</Text>);
+
+        /* tslint:disable */
+        (expect(toJson(smallText.dive())) as any).toHaveStyleRule('font-size', '12px');
+        (expect(toJson(regularText.dive())) as any).toHaveStyleRule('font-size', '15px');
+        (expect(toJson(largeText.dive())) as any).toHaveStyleRule('font-size', '18px');
+        (expect(toJson(XLText.dive())) as any).toHaveStyleRule('font-size', '21px');
+        (expect(toJson(displayText.dive())) as any).toHaveStyleRule('font-size', '60px');
+        /* tslint:enable */
+    });
+
+    it('should render text with different severities', () => {
+        const defaultText = shallowWithTheme(<Text severity="default">Descriptive text</Text>);
+        const errorText = shallowWithTheme(<Text severity="error">Descriptive text</Text>);
+        const successText = shallowWithTheme(<Text severity="success">Descriptive text</Text>);
+        const infoText = shallowWithTheme(<Text severity="info">Descriptive text</Text>);
+        const warningText = shallowWithTheme(<Text severity="warning">Descriptive text</Text>);
+
+        /* tslint:disable */
+        (expect(toJson(defaultText.dive())) as any).toHaveStyleRule('color', '#333740');
+        (expect(toJson(errorText.dive())) as any).toHaveStyleRule('color', '#c81746');
+        (expect(toJson(successText.dive())) as any).toHaveStyleRule('color', '#4cc55b');
+        (expect(toJson(infoText.dive())) as any).toHaveStyleRule('color', '#a6aab3');
+        (expect(toJson(warningText.dive())) as any).toHaveStyleRule('color', '#edb107');
+        /* tslint:enable */
+    });
+
+    it('should render text with compact styling', () => {
+        const defaultCompact = shallowWithTheme(<Text compact>Descriptive text</Text>);
+        const XLCompact = shallowWithTheme(<Text variant="XL" compact>Descriptive text</Text>);
+
+        /* tslint:disable */
+        (expect(toJson(defaultCompact.dive())) as any).toHaveStyleRule('line-height', '18px');
+        (expect(toJson(XLCompact.dive())) as any).toHaveStyleRule('line-height', '27px');
+        /* tslint:enable */
+    });
+
     it('should render text with strong styling', () => {
         const component = shallowWithTheme(<Text strong>Strong text</Text>);
 
         /* tslint:disable */
         (expect(toJson(component.dive())) as any).toHaveStyleRule('font-weight', '700');
-        /* tslint:enable */
-    });
-
-    it('should render text with descriptive styling', () => {
-        const component = shallowWithTheme(<Text descriptive>Descriptive text</Text>);
-
-        /* tslint:disable */
-        (expect(toJson(component.dive())) as any).toHaveStyleRule('color', '#a6aab3');
-        /* tslint:enable */
-    });
-
-    it('should render text with compact styling', () => {
-        const component = shallowWithTheme(<Text compact>Descriptive text</Text>);
-
-        /* tslint:disable */
-        (expect(toJson(component.dive())) as any).toHaveStyleRule('line-height', '1.25');
         /* tslint:enable */
     });
 

--- a/src/components/Text/test.tsx
+++ b/src/components/Text/test.tsx
@@ -14,14 +14,14 @@ describe('Text', () => {
         const smallText = shallowWithTheme(<Text variant="small">Small text</Text>);
         const regularText = shallowWithTheme(<Text variant="regular">Regular text</Text>);
         const largeText = shallowWithTheme(<Text variant="large">Large text</Text>);
-        const XLText = shallowWithTheme(<Text variant="XL">XL text</Text>);
+        const extraLargeText = shallowWithTheme(<Text variant="extraLarge">extraLarge text</Text>);
         const displayText = shallowWithTheme(<Text variant="display">Display text</Text>);
 
         /* tslint:disable */
         (expect(toJson(smallText.dive())) as any).toHaveStyleRule('font-size', '12px');
         (expect(toJson(regularText.dive())) as any).toHaveStyleRule('font-size', '15px');
         (expect(toJson(largeText.dive())) as any).toHaveStyleRule('font-size', '18px');
-        (expect(toJson(XLText.dive())) as any).toHaveStyleRule('font-size', '21px');
+        (expect(toJson(extraLargeText.dive())) as any).toHaveStyleRule('font-size', '21px');
         (expect(toJson(displayText.dive())) as any).toHaveStyleRule('font-size', '60px');
         /* tslint:enable */
     });
@@ -44,11 +44,11 @@ describe('Text', () => {
 
     it('should render text with compact styling', () => {
         const defaultCompact = shallowWithTheme(<Text compact>Descriptive text</Text>);
-        const XLCompact = shallowWithTheme(<Text variant="XL" compact>Descriptive text</Text>);
+        const extraLargeCompact = shallowWithTheme(<Text variant="extraLarge" compact>Descriptive text</Text>);
 
         /* tslint:disable */
         (expect(toJson(defaultCompact.dive())) as any).toHaveStyleRule('line-height', '18px');
-        (expect(toJson(XLCompact.dive())) as any).toHaveStyleRule('line-height', '27px');
+        (expect(toJson(extraLargeCompact.dive())) as any).toHaveStyleRule('line-height', '27px');
         /* tslint:enable */
     });
 

--- a/src/components/TextField/formatters/withCurrencyFormatting/__snapshots__/story.storyshot
+++ b/src/components/TextField/formatters/withCurrencyFormatting/__snapshots__/story.storyshot
@@ -77,7 +77,7 @@ Array [
     className="sc-bwzfXH gKGSfm"
   >
     <p
-      className="sc-bxivhb fhwEDr"
+      className="sc-bxivhb bgphtb"
     >
       <span
         className="sc-htpNat frObKr"
@@ -152,7 +152,7 @@ Array [
     className="sc-bwzfXH gKGSfm"
   >
     <p
-      className="sc-bxivhb eEGBVx"
+      className="sc-bxivhb jNLkvd"
     >
       <span
         className="sc-htpNat frObKr"

--- a/src/components/TextField/style.tsx
+++ b/src/components/TextField/style.tsx
@@ -96,7 +96,7 @@ const StyledWrapper = withProps<WrapperProps, HTMLDivElement>(styled.div)`
 
     ${({ focus, severity, theme }): string =>
         focus
-            ? `border: solid 1px ${theme.Text.severity[severity].color}`
+            ? `border: solid 1px ${theme.Text.severity[severity]}`
             : `border: solid 1px ${theme.TextField.idle.common.borderColor}`};
 
     ${({ focus, disabled, severity, theme }): string =>

--- a/src/components/Toaster/__snapshots__/story.storyshot
+++ b/src/components/Toaster/__snapshots__/story.storyshot
@@ -24,7 +24,7 @@ exports[`Storyshots Toaster Default 1`] = `
             className="sc-bwzfXH jQmHZh"
           >
             <span
-              className="sc-ifAKCX kTqttQ"
+              className="sc-ifAKCX jHMnVy"
             >
               <span
                 aria-hidden={true}
@@ -45,12 +45,12 @@ exports[`Storyshots Toaster Default 1`] = `
               className="sc-bwzfXH gaQYSB"
             >
               <p
-                className="sc-bxivhb gTyNSX"
+                className="sc-bxivhb gAVOHP"
               >
                 Thought provoking we must stand.
               </p>
               <p
-                className="sc-bxivhb jpexxn"
+                className="sc-bxivhb fpMQQD"
               >
                 Game-changer problem-solvers; state of play invest, synergy uplift we must stand up ideate social intrapreneurship.
               </p>
@@ -110,7 +110,7 @@ exports[`Storyshots Toaster With action button 1`] = `
             className="sc-bwzfXH jQmHZh"
           >
             <span
-              className="sc-ifAKCX icOBot"
+              className="sc-ifAKCX fbGKwU"
             >
               <span
                 aria-hidden={true}
@@ -131,12 +131,12 @@ exports[`Storyshots Toaster With action button 1`] = `
               className="sc-bwzfXH gaQYSB"
             >
               <p
-                className="sc-bxivhb gTyNSX"
+                className="sc-bxivhb gAVOHP"
               >
                 Overcome injustice.
               </p>
               <p
-                className="sc-bxivhb jpexxn"
+                className="sc-bxivhb fpMQQD"
               >
                 Global low-hanging fruit, collaborative consumption segmentation mobilize support. Problem-solvers cultivate, best practices, shared unit of.
               </p>

--- a/src/components/Toaster/style.tsx
+++ b/src/components/Toaster/style.tsx
@@ -11,6 +11,12 @@ type ToasterPropsType = {
 type ToasterThemeType = {
     borderRadius: string;
     backgroundColor: string;
+    severity: {
+        error: string;
+        success: string;
+        info: string;
+        warning: string;
+    };
 };
 
 const StyledToasterWrapper = styled.div`
@@ -34,7 +40,7 @@ const StyledToaster = withProps<ToasterPropsType, HTMLDivElement>(styled.div)`
     box-shadow: 0 3px 48px rgba(0,0,0,0.3);
     border-radius: ${({ theme }): string => theme.Toaster.borderRadius}
     background-color: ${({ theme }): string => theme.Toaster.backgroundColor}
-    border-left: ${({ severity, theme }): string => `4px solid ${theme.Text.severity[severity].color};`}
+    border-left: ${({ severity, theme }): string => `4px solid ${theme.Toaster.severity[severity]};`}
 `;
 
 export default StyledToaster;

--- a/src/components/Toggle/__snapshots__/story.storyshot
+++ b/src/components/Toggle/__snapshots__/story.storyshot
@@ -34,7 +34,7 @@ exports[`Storyshots Toggle Default 1`] = `
       className="sc-bwzfXH fmiztD"
     >
       <p
-        className="sc-bxivhb jpexxn"
+        className="sc-bxivhb fpMQQD"
       >
          
         Turn me on!

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -75,7 +75,7 @@ class Toggle extends Component<PropsType, StateType> {
                         </StyledToggleSkin>
                     </Box>
                     <Box margin={trbl(9, 0, 0, 0)}>
-                        <Text descriptive={this.props.disabled}>
+                        <Text severity={this.props.disabled ? 'info' : 'default'}>
                             {this.props.disabledIcon && this.props.disabled && <Icon size="medium" icon="locked" />}{' '}
                             {this.props.label}
                         </Text>

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -75,7 +75,7 @@ class Toggle extends Component<PropsType, StateType> {
                         </StyledToggleSkin>
                     </Box>
                     <Box margin={trbl(9, 0, 0, 0)}>
-                        <Text severity={this.props.disabled ? 'info' : 'default'}>
+                        <Text severity={this.props.disabled ? 'info' : undefined}>
                             {this.props.disabledIcon && this.props.disabled && <Icon size="medium" icon="locked" />}{' '}
                             {this.props.label}
                         </Text>

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -71,6 +71,7 @@ const theme: ThemeType = {
     Badge: {
         backgroundColor: red.base,
         color: silver.lighter1,
+        fontFamily: bodyFont,
     },
     Button: {
         common: {

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -625,7 +625,7 @@ const theme: ThemeType = {
                     compact: '21px',
                 },
             },
-            XL: {
+            extraLarge: {
                 fontFamily: bodyFont,
                 fontSize: '21px',
                 fontWeight: fontWeight.light,

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -598,6 +598,9 @@ const theme: ThemeType = {
         },
     },
     Text: {
+        default: {
+            color: grey.base,
+        },
         variant: {
             small: {
                 fontFamily: bodyFont,
@@ -649,7 +652,6 @@ const theme: ThemeType = {
             fontWeight: fontWeight.bold,
         },
         severity: {
-            default: grey.base,
             error: severity.error,
             success: severity.success,
             info: severity.info,

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -13,6 +13,11 @@ const fontSize = {
     larger3: '36px',
 };
 
+const fontWeight = {
+    light: '300',
+    bold: '700',
+};
+
 const green = {
     lighter1: '#7ce88a',
     base: '#6bde78',
@@ -53,6 +58,13 @@ const yellow = {
 
 const roundness = {
     base: '3px',
+};
+
+const severity = {
+    error: red.darker2,
+    success: green.darker2,
+    info: grey.lighter3,
+    warning: yellow.darker2,
 };
 
 const theme: ThemeType = {
@@ -585,32 +597,62 @@ const theme: ThemeType = {
         },
     },
     Text: {
-        default: {
-            color: grey.base,
-            fontFamily: bodyFont,
-            fontSize: fontSize.base,
-            fontWeight: '400',
-        },
-        descriptive: {
-            color: grey.lighter3,
+        variant: {
+            small: {
+                fontFamily: bodyFont,
+                fontSize: '12px',
+                fontWeight: fontWeight.light,
+                lineHeight: {
+                    default: '18px',
+                    compact: '15px',
+                },
+            },
+            regular: {
+                fontFamily: bodyFont,
+                fontSize: '15px',
+                fontWeight: fontWeight.light,
+                lineHeight: {
+                    default: '21px',
+                    compact: '18px',
+                },
+            },
+            large: {
+                fontFamily: bodyFont,
+                fontSize: '18px',
+                fontWeight: fontWeight.light,
+                lineHeight: {
+                    default: '27px',
+                    compact: '21px',
+                },
+            },
+            XL: {
+                fontFamily: bodyFont,
+                fontSize: '21px',
+                fontWeight: fontWeight.light,
+                lineHeight: {
+                    default: '30px',
+                    compact: '27px',
+                },
+            },
+            display: {
+                fontFamily: headingFont,
+                fontSize: '60px',
+                fontWeight: fontWeight.bold,
+                lineHeight: {
+                    default: '75px',
+                    compact: '75px',
+                },
+            },
         },
         strong: {
-            fontWeight: '700',
-        },
-        small: {
-            fontSize: fontSize.smaller1,
-        },
-        base: {
-            fontSize: fontSize.base,
-        },
-        large: {
-            fontSize: fontSize.larger1,
+            fontWeight: fontWeight.bold,
         },
         severity: {
-            error: { color: red.darker2 },
-            success: { color: green.darker2 },
-            info: { color: grey.lighter3 },
-            warning: { color: yellow.darker2 },
+            default: grey.base,
+            error: severity.error,
+            success: severity.success,
+            info: severity.info,
+            warning: severity.warning,
         },
     },
     TextField: {
@@ -652,6 +694,12 @@ const theme: ThemeType = {
     Toaster: {
         borderRadius: roundness.base,
         backgroundColor: silver.lighter1,
+        severity: {
+            error: severity.error,
+            success: severity.success,
+            info: severity.info,
+            warning: severity.warning,
+        },
     },
     Toggle: {
         general: {


### PR DESCRIPTION
### This PR:

The `Text` component had different size-steps then design had designed. This PR implements a new way to use the `Text` component, according to the design.

proposed release: `minor`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)
- [x] Appropriate tests have been added for my functionality (check if not applicable)

**Changes** 🌀
- Property `variant` is changed from: `small` | `base` | `large` to: `small` | `regular` | `large` | `XL` | `display`. Use this prop to set the font-size.
- Property `severity` accepts also `default` and `info` now. Use this prop to set the color.

**Removes** 👋
- `descriptive` property. If you want to make the text look descriptive now, just set the `severity`-property to `info`, like this: `<Text severity="info">Descriptive text</Text>`
