### PR TITLE
modal now only too large in IE11

### DIFF
--- a/src/components/Modal/__snapshots__/story.storyshot
+++ b/src/components/Modal/__snapshots__/story.storyshot
@@ -15,7 +15,7 @@ exports[`Storyshots Modal Default 1`] = `
       }
     >
       <div
-        className="sc-jlyJG cZkCvT"
+        className="sc-jlyJG fPCoSz"
       >
         <div
           className="sc-bwzfXH jTCciZ"
@@ -167,7 +167,7 @@ exports[`Storyshots Modal Without closeAction 1`] = `
       }
     >
       <div
-        className="sc-jlyJG cZkCvT"
+        className="sc-jlyJG fPCoSz"
       >
         <div
           className="sc-bwzfXH jTCciZ"

--- a/src/components/Modal/style.tsx
+++ b/src/components/Modal/style.tsx
@@ -51,11 +51,14 @@ const StyledModal = withProps<ModalPropsType>(styled.div)`
     width: ${({ modalSize }): string => ModalSizes[modalSize]};
     display: flex;
     flex-direction: column;
-    height: 100vh;
     overflow: hidden;
     max-height: calc(300px + (600 - 300) * (100vh - 300px) / (900 - 300));
     background: ${({ theme }): string => theme.Modal.backgroundColor};
     border-radius: ${({ theme }): string => theme.Modal.borderRadius};
+
+    @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+        height: 100vh;
+    }
 `;
 
 export default StyledModal;


### PR DESCRIPTION
### This PR:

The css rule `height: 100vh;` is now only applied to IE11 browsers, restoring the prefered behaviour on the newer browsers. 
This does mean that the modal will stil be streched on IE11, i haven't found a suitable solution for this. 

resolves #231 

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)
- [x] Appropriate tests have been added for my functionality (check if not applicable)

**Changes** 🌀
- Css rule `height: 100vh;` is now only applied to IE11 browsers, restoring the prefered behaviour on the newer browsers. 
