### PR TITLE
Fixed IE flexbox issue in Text and stories in FormRow that were affected by this issue

### DIFF
--- a/src/components/Box/__snapshots__/story.storyshot
+++ b/src/components/Box/__snapshots__/story.storyshot
@@ -17,7 +17,7 @@ exports[`Storyshots Box Default 1`] = `
           className="sc-bwzfXH cFJdBG"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb kFVWeI"
           >
             Box 
             1
@@ -35,7 +35,7 @@ exports[`Storyshots Box Default 1`] = `
           className="sc-bwzfXH cFJdBG"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb kFVWeI"
           >
             Box 
             2
@@ -53,7 +53,7 @@ exports[`Storyshots Box Default 1`] = `
           className="sc-bwzfXH cFJdBG"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb kFVWeI"
           >
             Box 
             3
@@ -71,7 +71,7 @@ exports[`Storyshots Box Default 1`] = `
           className="sc-bwzfXH cFJdBG"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb kFVWeI"
           >
             Box 
             4
@@ -89,7 +89,7 @@ exports[`Storyshots Box Default 1`] = `
           className="sc-bwzfXH cFJdBG"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb kFVWeI"
           >
             Box 
             5
@@ -107,7 +107,7 @@ exports[`Storyshots Box Default 1`] = `
           className="sc-bwzfXH cFJdBG"
         >
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb kFVWeI"
           >
             Box 
             6

--- a/src/components/Branch/__snapshots__/story.storyshot
+++ b/src/components/Branch/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Branch Default 1`] = `
 <p
-  className="sc-bxivhb jpexxn"
+  className="sc-bxivhb kFVWeI"
 >
   This is shown when condition is true. 
   This line is shared whether the condition is true or not.

--- a/src/components/BreakpointProvider/__snapshots__/story.storyshot
+++ b/src/components/BreakpointProvider/__snapshots__/story.storyshot
@@ -12,7 +12,7 @@ exports[`Storyshots BreakpointProvider Default 1`] = `
     className="sc-gzVnrw eSDhrQ"
   >
     <p
-      className="sc-bxivhb jpexxn"
+      className="sc-bxivhb kFVWeI"
     >
       Current breakpoint is 
       large

--- a/src/components/EmptyState/__snapshots__/story.storyshot
+++ b/src/components/EmptyState/__snapshots__/story.storyshot
@@ -31,7 +31,7 @@ exports[`Storyshots EmptyState Default 1`] = `
       className="sc-bwzfXH eTHzfe"
     >
       <p
-        className="sc-bxivhb fieUlb"
+        className="sc-bxivhb dGxAqY"
       >
         ..A tumbleweed passes by
       </p>
@@ -71,7 +71,7 @@ exports[`Storyshots EmptyState With button (as children) 1`] = `
       className="sc-bwzfXH eTHzfe"
     >
       <p
-        className="sc-bxivhb fieUlb"
+        className="sc-bxivhb dGxAqY"
       >
         There are no filters applied yet. Use the button below to apply a filter.
       </p>

--- a/src/components/ErrorBoundary/__snapshots__/story.storyshot
+++ b/src/components/ErrorBoundary/__snapshots__/story.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots ErrorBoundary Default 1`] = `
 <div>
   <p
-    className="sc-bxivhb jpexxn"
+    className="sc-bxivhb kFVWeI"
   >
     This does not have an error.
   </p>

--- a/src/components/FoldOut/__snapshots__/story.storyshot
+++ b/src/components/FoldOut/__snapshots__/story.storyshot
@@ -10,7 +10,7 @@ exports[`Storyshots FoldOut With a toggle 1`] = `
         className="sc-bwzfXH ebfsxO"
       >
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb kFVWeI"
         >
           
     Now this is the story all about how

--- a/src/components/FormRow/__snapshots__/story.storyshot
+++ b/src/components/FormRow/__snapshots__/story.storyshot
@@ -9,17 +9,13 @@ exports[`Storyshots FormRow Default 1`] = `
       className="sc-bwzfXH lkpHKK"
     >
       <label>
-        <div
-          className="sc-bwzfXH cAZkVZ"
-        >
-          <p
-            className="sc-bxivhb jpexxn"
-          >
-            What is your name?
-          </p>
-        </div>
         <p
-          className="sc-bxivhb fhIWly"
+          className="sc-bxivhb kFVWeI"
+        >
+          What is your name?
+        </p>
+        <p
+          className="sc-bxivhb kTaguW"
         >
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus, corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
         </p>
@@ -144,17 +140,13 @@ exports[`Storyshots FormRow Default 1`] = `
       className="sc-bwzfXH lkpHKK"
     >
       <label>
-        <div
-          className="sc-bwzfXH cAZkVZ"
-        >
-          <p
-            className="sc-bxivhb jpexxn"
-          >
-            Where do you live?
-          </p>
-        </div>
         <p
-          className="sc-bxivhb fhIWly"
+          className="sc-bxivhb kFVWeI"
+        >
+          Where do you live?
+        </p>
+        <p
+          className="sc-bxivhb kTaguW"
         >
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus, corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
         </p>
@@ -242,17 +234,13 @@ exports[`Storyshots FormRow Default 1`] = `
       className="sc-bwzfXH lkpHKK"
     >
       <label>
-        <div
-          className="sc-bwzfXH cAZkVZ"
-        >
-          <p
-            className="sc-bxivhb jpexxn"
-          >
-            Can a boolean only be either true or false?
-          </p>
-        </div>
         <p
-          className="sc-bxivhb fhIWly"
+          className="sc-bxivhb kFVWeI"
+        >
+          Can a boolean only be either true or false?
+        </p>
+        <p
+          className="sc-bxivhb kTaguW"
         >
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus, corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
         </p>
@@ -293,7 +281,7 @@ exports[`Storyshots FormRow Default 1`] = `
               </div>
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               <span
                 className="sc-htpNat ivSMHx"
@@ -336,7 +324,7 @@ exports[`Storyshots FormRow Default 1`] = `
               </div>
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               <span
                 className="sc-htpNat ivSMHx"
@@ -379,7 +367,7 @@ exports[`Storyshots FormRow Default 1`] = `
               </div>
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               <span
                 className="sc-htpNat ivSMHx"
@@ -409,7 +397,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     >
       <label>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb kFVWeI"
         >
           What is your name?
         </p>
@@ -465,7 +453,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     >
       <label>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb kFVWeI"
         >
           Where do you live?
         </p>
@@ -521,7 +509,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     >
       <label>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb kFVWeI"
         >
           Can a boolean only be true or false?
         </p>
@@ -562,7 +550,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
               </div>
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               <span
                 className="sc-htpNat ivSMHx"
@@ -605,7 +593,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
               </div>
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               <span
                 className="sc-htpNat ivSMHx"
@@ -648,7 +636,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
               </div>
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               <span
                 className="sc-htpNat ivSMHx"
@@ -673,7 +661,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     >
       <label>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb kFVWeI"
         >
           Do you like toggles?
         </p>
@@ -715,7 +703,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
             className="sc-bwzfXH fmiztD"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
                
               Toggle to indicate your preference!
@@ -733,7 +721,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     >
       <label>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb kFVWeI"
         >
           Do you like checkboxes
         </p>

--- a/src/components/FormRow/story.tsx
+++ b/src/components/FormRow/story.tsx
@@ -49,9 +49,7 @@ class DemoComponent extends Component<PropsType, StateType> {
                     <FormRow
                         label={
                             <label>
-                                <Box>
-                                    <Text>What is your name?</Text>
-                                </Box>
+                                <Text>What is your name?</Text>
                                 <Text descriptive>
                                     Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
                                     similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
@@ -93,9 +91,7 @@ class DemoComponent extends Component<PropsType, StateType> {
                     <FormRow
                         label={
                             <label>
-                                <Box>
-                                    <Text>Where do you live?</Text>
-                                </Box>
+                                <Text>Where do you live?</Text>
                                 <Text descriptive>
                                     Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
                                     similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
@@ -127,9 +123,7 @@ class DemoComponent extends Component<PropsType, StateType> {
                     <FormRow
                         label={
                             <label>
-                                <Box>
-                                    <Text>Can a boolean only be either true or false?</Text>
-                                </Box>
+                                <Text>Can a boolean only be either true or false?</Text>
                                 <Text descriptive>
                                     Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
                                     similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,

--- a/src/components/InlineNotification/__snapshots__/story.storyshot
+++ b/src/components/InlineNotification/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots InlineNotification Default 1`] = `
 <p
-  className="sc-bxivhb eEGBVx"
+  className="sc-bxivhb gWsGB"
 >
   <span
     className="sc-htpNat frObKr"
@@ -32,7 +32,7 @@ exports[`Storyshots InlineNotification Default 1`] = `
 
 exports[`Storyshots InlineNotification With children 1`] = `
 <p
-  className="sc-bxivhb fhwEDr"
+  className="sc-bxivhb bfQmQc"
 >
   <span
     className="sc-htpNat frObKr"
@@ -71,7 +71,7 @@ exports[`Storyshots InlineNotification With children 1`] = `
 
 exports[`Storyshots InlineNotification With overwritten Icon 1`] = `
 <p
-  className="sc-bxivhb eEGBVx"
+  className="sc-bxivhb gWsGB"
 >
   <span
     className="sc-htpNat frObKr"

--- a/src/components/Link/__snapshots__/story.storyshot
+++ b/src/components/Link/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Link Action with child element 1`] = `
 <p
-  className="sc-bxivhb jpexxn"
+  className="sc-bxivhb kFVWeI"
 >
   <button
     className="sc-hSdWYo XiZO"
@@ -19,7 +19,7 @@ exports[`Storyshots Link Action with child element 1`] = `
 
 exports[`Storyshots Link Default 1`] = `
 <p
-  className="sc-bxivhb jpexxn"
+  className="sc-bxivhb kFVWeI"
 >
   <a
     className="sc-iAyFgw gqgAvO"

--- a/src/components/MessageStream/__snapshots__/story.storyshot
+++ b/src/components/MessageStream/__snapshots__/story.storyshot
@@ -18,12 +18,12 @@ exports[`Storyshots MessageStream Default 1`] = `
           className="sc-bwzfXH injrXU"
         >
           <p
-            className="sc-bxivhb gTyNSX"
+            className="sc-bxivhb ildJSL"
           >
             Sit Inceptos Magna
           </p>
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb kFVWeI"
           >
             <span
               dangerouslySetInnerHTML={
@@ -34,7 +34,7 @@ exports[`Storyshots MessageStream Default 1`] = `
             />
           </p>
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             Today 12:00
           </p>
@@ -59,12 +59,12 @@ exports[`Storyshots MessageStream Default 1`] = `
           className="sc-bwzfXH injrXU"
         >
           <p
-            className="sc-bxivhb gTyNSX"
+            className="sc-bxivhb ildJSL"
           >
             Aenean Dapibus Vulputate Tortor Magna
           </p>
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb kFVWeI"
           >
             <span
               dangerouslySetInnerHTML={
@@ -76,7 +76,7 @@ exports[`Storyshots MessageStream Default 1`] = `
             />
           </p>
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             Today 10:00
           </p>
@@ -101,12 +101,12 @@ exports[`Storyshots MessageStream Default 1`] = `
           className="sc-bwzfXH injrXU"
         >
           <p
-            className="sc-bxivhb gTyNSX"
+            className="sc-bxivhb ildJSL"
           >
             Vestibulum Dapibus
           </p>
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb kFVWeI"
           >
             <span
               dangerouslySetInnerHTML={
@@ -117,7 +117,7 @@ exports[`Storyshots MessageStream Default 1`] = `
             />
           </p>
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             Yesterday 12:00
           </p>
@@ -158,12 +158,12 @@ exports[`Storyshots MessageStream Default 1`] = `
           className="sc-bwzfXH injrXU"
         >
           <p
-            className="sc-bxivhb gTyNSX"
+            className="sc-bxivhb ildJSL"
           >
             Parturient Euismod Mollis Fringilla
           </p>
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb kFVWeI"
           >
             <span
               dangerouslySetInnerHTML={
@@ -175,7 +175,7 @@ exports[`Storyshots MessageStream Default 1`] = `
             />
           </p>
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             12-12-2012 12:00
           </p>
@@ -216,12 +216,12 @@ exports[`Storyshots MessageStream Default 1`] = `
           className="sc-bwzfXH injrXU"
         >
           <p
-            className="sc-bxivhb gTyNSX"
+            className="sc-bxivhb ildJSL"
           >
             Tortor Cursus
           </p>
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb kFVWeI"
           >
             <span
               dangerouslySetInnerHTML={
@@ -232,7 +232,7 @@ exports[`Storyshots MessageStream Default 1`] = `
             />
           </p>
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             12-12-2012 12:00
           </p>
@@ -273,12 +273,12 @@ exports[`Storyshots MessageStream Default 1`] = `
           className="sc-bwzfXH injrXU"
         >
           <p
-            className="sc-bxivhb gTyNSX"
+            className="sc-bxivhb ildJSL"
           >
             Euismod Dolor Consectetur
           </p>
           <p
-            className="sc-bxivhb jpexxn"
+            className="sc-bxivhb kFVWeI"
           >
             <span
               dangerouslySetInnerHTML={
@@ -289,7 +289,7 @@ exports[`Storyshots MessageStream Default 1`] = `
             />
           </p>
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           />
         </div>
         <div

--- a/src/components/Modal/__snapshots__/story.storyshot
+++ b/src/components/Modal/__snapshots__/story.storyshot
@@ -65,7 +65,7 @@ exports[`Storyshots Modal Default 1`] = `
               className="sc-bwzfXH fiOUi"
             >
               <p
-                className="sc-bxivhb jpexxn"
+                className="sc-bxivhb kFVWeI"
               >
                 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut mi ligula. Phasellus tellus nulla,
@@ -192,7 +192,7 @@ exports[`Storyshots Modal Without closeAction 1`] = `
               className="sc-bwzfXH fiOUi"
             >
               <p
-                className="sc-bxivhb jpexxn"
+                className="sc-bxivhb kFVWeI"
               >
                 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut mi ligula. Phasellus tellus nulla,

--- a/src/components/RadioButton/__snapshots__/story.storyshot
+++ b/src/components/RadioButton/__snapshots__/story.storyshot
@@ -27,7 +27,7 @@ exports[`Storyshots RadioButton Default 1`] = `
     </div>
   </div>
   <p
-    className="sc-bxivhb jpexxn"
+    className="sc-bxivhb kFVWeI"
   >
     <span
       className="sc-htpNat ivSMHx"

--- a/src/components/RadioButtonGroup/__snapshots__/story.storyshot
+++ b/src/components/RadioButtonGroup/__snapshots__/story.storyshot
@@ -36,7 +36,7 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
           </div>
         </div>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb kFVWeI"
         >
           <span
             className="sc-htpNat ivSMHx"
@@ -79,7 +79,7 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
           </div>
         </div>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb kFVWeI"
         >
           <span
             className="sc-htpNat ivSMHx"
@@ -122,7 +122,7 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
           </div>
         </div>
         <p
-          className="sc-bxivhb jpexxn"
+          className="sc-bxivhb kFVWeI"
         >
           <span
             className="sc-htpNat ivSMHx"

--- a/src/components/ScrollBox/__snapshots__/story.storyshot
+++ b/src/components/ScrollBox/__snapshots__/story.storyshot
@@ -27,7 +27,7 @@ Array [
               They see me scrollin'
             </div>
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut mi ligula. Phasellus tellus nulla,
@@ -88,7 +88,7 @@ Array [
     </div>
   </div>,
   <p
-    className="sc-bxivhb jpexxn"
+    className="sc-bxivhb kFVWeI"
   >
     scrollTop: 
     0

--- a/src/components/Select/Option/__snapshots__/test.tsx.snap
+++ b/src/components/Select/Option/__snapshots__/test.tsx.snap
@@ -84,9 +84,6 @@ exports[`Option should render 1`] = `
   margin: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
 }
 
 .c6 {
@@ -98,9 +95,6 @@ exports[`Option should render 1`] = `
   margin: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
 }
 
 .c5 {

--- a/src/components/Select/__snapshots__/story.storyshot
+++ b/src/components/Select/__snapshots__/story.storyshot
@@ -23,7 +23,7 @@ exports[`Storyshots Select Custom rendering 1`] = `
           className="sc-bwzfXH fsbcIX"
         >
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             Make a selection
           </p>
@@ -93,12 +93,12 @@ exports[`Storyshots Select Custom rendering 1`] = `
                     className="sc-bwzfXH bQfpwP"
                   >
                     <p
-                      className="sc-bxivhb jpexxn"
+                      className="sc-bxivhb kFVWeI"
                     >
                       Bar A
                     </p>
                     <p
-                      className="sc-bxivhb fhIWly"
+                      className="sc-bxivhb kTaguW"
                     >
                       Lorem ipsum dolor sit amet.
                     </p>
@@ -128,12 +128,12 @@ exports[`Storyshots Select Custom rendering 1`] = `
                     className="sc-bwzfXH bQfpwP"
                   >
                     <p
-                      className="sc-bxivhb jpexxn"
+                      className="sc-bxivhb kFVWeI"
                     >
                       Foo B
                     </p>
                     <p
-                      className="sc-bxivhb fhIWly"
+                      className="sc-bxivhb kTaguW"
                     >
                       Lorem ipsum dolor sit amet.
                     </p>
@@ -163,12 +163,12 @@ exports[`Storyshots Select Custom rendering 1`] = `
                     className="sc-bwzfXH bQfpwP"
                   >
                     <p
-                      className="sc-bxivhb jpexxn"
+                      className="sc-bxivhb kFVWeI"
                     >
                       Bar C
                     </p>
                     <p
-                      className="sc-bxivhb fhIWly"
+                      className="sc-bxivhb kTaguW"
                     >
                       Lorem ipsum dolor sit amet.
                     </p>
@@ -198,12 +198,12 @@ exports[`Storyshots Select Custom rendering 1`] = `
                     className="sc-bwzfXH bQfpwP"
                   >
                     <p
-                      className="sc-bxivhb jpexxn"
+                      className="sc-bxivhb kFVWeI"
                     >
                       Foo D
                     </p>
                     <p
-                      className="sc-bxivhb fhIWly"
+                      className="sc-bxivhb kTaguW"
                     >
                       Lorem ipsum dolor sit amet.
                     </p>
@@ -233,12 +233,12 @@ exports[`Storyshots Select Custom rendering 1`] = `
                     className="sc-bwzfXH bQfpwP"
                   >
                     <p
-                      className="sc-bxivhb jpexxn"
+                      className="sc-bxivhb kFVWeI"
                     >
                       Bar E
                     </p>
                     <p
-                      className="sc-bxivhb fhIWly"
+                      className="sc-bxivhb kTaguW"
                     >
                       Lorem ipsum dolor sit amet.
                     </p>
@@ -268,12 +268,12 @@ exports[`Storyshots Select Custom rendering 1`] = `
                     className="sc-bwzfXH bQfpwP"
                   >
                     <p
-                      className="sc-bxivhb jpexxn"
+                      className="sc-bxivhb kFVWeI"
                     >
                       Bar F
                     </p>
                     <p
-                      className="sc-bxivhb fhIWly"
+                      className="sc-bxivhb kTaguW"
                     >
                       Lorem ipsum dolor sit amet.
                     </p>
@@ -309,7 +309,7 @@ exports[`Storyshots Select Default 1`] = `
         onClick={[Function]}
       >
         <p
-          className="sc-bxivhb fhIWly"
+          className="sc-bxivhb kTaguW"
         >
           <span
             className="sc-kgAjT WmYSY"
@@ -372,7 +372,7 @@ exports[`Storyshots Select Default 1`] = `
                   className="sc-htpNat kTMegb"
                 >
                   <span
-                    className="sc-ifAKCX kRfhnK"
+                    className="sc-ifAKCX cdTTkb"
                   >
                     Bar A
                   </span>
@@ -391,7 +391,7 @@ exports[`Storyshots Select Default 1`] = `
                   className="sc-htpNat kTMegb"
                 >
                   <span
-                    className="sc-ifAKCX kRfhnK"
+                    className="sc-ifAKCX cdTTkb"
                   >
                     Foo B
                   </span>
@@ -410,7 +410,7 @@ exports[`Storyshots Select Default 1`] = `
                   className="sc-htpNat kTMegb"
                 >
                   <span
-                    className="sc-ifAKCX kRfhnK"
+                    className="sc-ifAKCX cdTTkb"
                   >
                     Bar C
                   </span>
@@ -429,7 +429,7 @@ exports[`Storyshots Select Default 1`] = `
                   className="sc-htpNat kTMegb"
                 >
                   <span
-                    className="sc-ifAKCX kRfhnK"
+                    className="sc-ifAKCX cdTTkb"
                   >
                     Foo D
                   </span>
@@ -448,7 +448,7 @@ exports[`Storyshots Select Default 1`] = `
                   className="sc-htpNat kTMegb"
                 >
                   <span
-                    className="sc-ifAKCX kRfhnK"
+                    className="sc-ifAKCX cdTTkb"
                   >
                     Bar E
                   </span>
@@ -467,7 +467,7 @@ exports[`Storyshots Select Default 1`] = `
                   className="sc-htpNat kTMegb"
                 >
                   <span
-                    className="sc-ifAKCX kRfhnK"
+                    className="sc-ifAKCX cdTTkb"
                   >
                     Bar F
                   </span>

--- a/src/components/Spacer/__snapshots__/story.storyshot
+++ b/src/components/Spacer/__snapshots__/story.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots Spacer ⚠️  With margin 1`] = `
     className="sc-hEsumM kphJem"
   >
     <p
-      className="sc-bxivhb jpexxn"
+      className="sc-bxivhb kFVWeI"
     >
       This has a margin.
     </p>
@@ -24,7 +24,7 @@ exports[`Storyshots Spacer ⚠️  With padding 1`] = `
     className="sc-hqyNC cORRFV"
   >
     <p
-      className="sc-bxivhb jpexxn"
+      className="sc-bxivhb kFVWeI"
     >
       This has padding.
     </p>

--- a/src/components/Table/__snapshots__/story.storyshot
+++ b/src/components/Table/__snapshots__/story.storyshot
@@ -17,7 +17,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb gTyNSX"
+              className="sc-bxivhb ildJSL"
             >
               <span
                 aria-hidden={true}
@@ -40,7 +40,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb gTyNSX"
+              className="sc-bxivhb ildJSL"
             >
               Header B
             </p>
@@ -53,7 +53,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb gTyNSX"
+              className="sc-bxivhb ildJSL"
             >
               Header C
             </p>
@@ -66,7 +66,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH eFkGjS"
           >
             <p
-              className="sc-bxivhb gTyNSX"
+              className="sc-bxivhb ildJSL"
             >
               Actions
             </p>
@@ -86,7 +86,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             <span
               aria-hidden={true}
@@ -109,7 +109,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               A1
             </p>
@@ -124,7 +124,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               B1
             </p>
@@ -139,7 +139,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               C1
             </p>
@@ -209,7 +209,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             <span
               aria-hidden={true}
@@ -232,7 +232,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               A2
             </p>
@@ -247,7 +247,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               B2
             </p>
@@ -262,7 +262,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               C2
             </p>
@@ -332,7 +332,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             <span
               aria-hidden={true}
@@ -355,7 +355,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               A3
             </p>
@@ -370,7 +370,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               B3
             </p>
@@ -385,7 +385,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               C3
             </p>
@@ -455,7 +455,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             <span
               aria-hidden={true}
@@ -478,7 +478,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               A4
             </p>
@@ -493,7 +493,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               B4
             </p>
@@ -508,7 +508,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               C4
             </p>
@@ -578,7 +578,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             <span
               aria-hidden={true}
@@ -601,7 +601,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               A5
             </p>
@@ -616,7 +616,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               B5
             </p>
@@ -631,7 +631,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               C5
             </p>
@@ -701,7 +701,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             <span
               aria-hidden={true}
@@ -724,7 +724,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               A6
             </p>
@@ -739,7 +739,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               B6
             </p>
@@ -754,7 +754,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               C6
             </p>
@@ -824,7 +824,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             <span
               aria-hidden={true}
@@ -847,7 +847,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               A7
             </p>
@@ -862,7 +862,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               B7
             </p>
@@ -877,7 +877,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               C7
             </p>
@@ -947,7 +947,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             <span
               aria-hidden={true}
@@ -970,7 +970,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               A8
             </p>
@@ -985,7 +985,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               B8
             </p>
@@ -1000,7 +1000,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               C8
             </p>
@@ -1070,7 +1070,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             <span
               aria-hidden={true}
@@ -1093,7 +1093,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               A9
             </p>
@@ -1108,7 +1108,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               B9
             </p>
@@ -1123,7 +1123,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               C9
             </p>
@@ -1193,7 +1193,7 @@ exports[`Storyshots Table Default 1`] = `
           onFocus={[Function]}
         >
           <p
-            className="sc-bxivhb fhIWly"
+            className="sc-bxivhb kTaguW"
           >
             <span
               aria-hidden={true}
@@ -1216,7 +1216,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               A10
             </p>
@@ -1231,7 +1231,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH jXZncb"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               B10
             </p>
@@ -1246,7 +1246,7 @@ exports[`Storyshots Table Default 1`] = `
             className="sc-bwzfXH keAoja"
           >
             <p
-              className="sc-bxivhb jpexxn"
+              className="sc-bxivhb kFVWeI"
             >
               C10
             </p>

--- a/src/components/Text/__snapshots__/story.storyshot
+++ b/src/components/Text/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Text Default 1`] = `
 <p
-  className="sc-bxivhb gfECsG"
+  className="sc-bxivhb iLCmyv"
 >
   
     Now this is the story all about how

--- a/src/components/Text/__snapshots__/test.tsx.snap
+++ b/src/components/Text/__snapshots__/test.tsx.snap
@@ -10,9 +10,6 @@ exports[`Text should render text with default styling 1`] = `
   margin: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
 }
 
 <p

--- a/src/components/Text/style.tsx
+++ b/src/components/Text/style.tsx
@@ -66,9 +66,6 @@ const StyledParagraph = withProps<TextPropsType, HTMLParagraphElement>(styled.p)
     margin: 0;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-
-    // This makes sure text wraps in IE:
-    flex: 1;
     `;
 
 const StyledSpan = StyledParagraph.withComponent('span');

--- a/src/components/TextArea/__snapshots__/story.storyshot
+++ b/src/components/TextArea/__snapshots__/story.storyshot
@@ -37,7 +37,7 @@ Array [
     className="sc-bwzfXH gKGSfm"
   >
     <p
-      className="sc-bxivhb eEGBVx"
+      className="sc-bxivhb gWsGB"
     >
       <span
         className="sc-htpNat frObKr"

--- a/src/components/TextField/__snapshots__/story.storyshot
+++ b/src/components/TextField/__snapshots__/story.storyshot
@@ -77,7 +77,7 @@ Array [
     className="sc-bwzfXH gKGSfm"
   >
     <p
-      className="sc-bxivhb fhwEDr"
+      className="sc-bxivhb bfQmQc"
     >
       <span
         className="sc-htpNat frObKr"
@@ -152,7 +152,7 @@ Array [
     className="sc-bwzfXH gKGSfm"
   >
     <p
-      className="sc-bxivhb eEGBVx"
+      className="sc-bxivhb gWsGB"
     >
       <span
         className="sc-htpNat frObKr"

--- a/src/components/Toaster/__snapshots__/story.storyshot
+++ b/src/components/Toaster/__snapshots__/story.storyshot
@@ -24,7 +24,7 @@ exports[`Storyshots Toaster Default 1`] = `
             className="sc-bwzfXH jQmHZh"
           >
             <span
-              className="sc-ifAKCX kTqttQ"
+              className="sc-ifAKCX chsNTs"
             >
               <span
                 aria-hidden={true}
@@ -45,12 +45,12 @@ exports[`Storyshots Toaster Default 1`] = `
               className="sc-bwzfXH gaQYSB"
             >
               <p
-                className="sc-bxivhb gTyNSX"
+                className="sc-bxivhb ildJSL"
               >
                 Thought provoking we must stand.
               </p>
               <p
-                className="sc-bxivhb jpexxn"
+                className="sc-bxivhb kFVWeI"
               >
                 Game-changer problem-solvers; state of play invest, synergy uplift we must stand up ideate social intrapreneurship.
               </p>
@@ -112,7 +112,7 @@ exports[`Storyshots Toaster With action button 1`] = `
             className="sc-bwzfXH jQmHZh"
           >
             <span
-              className="sc-ifAKCX icOBot"
+              className="sc-ifAKCX hURNXo"
             >
               <span
                 aria-hidden={true}
@@ -133,12 +133,12 @@ exports[`Storyshots Toaster With action button 1`] = `
               className="sc-bwzfXH gaQYSB"
             >
               <p
-                className="sc-bxivhb gTyNSX"
+                className="sc-bxivhb ildJSL"
               >
                 Overcome injustice.
               </p>
               <p
-                className="sc-bxivhb jpexxn"
+                className="sc-bxivhb kFVWeI"
               >
                 Global low-hanging fruit, collaborative consumption segmentation mobilize support. Problem-solvers cultivate, best practices, shared unit of.
               </p>

--- a/src/components/Toggle/__snapshots__/story.storyshot
+++ b/src/components/Toggle/__snapshots__/story.storyshot
@@ -34,7 +34,7 @@ exports[`Storyshots Toggle Default 1`] = `
       className="sc-bwzfXH fmiztD"
     >
       <p
-        className="sc-bxivhb jpexxn"
+        className="sc-bxivhb kFVWeI"
       >
          
         Turn me on!


### PR DESCRIPTION
### This PR:

It turned out that using `flex: 1` in the styling of `Text` to make text wrap in IE in the specific context of the `FormRow` story was causing problems in other applications without fixing any issues outside of the formrow story. Therefore `flex: 1` was removed and the stories were adjusted to render properly.

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)
- [x] Appropriate tests have been added for my functionality (check if not applicable)
- [x] A designer has seen and approved my changes (check if not applicable)


**Changes** 🌀
- `FormRow` story to remove unnecessary Box components and render properly in IE.

**Removes** 👋
- Problematic `flex: 1` in `Text` `style.tsx`.

**Breaking changes** 🔥
- Feature `foo` no longer supports `foo` and needs to be converted to `foop`
