### PR TITLE
removed onFocus- onBlurCapture from wrapper to prevent double focus

### DIFF
--- a/src/components/FormRow/__snapshots__/story.storyshot
+++ b/src/components/FormRow/__snapshots__/story.storyshot
@@ -36,13 +36,11 @@ exports[`Storyshots FormRow Default 1`] = `
             <div
               className="sc-hMqMXs lcVHiK"
               disabled={undefined}
-              onBlurCapture={[Function]}
-              onClick={[Function]}
-              onFocusCapture={[Function]}
             >
               <div
                 className="sc-jKJlTe kuDUsE"
                 disabled={undefined}
+                onClick={[Function]}
               >
                 <span
                   className="sc-eNQAEJ hiLfdP"
@@ -76,13 +74,11 @@ exports[`Storyshots FormRow Default 1`] = `
             <div
               className="sc-hMqMXs lcVHiK"
               disabled={undefined}
-              onBlurCapture={[Function]}
-              onClick={[Function]}
-              onFocusCapture={[Function]}
             >
               <div
                 className="sc-jKJlTe kuDUsE"
                 disabled={undefined}
+                onClick={[Function]}
               >
                 <span
                   className="sc-eNQAEJ hiLfdP"
@@ -117,13 +113,11 @@ exports[`Storyshots FormRow Default 1`] = `
           <div
             className="sc-hMqMXs lcVHiK"
             disabled={undefined}
-            onBlurCapture={[Function]}
-            onClick={[Function]}
-            onFocusCapture={[Function]}
           >
             <div
               className="sc-jKJlTe kuDUsE"
               disabled={undefined}
+              onClick={[Function]}
             >
               <span
                 className="sc-eNQAEJ hiLfdP"
@@ -185,13 +179,11 @@ exports[`Storyshots FormRow Default 1`] = `
           <div
             className="sc-hMqMXs lcVHiK"
             disabled={undefined}
-            onBlurCapture={[Function]}
-            onClick={[Function]}
-            onFocusCapture={[Function]}
           >
             <div
               className="sc-jKJlTe kuDUsE"
               disabled={undefined}
+              onClick={[Function]}
             >
               <span
                 className="sc-eNQAEJ hiLfdP"
@@ -225,13 +217,11 @@ exports[`Storyshots FormRow Default 1`] = `
           <div
             className="sc-hMqMXs lcVHiK"
             disabled={undefined}
-            onBlurCapture={[Function]}
-            onClick={[Function]}
-            onFocusCapture={[Function]}
           >
             <div
               className="sc-jKJlTe kuDUsE"
               disabled={undefined}
+              onClick={[Function]}
             >
               <span
                 className="sc-eNQAEJ hiLfdP"
@@ -450,13 +440,11 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           <div
             className="sc-hMqMXs lcVHiK"
             disabled={undefined}
-            onBlurCapture={[Function]}
-            onClick={[Function]}
-            onFocusCapture={[Function]}
           >
             <div
               className="sc-jKJlTe kuDUsE"
               disabled={undefined}
+              onClick={[Function]}
             >
               <span
                 className="sc-eNQAEJ hiLfdP"
@@ -513,13 +501,11 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           <div
             className="sc-hMqMXs lcVHiK"
             disabled={undefined}
-            onBlurCapture={[Function]}
-            onClick={[Function]}
-            onFocusCapture={[Function]}
           >
             <div
               className="sc-jKJlTe kuDUsE"
               disabled={undefined}
+              onClick={[Function]}
             >
               <span
                 className="sc-eNQAEJ hiLfdP"

--- a/src/components/Range/__snapshots__/story.storyshot
+++ b/src/components/Range/__snapshots__/story.storyshot
@@ -16,9 +16,6 @@ exports[`Storyshots Range Default 1`] = `
         <div
           className="sc-hMqMXs lcVHiK"
           disabled={false}
-          onBlurCapture={[Function]}
-          onClick={[Function]}
-          onFocusCapture={[Function]}
         >
           <div
             className="sc-bwzfXH grkVqn"
@@ -41,6 +38,7 @@ exports[`Storyshots Range Default 1`] = `
           <div
             className="sc-jKJlTe kuDUsE"
             disabled={false}
+            onClick={[Function]}
           >
             <span
               className="sc-eNQAEJ hiLfdP"
@@ -56,9 +54,6 @@ exports[`Storyshots Range Default 1`] = `
         <div
           className="sc-hMqMXs lcVHiK"
           disabled={false}
-          onBlurCapture={[Function]}
-          onClick={[Function]}
-          onFocusCapture={[Function]}
         >
           <div
             className="sc-bwzfXH grkVqn"
@@ -81,6 +76,7 @@ exports[`Storyshots Range Default 1`] = `
           <div
             className="sc-jKJlTe kuDUsE"
             disabled={false}
+            onClick={[Function]}
           >
             <span
               className="sc-eNQAEJ hiLfdP"

--- a/src/components/TextField/__snapshots__/story.storyshot
+++ b/src/components/TextField/__snapshots__/story.storyshot
@@ -4,13 +4,11 @@ exports[`Storyshots TextField Default 1`] = `
 <div
   className="sc-hMqMXs lcVHiK"
   disabled={false}
-  onBlurCapture={[Function]}
-  onClick={[Function]}
-  onFocusCapture={[Function]}
 >
   <div
     className="sc-jKJlTe kuDUsE"
     disabled={false}
+    onClick={[Function]}
   >
     <span
       className="sc-eNQAEJ hiLfdP"
@@ -39,6 +37,7 @@ exports[`Storyshots TextField Default 1`] = `
   <div
     className="sc-jKJlTe kuDUsE"
     disabled={false}
+    onClick={[Function]}
   >
     <span
       className="sc-eNQAEJ hiLfdP"
@@ -54,13 +53,11 @@ Array [
   <div
     className="sc-hMqMXs lcVHiK"
     disabled={false}
-    onBlurCapture={[Function]}
-    onClick={[Function]}
-    onFocusCapture={[Function]}
   >
     <div
       className="sc-jKJlTe kuDUsE"
       disabled={false}
+      onClick={[Function]}
     >
       <span
         className="sc-eNQAEJ hiLfdP"
@@ -126,13 +123,11 @@ Array [
   <div
     className="sc-hMqMXs lcVHiK"
     disabled={false}
-    onBlurCapture={[Function]}
-    onClick={[Function]}
-    onFocusCapture={[Function]}
   >
     <div
       className="sc-jKJlTe kuDUsE"
       disabled={false}
+      onClick={[Function]}
     >
       <span
         className="sc-eNQAEJ hiLfdP"
@@ -161,6 +156,7 @@ Array [
     <div
       className="sc-jKJlTe kuDUsE"
       disabled={false}
+      onClick={[Function]}
     >
       <span
         className="sc-eNQAEJ hiLfdP"
@@ -207,9 +203,6 @@ exports[`Storyshots TextField With Number formatting 1`] = `
 <div
   className="sc-hMqMXs lcVHiK"
   disabled={false}
-  onBlurCapture={[Function]}
-  onClick={[Function]}
-  onFocusCapture={[Function]}
 >
   <div
     className="sc-bwzfXH grkVqn"

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -7,7 +7,6 @@ import { StyledInput, StyledWrapper, StyledAffix, StyledAffixWrapper } from './s
 import withCurrencyFormatting, { WithCurrencyFormattingType } from './formatters/withCurrencyFormatting';
 import withNumberFormatting, { WithNumberFormattingType } from './formatters/withNumberFormatting';
 import Icon from '../Icon';
-import BreakpointProvider from '../BreakpointProvider';
 
 type PropsType = {
     value: string;
@@ -64,12 +63,9 @@ class TextField extends Component<PropsType, StateType> {
                     focus={this.state.focus}
                     disabled={this.props.disabled}
                     severity={this.props.feedback ? this.props.feedback.severity : 'success'}
-                    onFocusCapture={this.handleFocus}
-                    onBlurCapture={this.handleBlur}
-                    onClick={this.handleFocus}
                 >
                     {this.props.prefix && (
-                        <StyledAffixWrapper disabled={this.props.disabled}>
+                        <StyledAffixWrapper onClick={this.handleFocus} disabled={this.props.disabled}>
                             <StyledAffix>{this.props.prefix}</StyledAffix>
                         </StyledAffixWrapper>
                     )}
@@ -93,7 +89,7 @@ class TextField extends Component<PropsType, StateType> {
                         </Box>
                     </Box>
                     {this.props.suffix && (
-                        <StyledAffixWrapper disabled={this.props.disabled}>
+                        <StyledAffixWrapper onClick={this.handleFocus} disabled={this.props.disabled}>
                             <StyledAffix>{this.props.suffix}</StyledAffix>
                         </StyledAffixWrapper>
                     )}

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -26,9 +26,7 @@ type PropsType = {
     onFocus?(): void;
 };
 
-type StateType = {
-    focus: boolean;
-};
+type StateType = { focus: boolean };
 
 class TextField extends Component<PropsType, StateType> {
     public static Currency: WithCurrencyFormattingType = withCurrencyFormatting(TextField);
@@ -42,9 +40,7 @@ class TextField extends Component<PropsType, StateType> {
         this.state = { focus: false };
     }
 
-    public forceFocus = (): void => {
-        this.setState({ focus: true }, () => this.inputRef.focus());
-    };
+    public forceFocus = (): void => this.setState({ focus: true }, () => this.inputRef.focus());
 
     public handleFocus = (): void => {
         this.setState({ focus: true }, () => this.inputRef.focus());
@@ -93,7 +89,7 @@ class TextField extends Component<PropsType, StateType> {
                         </Box>
                     </Box>
                     {this.props.suffix && (
-                        <StyledAffixWrapper onClick={this.handleFocus} disabled={this.props.disabled}>
+                        <StyledAffixWrapper onClick={this.forceFocus} disabled={this.props.disabled}>
                             <StyledAffix>{this.props.suffix}</StyledAffix>
                         </StyledAffixWrapper>
                     )}

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -42,6 +42,10 @@ class TextField extends Component<PropsType, StateType> {
         this.state = { focus: false };
     }
 
+    public forceFocus = (): void => {
+        this.setState({ focus: true }, () => this.inputRef.focus());
+    };
+
     public handleFocus = (): void => {
         this.setState({ focus: true }, () => this.inputRef.focus());
         if (this.props.onFocus !== undefined) this.props.onFocus();
@@ -65,7 +69,7 @@ class TextField extends Component<PropsType, StateType> {
                     severity={this.props.feedback ? this.props.feedback.severity : 'success'}
                 >
                     {this.props.prefix && (
-                        <StyledAffixWrapper onClick={this.handleFocus} disabled={this.props.disabled}>
+                        <StyledAffixWrapper onClick={this.forceFocus} disabled={this.props.disabled}>
                             <StyledAffix>{this.props.prefix}</StyledAffix>
                         </StyledAffixWrapper>
                     )}

--- a/src/components/TextField/test.tsx
+++ b/src/components/TextField/test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TextField from '.';
 import { mountWithTheme } from '../../utility/styled/testing';
-import { StyledInput, StyledWrapper } from './style';
+import { StyledInput, StyledWrapper, StyledAffixWrapper } from './style';
 
 describe('TextField', () => {
     it('should not change value when disabled', () => {
@@ -32,6 +32,14 @@ describe('TextField', () => {
         const component = mountWithTheme(<TextField value="" name="firstName" onChange={jest.fn()} />);
 
         component.find(StyledInput).simulate('focus');
+
+        expect(component.find(StyledWrapper).prop('focus')).toBe(true);
+    });
+
+    it('should render an active state when focussed by clicking an affix', () => {
+        const component = mountWithTheme(<TextField value="" suffix="hi" name="firstName" onChange={jest.fn()} />);
+
+        component.find(StyledAffixWrapper).simulate('click');
 
         expect(component.find(StyledWrapper).prop('focus')).toBe(true);
     });

--- a/src/components/TextField/test.tsx
+++ b/src/components/TextField/test.tsx
@@ -36,7 +36,7 @@ describe('TextField', () => {
         expect(component.find(StyledWrapper).prop('focus')).toBe(true);
     });
 
-    it('should render an active state when focussed by clicking an affix', () => {
+    it('should render a focus state after clicking an affix', () => {
         const component = mountWithTheme(<TextField value="" suffix="hi" name="firstName" onChange={jest.fn()} />);
 
         component.find(StyledAffixWrapper).simulate('click');


### PR DESCRIPTION
### This PR:

removed onFocus- onBlurCapture from wrapper to prevent double focus.
resolves #256  

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)
- [x] Appropriate tests have been added for my functionality (check if not applicable)
- [x] A designer has seen and approved my changes (check if not applicable)
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers)


**Changes** 🌀
- removed onFocus- onBlurCapture from wrapper to prevent double focus