### PR TITLE
Removed default offset from checkbox

### DIFF
--- a/src/components/Checkbox/__snapshots__/story.storyshot
+++ b/src/components/Checkbox/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Checkbox Default 1`] = `
 <div
-  className="sc-jTzLTM dxYrGK"
+  className="checkbox sc-jTzLTM dTwpfN"
   disabled={false}
   onClick={[Function]}
 >

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -41,6 +41,7 @@ class Checkbox extends Component<PropsType, StateType> {
 
         return (
             <StyledCheckboxSkin
+                className="checkbox"
                 checkedState={this.props.checked}
                 onClick={(event): void => this.changeHandler(event)}
                 elementFocus={this.state.focus}

--- a/src/components/Checkbox/style.tsx
+++ b/src/components/Checkbox/style.tsx
@@ -43,7 +43,6 @@ const StyledCheckbox = withProps<{}, HTMLInputElement>(styled.input)`
 const StyledCheckboxSkin = withProps<StyledCheckboxSkinType, HTMLDivElement>(styled.div)`
     width: 16px;
     height: 16px;
-    margin-top: 12px;
     border-radius: ${({ theme }): string => theme.Checkbox.idle.borderRadius};
     position: relative;
     outline: none;

--- a/src/components/FormRow/__snapshots__/story.storyshot
+++ b/src/components/FormRow/__snapshots__/story.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots FormRow Default 1`] = `
 <form>
   <div
-    className="sc-bwzfXH fdTlHl"
+    className="sc-kgoBCf kcavcy"
   >
     <div
       className="sc-bwzfXH lkpHKK"
@@ -34,18 +34,18 @@ exports[`Storyshots FormRow Default 1`] = `
             className="sc-bwzfXH kxsXCq"
           >
             <div
-              className="sc-eNQAEJ hdXQwO"
+              className="sc-hMqMXs lcVHiK"
               disabled={undefined}
               onBlurCapture={[Function]}
               onClick={[Function]}
               onFocusCapture={[Function]}
             >
               <div
-                className="sc-ckVGcZ bUDAVg"
+                className="sc-jKJlTe kuDUsE"
                 disabled={undefined}
               >
                 <span
-                  className="sc-jKJlTe eFYypy"
+                  className="sc-eNQAEJ hiLfdP"
                 >
                   Initials
                 </span>
@@ -54,7 +54,7 @@ exports[`Storyshots FormRow Default 1`] = `
                 className="sc-bwzfXH grkVqn"
               >
                 <input
-                  className="sc-dxgOiQ dxkTXN"
+                  className="sc-ckVGcZ gBhdDx"
                   disabled={undefined}
                   id={undefined}
                   name="Initials"
@@ -74,18 +74,18 @@ exports[`Storyshots FormRow Default 1`] = `
             className="sc-bwzfXH fkLxMw"
           >
             <div
-              className="sc-eNQAEJ hdXQwO"
+              className="sc-hMqMXs lcVHiK"
               disabled={undefined}
               onBlurCapture={[Function]}
               onClick={[Function]}
               onFocusCapture={[Function]}
             >
               <div
-                className="sc-ckVGcZ bUDAVg"
+                className="sc-jKJlTe kuDUsE"
                 disabled={undefined}
               >
                 <span
-                  className="sc-jKJlTe eFYypy"
+                  className="sc-eNQAEJ hiLfdP"
                 >
                   First name
                 </span>
@@ -94,7 +94,7 @@ exports[`Storyshots FormRow Default 1`] = `
                 className="sc-bwzfXH grkVqn"
               >
                 <input
-                  className="sc-dxgOiQ dxkTXN"
+                  className="sc-ckVGcZ gBhdDx"
                   disabled={undefined}
                   id={undefined}
                   name="First name"
@@ -115,18 +115,18 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ hdXQwO"
+            className="sc-hMqMXs lcVHiK"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
             onFocusCapture={[Function]}
           >
             <div
-              className="sc-ckVGcZ bUDAVg"
+              className="sc-jKJlTe kuDUsE"
               disabled={undefined}
             >
               <span
-                className="sc-jKJlTe eFYypy"
+                className="sc-eNQAEJ hiLfdP"
               >
                 Surname
               </span>
@@ -135,7 +135,7 @@ exports[`Storyshots FormRow Default 1`] = `
               className="sc-bwzfXH grkVqn"
             >
               <input
-                className="sc-dxgOiQ dxkTXN"
+                className="sc-ckVGcZ gBhdDx"
                 disabled={undefined}
                 id={undefined}
                 name="Surname"
@@ -155,7 +155,7 @@ exports[`Storyshots FormRow Default 1`] = `
     </div>
   </div>
   <div
-    className="sc-bwzfXH fdTlHl"
+    className="sc-kgoBCf kcavcy"
   >
     <div
       className="sc-bwzfXH lkpHKK"
@@ -183,18 +183,18 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ hdXQwO"
+            className="sc-hMqMXs lcVHiK"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
             onFocusCapture={[Function]}
           >
             <div
-              className="sc-ckVGcZ bUDAVg"
+              className="sc-jKJlTe kuDUsE"
               disabled={undefined}
             >
               <span
-                className="sc-jKJlTe eFYypy"
+                className="sc-eNQAEJ hiLfdP"
               >
                 Country
               </span>
@@ -203,7 +203,7 @@ exports[`Storyshots FormRow Default 1`] = `
               className="sc-bwzfXH grkVqn"
             >
               <input
-                className="sc-dxgOiQ dxkTXN"
+                className="sc-ckVGcZ gBhdDx"
                 disabled={undefined}
                 id={undefined}
                 name="Country"
@@ -223,18 +223,18 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hoLhPq"
         >
           <div
-            className="sc-eNQAEJ hdXQwO"
+            className="sc-hMqMXs lcVHiK"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
             onFocusCapture={[Function]}
           >
             <div
-              className="sc-ckVGcZ bUDAVg"
+              className="sc-jKJlTe kuDUsE"
               disabled={undefined}
             >
               <span
-                className="sc-jKJlTe eFYypy"
+                className="sc-eNQAEJ hiLfdP"
               >
                 City
               </span>
@@ -243,7 +243,7 @@ exports[`Storyshots FormRow Default 1`] = `
               className="sc-bwzfXH grkVqn"
             >
               <input
-                className="sc-dxgOiQ dxkTXN"
+                className="sc-ckVGcZ gBhdDx"
                 disabled={undefined}
                 id={undefined}
                 name="City"
@@ -263,7 +263,7 @@ exports[`Storyshots FormRow Default 1`] = `
     </div>
   </div>
   <div
-    className="sc-bwzfXH fdTlHl"
+    className="sc-kgoBCf kcavcy"
   >
     <div
       className="sc-bwzfXH lkpHKK"
@@ -291,7 +291,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH hurwPi"
         >
           <div
-            className="sc-kgoBCf BEYlJ"
+            className="sc-kGXeez iBFgVY"
             onClick={[Function]}
           >
             <div
@@ -299,12 +299,12 @@ exports[`Storyshots FormRow Default 1`] = `
             >
               <div
                 checked={true}
-                className="sc-kpOJdX kyHwpB"
+                className="sc-dxgOiQ cmdPra"
                 disabled={undefined}
               >
                 <input
                   checked={true}
-                  className="sc-kGXeez sKBUe"
+                  className="sc-kpOJdX hZrIxJ"
                   id={undefined}
                   name="bool"
                   onBlur={[Function]}
@@ -334,7 +334,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH jQPdWH"
         >
           <div
-            className="sc-kgoBCf BEYlJ"
+            className="sc-kGXeez iBFgVY"
             onClick={[Function]}
           >
             <div
@@ -342,12 +342,12 @@ exports[`Storyshots FormRow Default 1`] = `
             >
               <div
                 checked={false}
-                className="sc-kpOJdX iNOmBO"
+                className="sc-dxgOiQ cZHqqG"
                 disabled={undefined}
               >
                 <input
                   checked={false}
-                  className="sc-kGXeez sKBUe"
+                  className="sc-kpOJdX hZrIxJ"
                   id={undefined}
                   name="bool"
                   onBlur={[Function]}
@@ -377,7 +377,7 @@ exports[`Storyshots FormRow Default 1`] = `
           className="sc-bwzfXH jQPdWH"
         >
           <div
-            className="sc-kgoBCf BEYlJ"
+            className="sc-kGXeez iBFgVY"
             onClick={[Function]}
           >
             <div
@@ -385,12 +385,12 @@ exports[`Storyshots FormRow Default 1`] = `
             >
               <div
                 checked={false}
-                className="sc-kpOJdX iNOmBO"
+                className="sc-dxgOiQ cZHqqG"
                 disabled={undefined}
               >
                 <input
                   checked={false}
-                  className="sc-kGXeez sKBUe"
+                  className="sc-kpOJdX hZrIxJ"
                   id={undefined}
                   name="bool"
                   onBlur={[Function]}
@@ -425,7 +425,7 @@ exports[`Storyshots FormRow Default 1`] = `
 exports[`Storyshots FormRow No Descriptions 1`] = `
 <form>
   <div
-    className="sc-bwzfXH fdTlHl"
+    className="sc-kgoBCf kcavcy"
   >
     <div
       className="sc-bwzfXH lkpHKK"
@@ -448,18 +448,18 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           className="sc-bwzfXH iFjvZT"
         >
           <div
-            className="sc-eNQAEJ hdXQwO"
+            className="sc-hMqMXs lcVHiK"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
             onFocusCapture={[Function]}
           >
             <div
-              className="sc-ckVGcZ bUDAVg"
+              className="sc-jKJlTe kuDUsE"
               disabled={undefined}
             >
               <span
-                className="sc-jKJlTe eFYypy"
+                className="sc-eNQAEJ hiLfdP"
               >
                 Name
               </span>
@@ -468,7 +468,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
               className="sc-bwzfXH grkVqn"
             >
               <input
-                className="sc-dxgOiQ dxkTXN"
+                className="sc-ckVGcZ gBhdDx"
                 disabled={undefined}
                 id={undefined}
                 name="Name"
@@ -488,7 +488,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     </div>
   </div>
   <div
-    className="sc-bwzfXH fdTlHl"
+    className="sc-kgoBCf kcavcy"
   >
     <div
       className="sc-bwzfXH lkpHKK"
@@ -511,18 +511,18 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           className="sc-bwzfXH iFjvZT"
         >
           <div
-            className="sc-eNQAEJ hdXQwO"
+            className="sc-hMqMXs lcVHiK"
             disabled={undefined}
             onBlurCapture={[Function]}
             onClick={[Function]}
             onFocusCapture={[Function]}
           >
             <div
-              className="sc-ckVGcZ bUDAVg"
+              className="sc-jKJlTe kuDUsE"
               disabled={undefined}
             >
               <span
-                className="sc-jKJlTe eFYypy"
+                className="sc-eNQAEJ hiLfdP"
               >
                 Country
               </span>
@@ -531,7 +531,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
               className="sc-bwzfXH grkVqn"
             >
               <input
-                className="sc-dxgOiQ dxkTXN"
+                className="sc-ckVGcZ gBhdDx"
                 disabled={undefined}
                 id={undefined}
                 name="Country"
@@ -551,7 +551,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     </div>
   </div>
   <div
-    className="sc-bwzfXH fdTlHl"
+    className="sc-kgoBCf kcavcy"
   >
     <div
       className="sc-bwzfXH lkpHKK"
@@ -574,7 +574,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           className="sc-bwzfXH hurwPi"
         >
           <div
-            className="sc-kgoBCf BEYlJ"
+            className="sc-kGXeez iBFgVY"
             onClick={[Function]}
           >
             <div
@@ -582,12 +582,12 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
             >
               <div
                 checked={true}
-                className="sc-kpOJdX kyHwpB"
+                className="sc-dxgOiQ cmdPra"
                 disabled={undefined}
               >
                 <input
                   checked={true}
-                  className="sc-kGXeez sKBUe"
+                  className="sc-kpOJdX hZrIxJ"
                   id={undefined}
                   name="bool"
                   onBlur={[Function]}
@@ -617,7 +617,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           className="sc-bwzfXH jQPdWH"
         >
           <div
-            className="sc-kgoBCf BEYlJ"
+            className="sc-kGXeez iBFgVY"
             onClick={[Function]}
           >
             <div
@@ -625,12 +625,12 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
             >
               <div
                 checked={false}
-                className="sc-kpOJdX iNOmBO"
+                className="sc-dxgOiQ cZHqqG"
                 disabled={undefined}
               >
                 <input
                   checked={false}
-                  className="sc-kGXeez sKBUe"
+                  className="sc-kpOJdX hZrIxJ"
                   id={undefined}
                   name="bool"
                   onBlur={[Function]}
@@ -660,7 +660,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           className="sc-bwzfXH jQPdWH"
         >
           <div
-            className="sc-kgoBCf BEYlJ"
+            className="sc-kGXeez iBFgVY"
             onClick={[Function]}
           >
             <div
@@ -668,12 +668,12 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
             >
               <div
                 checked={false}
-                className="sc-kpOJdX iNOmBO"
+                className="sc-dxgOiQ cZHqqG"
                 disabled={undefined}
               >
                 <input
                   checked={false}
-                  className="sc-kGXeez sKBUe"
+                  className="sc-kpOJdX hZrIxJ"
                   id={undefined}
                   name="bool"
                   onBlur={[Function]}
@@ -703,7 +703,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     </div>
   </div>
   <div
-    className="sc-bwzfXH fdTlHl"
+    className="sc-kgoBCf kcavcy"
   >
     <div
       className="sc-bwzfXH lkpHKK"
@@ -720,7 +720,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
       className="sc-bwzfXH fQHYuO"
     >
       <div
-        className="sc-kkGfuU jvfvYf"
+        className="sc-iAyFgw DLXvm"
         onClick={[Function]}
       >
         <div
@@ -731,12 +731,12 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
           >
             <div
               checked={false}
-              className="sc-kEYyzF brBMbf"
+              className="sc-kkGfuU kGlPwr"
               disabled={undefined}
             >
               <input
                 checked={false}
-                className="sc-hMqMXs iiejKk"
+                className="sc-kEYyzF dpVfOt"
                 disabled={false}
                 id="toggle"
                 name="toggle"
@@ -763,7 +763,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
     </div>
   </div>
   <div
-    className="sc-bwzfXH fdTlHl"
+    className="sc-kgoBCf kcavcy"
   >
     <div
       className="sc-bwzfXH lkpHKK"
@@ -780,7 +780,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
       className="sc-bwzfXH fQHYuO"
     >
       <div
-        className="sc-jTzLTM buZGri"
+        className="checkbox sc-jTzLTM jQiTLj"
         disabled={undefined}
         onClick={[Function]}
       >

--- a/src/components/FormRow/index.tsx
+++ b/src/components/FormRow/index.tsx
@@ -1,6 +1,7 @@
 import React, { SFC } from 'react';
 import Box from '../Box';
 import trbl from '../../utility/trbl';
+import { StyledFormRow } from './style';
 
 type PropsType = {
     label: JSX.Element;
@@ -9,14 +10,14 @@ type PropsType = {
 
 const FormRow: SFC<PropsType> = (props): JSX.Element => {
     return (
-        <Box wrap grow={1}>
+        <StyledFormRow>
             <Box basis={'180px'} grow={1} maxWidth={'241px'} margin={trbl(18, 9, 0, 0)} justifyContent="stretch" wrap>
                 {props.label}
             </Box>
             <Box basis={'180px'} grow={1} maxWidth="470px" margin={trbl(9, 0)} alignItems="flex-start" wrap>
                 {props.field}
             </Box>
-        </Box>
+        </StyledFormRow>
     );
 };
 

--- a/src/components/FormRow/style.tsx
+++ b/src/components/FormRow/style.tsx
@@ -1,0 +1,16 @@
+import _R from 'react';
+import { StyledComponentClass as _S } from 'styled-components';
+import _T from '../../types/ThemeType';
+import styled from '../../utility/styled';
+
+const StyledFormRow = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    flex-grow: 1;
+
+    & .checkbox {
+        margin-top: 12px;
+    }
+`;
+
+export { StyledFormRow };

--- a/src/components/InlineNotification/__snapshots__/story.storyshot
+++ b/src/components/InlineNotification/__snapshots__/story.storyshot
@@ -56,7 +56,7 @@ exports[`Storyshots InlineNotification With children 1`] = `
     >
       Are you having trouble? Check out 
       <a
-        className="sc-iAyFgw gqgAvO"
+        className="sc-hSdWYo MukmX"
         href="http://google.com"
         target={undefined}
         title="some resource"

--- a/src/components/Link/__snapshots__/story.storyshot
+++ b/src/components/Link/__snapshots__/story.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots Link Action with child element 1`] = `
   className="sc-bxivhb kFVWeI"
 >
   <button
-    className="sc-hSdWYo XiZO"
+    className="sc-eHgmQL iyuPGH"
     onClick={[Function]}
     title="Google search"
     type="button"
@@ -22,7 +22,7 @@ exports[`Storyshots Link Default 1`] = `
   className="sc-bxivhb kFVWeI"
 >
   <a
-    className="sc-iAyFgw gqgAvO"
+    className="sc-hSdWYo MukmX"
     href="http://www.google.com"
     target="_self"
     title="Google search"

--- a/src/components/MessageStream/__snapshots__/story.storyshot
+++ b/src/components/MessageStream/__snapshots__/story.storyshot
@@ -2,10 +2,10 @@
 
 exports[`Storyshots MessageStream Default 1`] = `
 <div
-  className="sc-eHgmQL kzSkRt"
+  className="sc-cvbbAY gRnXOq"
 >
   <div
-    className="sc-jWBwVP clbKoT"
+    className="sc-brqgnP bChKpe"
     title="Sit Inceptos Magna"
   >
     <div
@@ -43,10 +43,10 @@ exports[`Storyshots MessageStream Default 1`] = `
     </div>
   </div>
   <div
-    className="sc-cvbbAY gFhhfi"
+    className="sc-jWBwVP citdJs"
   />
   <div
-    className="sc-jWBwVP gnUmav"
+    className="sc-brqgnP jgbAyr"
     title="Aenean Dapibus Vulputate Tortor Magna"
   >
     <div
@@ -85,10 +85,10 @@ exports[`Storyshots MessageStream Default 1`] = `
     </div>
   </div>
   <div
-    className="sc-cvbbAY gFhhfi"
+    className="sc-jWBwVP citdJs"
   />
   <div
-    className="sc-jWBwVP clbKoT"
+    className="sc-brqgnP bChKpe"
     title="Vestibulum Dapibus"
   >
     <div
@@ -142,10 +142,10 @@ exports[`Storyshots MessageStream Default 1`] = `
     </div>
   </div>
   <div
-    className="sc-cvbbAY gFhhfi"
+    className="sc-jWBwVP citdJs"
   />
   <div
-    className="sc-jWBwVP YbiWn"
+    className="sc-brqgnP eidfQB"
     title="Parturient Euismod Mollis Fringilla"
   >
     <div
@@ -200,10 +200,10 @@ exports[`Storyshots MessageStream Default 1`] = `
     </div>
   </div>
   <div
-    className="sc-cvbbAY gFhhfi"
+    className="sc-jWBwVP citdJs"
   />
   <div
-    className="sc-jWBwVP dtfdFl"
+    className="sc-brqgnP hCjuov"
     title="Tortor Cursus"
   >
     <div
@@ -257,10 +257,10 @@ exports[`Storyshots MessageStream Default 1`] = `
     </div>
   </div>
   <div
-    className="sc-cvbbAY gFhhfi"
+    className="sc-jWBwVP citdJs"
   />
   <div
-    className="sc-jWBwVP gnUmav"
+    className="sc-brqgnP jgbAyr"
     title="Euismod Dolor Consectetur"
   >
     <div

--- a/src/components/Modal/__snapshots__/story.storyshot
+++ b/src/components/Modal/__snapshots__/story.storyshot
@@ -2,10 +2,10 @@
 
 exports[`Storyshots Modal Default 1`] = `
 <div
-  className="sc-iRbamj kHmIFW"
+  className="sc-jlyJG gBxUkk"
 >
   <div
-    className="sc-gPEVay iwzqGY"
+    className="sc-iRbamj csmlRs"
   >
     <div
       style={
@@ -15,7 +15,7 @@ exports[`Storyshots Modal Default 1`] = `
       }
     >
       <div
-        className="sc-jlyJG fPCoSz"
+        className="sc-gipzik kNtMSr"
       >
         <div
           className="sc-bwzfXH jTCciZ"
@@ -53,13 +53,13 @@ exports[`Storyshots Modal Default 1`] = `
           </div>
         </div>
         <div
-          className="sc-brqgnP jwrNlU"
+          className="sc-cMljjf dUfgXO"
         >
           <div
-            className="sc-cMljjf krgCXT"
+            className="sc-jAaTju iVnhyn"
           >
             <div
-              className="sc-jAaTju fzRTCD"
+              className="sc-jDwBTQ bqIkRG"
             />
             <div
               className="sc-bwzfXH fiOUi"
@@ -90,7 +90,7 @@ pharetra. Duis sed magna vel odio ullamcorper gravida eu et nibh.
               </p>
             </div>
             <div
-              className="sc-jDwBTQ cXRqdb"
+              className="sc-gPEVay gkJgPo"
             />
           </div>
         </div>
@@ -154,10 +154,10 @@ pharetra. Duis sed magna vel odio ullamcorper gravida eu et nibh.
 
 exports[`Storyshots Modal Without closeAction 1`] = `
 <div
-  className="sc-iRbamj kHmIFW"
+  className="sc-jlyJG gBxUkk"
 >
   <div
-    className="sc-gPEVay iwzqGY"
+    className="sc-iRbamj csmlRs"
   >
     <div
       style={
@@ -167,7 +167,7 @@ exports[`Storyshots Modal Without closeAction 1`] = `
       }
     >
       <div
-        className="sc-jlyJG fPCoSz"
+        className="sc-gipzik kNtMSr"
       >
         <div
           className="sc-bwzfXH jTCciZ"
@@ -180,13 +180,13 @@ exports[`Storyshots Modal Without closeAction 1`] = `
           </div>
         </div>
         <div
-          className="sc-brqgnP jwrNlU"
+          className="sc-cMljjf dUfgXO"
         >
           <div
-            className="sc-cMljjf krgCXT"
+            className="sc-jAaTju iVnhyn"
           >
             <div
-              className="sc-jAaTju fzRTCD"
+              className="sc-jDwBTQ bqIkRG"
             />
             <div
               className="sc-bwzfXH fiOUi"
@@ -217,7 +217,7 @@ pharetra. Duis sed magna vel odio ullamcorper gravida eu et nibh.
               </p>
             </div>
             <div
-              className="sc-jDwBTQ cXRqdb"
+              className="sc-gPEVay gkJgPo"
             />
           </div>
         </div>

--- a/src/components/MultiButton/__snapshots__/story.storyshot
+++ b/src/components/MultiButton/__snapshots__/story.storyshot
@@ -9,13 +9,13 @@ exports[`Storyshots MultiButton Default 1`] = `
   >
     <div>
       <div
-        className="sc-bRBYWo iZCyXo"
+        className="sc-hzDkRC gbbQih"
       >
         <div
           className="sc-bwzfXH cAZkVZ"
         >
           <button
-            className="sc-csuQGl jNOnPN sc-htoDjs eHXLyg"
+            className="sc-Rmtcm dhDgko sc-htoDjs eHXLyg"
             color={undefined}
             disabled={undefined}
             icon={undefined}
@@ -31,7 +31,7 @@ exports[`Storyshots MultiButton Default 1`] = `
             </span>
           </button>
           <button
-            className="sc-Rmtcm lmZKVG sc-htoDjs bcNitD"
+            className="sc-bRBYWo iBpAcT sc-htoDjs bcNitD"
             color={undefined}
             disabled={undefined}
             icon={undefined}

--- a/src/components/Popover/__snapshots__/story.storyshot
+++ b/src/components/Popover/__snapshots__/story.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots Popover Default 1`] = `
   >
     <div>
       <div
-        className="sc-jhAzac gaRQRf"
+        className="sc-fBuWsC lnEvtg"
       >
         <button
           className="sc-htoDjs fAnDzT"
@@ -38,7 +38,7 @@ exports[`Storyshots Popover Internal state on click 1`] = `
   >
     <div>
       <div
-        className="sc-jhAzac gaRQRf"
+        className="sc-fBuWsC lnEvtg"
       >
         <button
           className="sc-htoDjs fAnDzT"
@@ -67,7 +67,7 @@ exports[`Storyshots Popover Internal state on hover 1`] = `
   >
     <div>
       <div
-        className="sc-jhAzac gaRQRf"
+        className="sc-fBuWsC lnEvtg"
       >
         <button
           className="sc-htoDjs fAnDzT"

--- a/src/components/PriceTag/__snapshots__/story.storyshot
+++ b/src/components/PriceTag/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots PriceTag Default 1`] = `
 <span
-  className="sc-fAjcbJ qdVfs"
+  className="sc-caSCKo gKwicb"
 >
   €
    

--- a/src/components/RadioButton/__snapshots__/story.storyshot
+++ b/src/components/RadioButton/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots RadioButton Default 1`] = `
 <div
-  className="sc-kgoBCf BEYlJ"
+  className="sc-kGXeez iBFgVY"
   onClick={[Function]}
 >
   <div
@@ -10,12 +10,12 @@ exports[`Storyshots RadioButton Default 1`] = `
   >
     <div
       checked={true}
-      className="sc-kpOJdX kyHwpB"
+      className="sc-dxgOiQ cmdPra"
       disabled={false}
     >
       <input
         checked={true}
-        className="sc-kGXeez sKBUe"
+        className="sc-kpOJdX hZrIxJ"
         id={undefined}
         name="demo"
         onBlur={[Function]}

--- a/src/components/RadioButtonGroup/__snapshots__/story.storyshot
+++ b/src/components/RadioButtonGroup/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots RadioButtonGroup Default 1`] = `
 <div
-  className="sc-caSCKo hFCFuy"
+  className="sc-gisBJw hkZRoH"
 >
   <div
     className="sc-bwzfXH ewkCPx"
@@ -11,7 +11,7 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
       className="sc-bwzfXH hurwPi"
     >
       <div
-        className="sc-kgoBCf BEYlJ"
+        className="sc-kGXeez iBFgVY"
         onClick={[Function]}
       >
         <div
@@ -19,12 +19,12 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
         >
           <div
             checked={true}
-            className="sc-kpOJdX kyHwpB"
+            className="sc-dxgOiQ cmdPra"
             disabled={undefined}
           >
             <input
               checked={true}
-              className="sc-kGXeez sKBUe"
+              className="sc-kpOJdX hZrIxJ"
               id={undefined}
               name="demo"
               onBlur={[Function]}
@@ -54,7 +54,7 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
       className="sc-bwzfXH jQPdWH"
     >
       <div
-        className="sc-kgoBCf BEYlJ"
+        className="sc-kGXeez iBFgVY"
         onClick={[Function]}
       >
         <div
@@ -62,12 +62,12 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
         >
           <div
             checked={false}
-            className="sc-kpOJdX iNOmBO"
+            className="sc-dxgOiQ cZHqqG"
             disabled={undefined}
           >
             <input
               checked={false}
-              className="sc-kGXeez sKBUe"
+              className="sc-kpOJdX hZrIxJ"
               id={undefined}
               name="demo"
               onBlur={[Function]}
@@ -97,7 +97,7 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
       className="sc-bwzfXH jQPdWH"
     >
       <div
-        className="sc-kgoBCf BEYlJ"
+        className="sc-kGXeez iBFgVY"
         onClick={[Function]}
       >
         <div
@@ -105,12 +105,12 @@ exports[`Storyshots RadioButtonGroup Default 1`] = `
         >
           <div
             checked={false}
-            className="sc-kpOJdX iNOmBO"
+            className="sc-dxgOiQ cZHqqG"
             disabled={undefined}
           >
             <input
               checked={false}
-              className="sc-kGXeez sKBUe"
+              className="sc-kpOJdX hZrIxJ"
               id={undefined}
               name="demo"
               onBlur={[Function]}

--- a/src/components/Raised/__snapshots__/story.storyshot
+++ b/src/components/Raised/__snapshots__/story.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots Raised Default 1`] = `
   className="sc-bwzfXH efqLmO"
 >
   <div
-    className="sc-gisBJw ccPELE"
+    className="sc-kjoXOD cJJYJL"
   >
     <div
       className="sc-fjdhpX jskuQK"

--- a/src/components/Range/__snapshots__/story.storyshot
+++ b/src/components/Range/__snapshots__/story.storyshot
@@ -14,7 +14,7 @@ exports[`Storyshots Range Default 1`] = `
         className="sc-bwzfXH jtHmcE"
       >
         <div
-          className="sc-eNQAEJ hdXQwO"
+          className="sc-hMqMXs lcVHiK"
           disabled={false}
           onBlurCapture={[Function]}
           onClick={[Function]}
@@ -24,7 +24,7 @@ exports[`Storyshots Range Default 1`] = `
             className="sc-bwzfXH grkVqn"
           >
             <input
-              className="sc-dxgOiQ dxkTXN"
+              className="sc-ckVGcZ gBhdDx"
               disabled={false}
               id={undefined}
               name="minimum"
@@ -39,11 +39,11 @@ exports[`Storyshots Range Default 1`] = `
             />
           </div>
           <div
-            className="sc-ckVGcZ bUDAVg"
+            className="sc-jKJlTe kuDUsE"
             disabled={false}
           >
             <span
-              className="sc-jKJlTe eFYypy"
+              className="sc-eNQAEJ hiLfdP"
             >
               cm
             </span>
@@ -54,7 +54,7 @@ exports[`Storyshots Range Default 1`] = `
         className="sc-bwzfXH jtHmcE"
       >
         <div
-          className="sc-eNQAEJ hdXQwO"
+          className="sc-hMqMXs lcVHiK"
           disabled={false}
           onBlurCapture={[Function]}
           onClick={[Function]}
@@ -64,7 +64,7 @@ exports[`Storyshots Range Default 1`] = `
             className="sc-bwzfXH grkVqn"
           >
             <input
-              className="sc-dxgOiQ dxkTXN"
+              className="sc-ckVGcZ gBhdDx"
               disabled={false}
               id={undefined}
               name="maximum"
@@ -79,11 +79,11 @@ exports[`Storyshots Range Default 1`] = `
             />
           </div>
           <div
-            className="sc-ckVGcZ bUDAVg"
+            className="sc-jKJlTe kuDUsE"
             disabled={false}
           >
             <span
-              className="sc-jKJlTe eFYypy"
+              className="sc-eNQAEJ hiLfdP"
             >
               cm
             </span>
@@ -93,7 +93,7 @@ exports[`Storyshots Range Default 1`] = `
     </div>
   </div>
   <div
-    className="sc-kjoXOD idZrPy"
+    className="sc-cHGsZl cCKPXt"
     disabled={false}
   >
     <div />

--- a/src/components/ScrollBox/__snapshots__/story.storyshot
+++ b/src/components/ScrollBox/__snapshots__/story.storyshot
@@ -3,19 +3,19 @@
 exports[`Storyshots ScrollBox Default 1`] = `
 Array [
   <div
-    className="sc-cHGsZl cclTPC"
+    className="sc-TOsTZ jnPRix"
   >
     <div
       className="sc-bwzfXH chAuJL"
     >
       <div
-        className="sc-brqgnP jwrNlU"
+        className="sc-cMljjf dUfgXO"
       >
         <div
-          className="sc-cMljjf krgCXT"
+          className="sc-jAaTju iVnhyn"
         >
           <div
-            className="sc-jAaTju fzRTCD"
+            className="sc-jDwBTQ bqIkRG"
           />
           <div
             className="sc-bwzfXH gAalro"
@@ -71,7 +71,7 @@ Array [
             </p>
           </div>
           <div
-            className="sc-jDwBTQ cXRqdb"
+            className="sc-gPEVay gkJgPo"
           />
         </div>
       </div>

--- a/src/components/Select/__snapshots__/story.storyshot
+++ b/src/components/Select/__snapshots__/story.storyshot
@@ -2,14 +2,14 @@
 
 exports[`Storyshots Select Custom rendering 1`] = `
 <div
-  className="sc-cJSrbW gsVfEA"
+  className="sc-ksYbfQ ciLspu"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDownCapture={[Function]}
   tabIndex={0}
 >
   <div
-    className="sc-hmzhuo fbmoed"
+    className="sc-frDJqD clOnjY"
     disabled={false}
   >
     <div
@@ -54,13 +54,13 @@ exports[`Storyshots Select Custom rendering 1`] = `
   </div>
   <MockPortal>
     <div
-      className="sc-ksYbfQ pMeUU"
+      className="sc-hmzhuo kGOZIp"
     >
       <div
-        className="sc-brqgnP jwrNlU"
+        className="sc-cMljjf dUfgXO"
       >
         <div
-          className="sc-cMljjf krgCXT"
+          className="sc-jAaTju iVnhyn"
         >
           <div
             data-test="bricks-select-collapse"
@@ -72,7 +72,7 @@ exports[`Storyshots Select Custom rendering 1`] = `
             }
           >
             <div
-              className="sc-TOsTZ NJJmQ"
+              className="sc-kgAjT hIDSch"
               onClick={[Function]}
               onMouseEnter={[Function]}
             >
@@ -107,7 +107,7 @@ exports[`Storyshots Select Custom rendering 1`] = `
               </div>
             </div>
             <div
-              className="sc-TOsTZ NJJmQ"
+              className="sc-kgAjT hIDSch"
               onClick={[Function]}
               onMouseEnter={[Function]}
             >
@@ -142,7 +142,7 @@ exports[`Storyshots Select Custom rendering 1`] = `
               </div>
             </div>
             <div
-              className="sc-TOsTZ NJJmQ"
+              className="sc-kgAjT hIDSch"
               onClick={[Function]}
               onMouseEnter={[Function]}
             >
@@ -177,7 +177,7 @@ exports[`Storyshots Select Custom rendering 1`] = `
               </div>
             </div>
             <div
-              className="sc-TOsTZ NJJmQ"
+              className="sc-kgAjT hIDSch"
               onClick={[Function]}
               onMouseEnter={[Function]}
             >
@@ -212,7 +212,7 @@ exports[`Storyshots Select Custom rendering 1`] = `
               </div>
             </div>
             <div
-              className="sc-TOsTZ NJJmQ"
+              className="sc-kgAjT hIDSch"
               onClick={[Function]}
               onMouseEnter={[Function]}
             >
@@ -247,7 +247,7 @@ exports[`Storyshots Select Custom rendering 1`] = `
               </div>
             </div>
             <div
-              className="sc-TOsTZ NJJmQ"
+              className="sc-kgAjT hIDSch"
               onClick={[Function]}
               onMouseEnter={[Function]}
             >
@@ -291,14 +291,14 @@ exports[`Storyshots Select Custom rendering 1`] = `
 
 exports[`Storyshots Select Default 1`] = `
 <div
-  className="sc-cJSrbW gsVfEA"
+  className="sc-ksYbfQ ciLspu"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDownCapture={[Function]}
   tabIndex={0}
 >
   <div
-    className="sc-hmzhuo fbmoed"
+    className="sc-frDJqD clOnjY"
     disabled={false}
   >
     <div
@@ -312,7 +312,7 @@ exports[`Storyshots Select Default 1`] = `
           className="sc-bxivhb kTaguW"
         >
           <span
-            className="sc-kgAjT WmYSY"
+            className="sc-cJSrbW hkmhZo"
           >
             Search a value
           </span>
@@ -343,13 +343,13 @@ exports[`Storyshots Select Default 1`] = `
   </div>
   <MockPortal>
     <div
-      className="sc-ksYbfQ pMeUU"
+      className="sc-hmzhuo kGOZIp"
     >
       <div
-        className="sc-brqgnP jwrNlU"
+        className="sc-cMljjf dUfgXO"
       >
         <div
-          className="sc-cMljjf krgCXT"
+          className="sc-jAaTju iVnhyn"
         >
           <div
             data-test="bricks-select-collapse"
@@ -361,7 +361,7 @@ exports[`Storyshots Select Default 1`] = `
             }
           >
             <div
-              className="sc-TOsTZ NJJmQ"
+              className="sc-kgAjT hIDSch"
               onClick={[Function]}
               onMouseEnter={[Function]}
             >
@@ -380,7 +380,7 @@ exports[`Storyshots Select Default 1`] = `
               </div>
             </div>
             <div
-              className="sc-TOsTZ NJJmQ"
+              className="sc-kgAjT hIDSch"
               onClick={[Function]}
               onMouseEnter={[Function]}
             >
@@ -399,7 +399,7 @@ exports[`Storyshots Select Default 1`] = `
               </div>
             </div>
             <div
-              className="sc-TOsTZ NJJmQ"
+              className="sc-kgAjT hIDSch"
               onClick={[Function]}
               onMouseEnter={[Function]}
             >
@@ -418,7 +418,7 @@ exports[`Storyshots Select Default 1`] = `
               </div>
             </div>
             <div
-              className="sc-TOsTZ NJJmQ"
+              className="sc-kgAjT hIDSch"
               onClick={[Function]}
               onMouseEnter={[Function]}
             >
@@ -437,7 +437,7 @@ exports[`Storyshots Select Default 1`] = `
               </div>
             </div>
             <div
-              className="sc-TOsTZ NJJmQ"
+              className="sc-kgAjT hIDSch"
               onClick={[Function]}
               onMouseEnter={[Function]}
             >
@@ -456,7 +456,7 @@ exports[`Storyshots Select Default 1`] = `
               </div>
             </div>
             <div
-              className="sc-TOsTZ NJJmQ"
+              className="sc-kgAjT hIDSch"
               onClick={[Function]}
               onMouseEnter={[Function]}
             >

--- a/src/components/Skeleton/__snapshots__/story.storyshot
+++ b/src/components/Skeleton/__snapshots__/story.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots Skeleton Button 1`] = `
 <div
   aria-hidden={true}
-  className="sc-kvZOFW gtCfQQ"
+  className="sc-hqyNC gQabiB"
   width={139}
 >
   _
@@ -14,21 +14,21 @@ exports[`Storyshots Skeleton Text 1`] = `
 Array [
   <div
     aria-hidden={true}
-    className="sc-frDJqD eyWbdn"
+    className="sc-kvZOFW hzSfWJ"
   >
     _
   </div>,
   <br />,
   <div
     aria-hidden={true}
-    className="sc-frDJqD eyWbdn"
+    className="sc-kvZOFW hzSfWJ"
   >
     _
   </div>,
   <br />,
   <div
     aria-hidden={true}
-    className="sc-frDJqD eyWbdn"
+    className="sc-kvZOFW hzSfWJ"
   >
     _
   </div>,

--- a/src/components/Spacer/__snapshots__/story.storyshot
+++ b/src/components/Spacer/__snapshots__/story.storyshot
@@ -2,10 +2,10 @@
 
 exports[`Storyshots Spacer ⚠️  With margin 1`] = `
 <div
-  className="sc-hqyNC xBAzG"
+  className="sc-jbKcbu tgGys"
 >
   <div
-    className="sc-hEsumM kphJem"
+    className="sc-ktHwxA geMWbx"
   >
     <p
       className="sc-bxivhb kFVWeI"
@@ -18,10 +18,10 @@ exports[`Storyshots Spacer ⚠️  With margin 1`] = `
 
 exports[`Storyshots Spacer ⚠️  With padding 1`] = `
 <div
-  className="sc-hEsumM kphJem"
+  className="sc-ktHwxA geMWbx"
 >
   <div
-    className="sc-hqyNC cORRFV"
+    className="sc-jbKcbu dSTwqC"
   >
     <p
       className="sc-bxivhb kFVWeI"

--- a/src/components/Table/__snapshots__/story.storyshot
+++ b/src/components/Table/__snapshots__/story.storyshot
@@ -3,15 +3,15 @@
 exports[`Storyshots Table Default 1`] = `
 <div>
   <table
-    className="sc-jbKcbu iTpJKE"
+    className="sc-dNLxif fhtdae"
   >
     <thead>
       <tr>
         <th
-          className="sc-uJMKN eZmZnz"
+          className="sc-bbmXgH kYhxUR"
         />
         <th
-          className="sc-uJMKN eZmZnz"
+          className="sc-bbmXgH kYhxUR"
         >
           <div
             className="sc-bwzfXH jXZncb"
@@ -34,7 +34,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </th>
         <th
-          className="sc-uJMKN eZmZnz"
+          className="sc-bbmXgH kYhxUR"
         >
           <div
             className="sc-bwzfXH jXZncb"
@@ -47,7 +47,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </th>
         <th
-          className="sc-uJMKN jMxXcn"
+          className="sc-bbmXgH leQOKW"
         >
           <div
             className="sc-bwzfXH keAoja"
@@ -60,7 +60,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </th>
         <th
-          className="sc-uJMKN ikRcdr"
+          className="sc-bbmXgH cYedlc"
         >
           <div
             className="sc-bwzfXH eFkGjS"
@@ -76,12 +76,12 @@ exports[`Storyshots Table Default 1`] = `
     </thead>
     <tbody>
       <tr
-        className="sc-jqCOkK epAbzf"
+        className="sc-uJMKN dKdOcQ"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <td
-          className="sc-dNLxif cnFzRn"
+          className="sc-jqCOkK OmRDH"
           onBlur={[Function]}
           onFocus={[Function]}
         >
@@ -101,7 +101,7 @@ exports[`Storyshots Table Default 1`] = `
           </p>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -116,7 +116,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -131,7 +131,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif cXYmpw"
+          className="sc-jqCOkK ezOFag"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -146,7 +146,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif hdokdw"
+          className="sc-jqCOkK dBFlhR"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -199,12 +199,12 @@ exports[`Storyshots Table Default 1`] = `
         </td>
       </tr>
       <tr
-        className="sc-jqCOkK epAbzf"
+        className="sc-uJMKN dKdOcQ"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <td
-          className="sc-dNLxif cnFzRn"
+          className="sc-jqCOkK OmRDH"
           onBlur={[Function]}
           onFocus={[Function]}
         >
@@ -224,7 +224,7 @@ exports[`Storyshots Table Default 1`] = `
           </p>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -239,7 +239,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -254,7 +254,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif cXYmpw"
+          className="sc-jqCOkK ezOFag"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -269,7 +269,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif hdokdw"
+          className="sc-jqCOkK dBFlhR"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -322,12 +322,12 @@ exports[`Storyshots Table Default 1`] = `
         </td>
       </tr>
       <tr
-        className="sc-jqCOkK epAbzf"
+        className="sc-uJMKN dKdOcQ"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <td
-          className="sc-dNLxif cnFzRn"
+          className="sc-jqCOkK OmRDH"
           onBlur={[Function]}
           onFocus={[Function]}
         >
@@ -347,7 +347,7 @@ exports[`Storyshots Table Default 1`] = `
           </p>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -362,7 +362,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -377,7 +377,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif cXYmpw"
+          className="sc-jqCOkK ezOFag"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -392,7 +392,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif hdokdw"
+          className="sc-jqCOkK dBFlhR"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -445,12 +445,12 @@ exports[`Storyshots Table Default 1`] = `
         </td>
       </tr>
       <tr
-        className="sc-jqCOkK epAbzf"
+        className="sc-uJMKN dKdOcQ"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <td
-          className="sc-dNLxif cnFzRn"
+          className="sc-jqCOkK OmRDH"
           onBlur={[Function]}
           onFocus={[Function]}
         >
@@ -470,7 +470,7 @@ exports[`Storyshots Table Default 1`] = `
           </p>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -485,7 +485,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -500,7 +500,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif cXYmpw"
+          className="sc-jqCOkK ezOFag"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -515,7 +515,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif hdokdw"
+          className="sc-jqCOkK dBFlhR"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -568,12 +568,12 @@ exports[`Storyshots Table Default 1`] = `
         </td>
       </tr>
       <tr
-        className="sc-jqCOkK epAbzf"
+        className="sc-uJMKN dKdOcQ"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <td
-          className="sc-dNLxif cnFzRn"
+          className="sc-jqCOkK OmRDH"
           onBlur={[Function]}
           onFocus={[Function]}
         >
@@ -593,7 +593,7 @@ exports[`Storyshots Table Default 1`] = `
           </p>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -608,7 +608,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -623,7 +623,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif cXYmpw"
+          className="sc-jqCOkK ezOFag"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -638,7 +638,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif hdokdw"
+          className="sc-jqCOkK dBFlhR"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -691,12 +691,12 @@ exports[`Storyshots Table Default 1`] = `
         </td>
       </tr>
       <tr
-        className="sc-jqCOkK epAbzf"
+        className="sc-uJMKN dKdOcQ"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <td
-          className="sc-dNLxif cnFzRn"
+          className="sc-jqCOkK OmRDH"
           onBlur={[Function]}
           onFocus={[Function]}
         >
@@ -716,7 +716,7 @@ exports[`Storyshots Table Default 1`] = `
           </p>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -731,7 +731,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -746,7 +746,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif cXYmpw"
+          className="sc-jqCOkK ezOFag"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -761,7 +761,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif hdokdw"
+          className="sc-jqCOkK dBFlhR"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -814,12 +814,12 @@ exports[`Storyshots Table Default 1`] = `
         </td>
       </tr>
       <tr
-        className="sc-jqCOkK epAbzf"
+        className="sc-uJMKN dKdOcQ"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <td
-          className="sc-dNLxif cnFzRn"
+          className="sc-jqCOkK OmRDH"
           onBlur={[Function]}
           onFocus={[Function]}
         >
@@ -839,7 +839,7 @@ exports[`Storyshots Table Default 1`] = `
           </p>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -854,7 +854,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -869,7 +869,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif cXYmpw"
+          className="sc-jqCOkK ezOFag"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -884,7 +884,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif hdokdw"
+          className="sc-jqCOkK dBFlhR"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -937,12 +937,12 @@ exports[`Storyshots Table Default 1`] = `
         </td>
       </tr>
       <tr
-        className="sc-jqCOkK epAbzf"
+        className="sc-uJMKN dKdOcQ"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <td
-          className="sc-dNLxif cnFzRn"
+          className="sc-jqCOkK OmRDH"
           onBlur={[Function]}
           onFocus={[Function]}
         >
@@ -962,7 +962,7 @@ exports[`Storyshots Table Default 1`] = `
           </p>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -977,7 +977,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -992,7 +992,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif cXYmpw"
+          className="sc-jqCOkK ezOFag"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -1007,7 +1007,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif hdokdw"
+          className="sc-jqCOkK dBFlhR"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -1060,12 +1060,12 @@ exports[`Storyshots Table Default 1`] = `
         </td>
       </tr>
       <tr
-        className="sc-jqCOkK epAbzf"
+        className="sc-uJMKN dKdOcQ"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <td
-          className="sc-dNLxif cnFzRn"
+          className="sc-jqCOkK OmRDH"
           onBlur={[Function]}
           onFocus={[Function]}
         >
@@ -1085,7 +1085,7 @@ exports[`Storyshots Table Default 1`] = `
           </p>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -1100,7 +1100,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -1115,7 +1115,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif cXYmpw"
+          className="sc-jqCOkK ezOFag"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -1130,7 +1130,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif hdokdw"
+          className="sc-jqCOkK dBFlhR"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -1183,12 +1183,12 @@ exports[`Storyshots Table Default 1`] = `
         </td>
       </tr>
       <tr
-        className="sc-jqCOkK epAbzf"
+        className="sc-uJMKN dKdOcQ"
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
         <td
-          className="sc-dNLxif cnFzRn"
+          className="sc-jqCOkK OmRDH"
           onBlur={[Function]}
           onFocus={[Function]}
         >
@@ -1208,7 +1208,7 @@ exports[`Storyshots Table Default 1`] = `
           </p>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -1223,7 +1223,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif bImkZW"
+          className="sc-jqCOkK clJpkq"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -1238,7 +1238,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif cXYmpw"
+          className="sc-jqCOkK ezOFag"
           onBlur={undefined}
           onFocus={undefined}
         >
@@ -1253,7 +1253,7 @@ exports[`Storyshots Table Default 1`] = `
           </div>
         </td>
         <td
-          className="sc-dNLxif hdokdw"
+          className="sc-jqCOkK dBFlhR"
           onBlur={undefined}
           onFocus={undefined}
         >

--- a/src/components/TextArea/__snapshots__/story.storyshot
+++ b/src/components/TextArea/__snapshots__/story.storyshot
@@ -2,11 +2,11 @@
 
 exports[`Storyshots TextArea Default 1`] = `
 <div
-  className="sc-bbmXgH knqKaW"
+  className="sc-gGBfsJ fZpuGH"
   disabled={false}
 >
   <textarea
-    className="sc-gGBfsJ ijKFkg"
+    className="sc-jnlKLf dHQZVe"
     disabled={false}
     id={undefined}
     name="description"
@@ -20,11 +20,11 @@ exports[`Storyshots TextArea Default 1`] = `
 exports[`Storyshots TextArea With Feedback 1`] = `
 Array [
   <div
-    className="sc-bbmXgH ixmdZe"
+    className="sc-gGBfsJ loTjVr"
     disabled={false}
   >
     <textarea
-      className="sc-gGBfsJ ijKFkg"
+      className="sc-jnlKLf dHQZVe"
       disabled={false}
       id={undefined}
       name="description"

--- a/src/components/TextField/__snapshots__/story.storyshot
+++ b/src/components/TextField/__snapshots__/story.storyshot
@@ -2,18 +2,18 @@
 
 exports[`Storyshots TextField Default 1`] = `
 <div
-  className="sc-eNQAEJ hdXQwO"
+  className="sc-hMqMXs lcVHiK"
   disabled={false}
   onBlurCapture={[Function]}
   onClick={[Function]}
   onFocusCapture={[Function]}
 >
   <div
-    className="sc-ckVGcZ bUDAVg"
+    className="sc-jKJlTe kuDUsE"
     disabled={false}
   >
     <span
-      className="sc-jKJlTe eFYypy"
+      className="sc-eNQAEJ hiLfdP"
     >
       Username
     </span>
@@ -22,7 +22,7 @@ exports[`Storyshots TextField Default 1`] = `
     className="sc-bwzfXH grkVqn"
   >
     <input
-      className="sc-dxgOiQ dxkTXN"
+      className="sc-ckVGcZ gBhdDx"
       disabled={false}
       id={undefined}
       name="firstname"
@@ -37,11 +37,11 @@ exports[`Storyshots TextField Default 1`] = `
     />
   </div>
   <div
-    className="sc-ckVGcZ bUDAVg"
+    className="sc-jKJlTe kuDUsE"
     disabled={false}
   >
     <span
-      className="sc-jKJlTe eFYypy"
+      className="sc-eNQAEJ hiLfdP"
     >
       $
     </span>
@@ -52,18 +52,18 @@ exports[`Storyshots TextField Default 1`] = `
 exports[`Storyshots TextField With Currency formatting 1`] = `
 Array [
   <div
-    className="sc-eNQAEJ hdXQwO"
+    className="sc-hMqMXs lcVHiK"
     disabled={false}
     onBlurCapture={[Function]}
     onClick={[Function]}
     onFocusCapture={[Function]}
   >
     <div
-      className="sc-ckVGcZ bUDAVg"
+      className="sc-jKJlTe kuDUsE"
       disabled={false}
     >
       <span
-        className="sc-jKJlTe eFYypy"
+        className="sc-eNQAEJ hiLfdP"
       >
         $
       </span>
@@ -72,7 +72,7 @@ Array [
       className="sc-bwzfXH grkVqn"
     >
       <input
-        className="sc-dxgOiQ dxkTXN"
+        className="sc-ckVGcZ gBhdDx"
         disabled={false}
         id={undefined}
         name="first name"
@@ -124,18 +124,18 @@ Array [
 exports[`Storyshots TextField With Feedback 1`] = `
 Array [
   <div
-    className="sc-eNQAEJ hdXQwO"
+    className="sc-hMqMXs lcVHiK"
     disabled={false}
     onBlurCapture={[Function]}
     onClick={[Function]}
     onFocusCapture={[Function]}
   >
     <div
-      className="sc-ckVGcZ bUDAVg"
+      className="sc-jKJlTe kuDUsE"
       disabled={false}
     >
       <span
-        className="sc-jKJlTe eFYypy"
+        className="sc-eNQAEJ hiLfdP"
       >
         Username
       </span>
@@ -144,7 +144,7 @@ Array [
       className="sc-bwzfXH grkVqn"
     >
       <input
-        className="sc-dxgOiQ dxkTXN"
+        className="sc-ckVGcZ gBhdDx"
         disabled={false}
         id={undefined}
         name="firstname"
@@ -159,11 +159,11 @@ Array [
       />
     </div>
     <div
-      className="sc-ckVGcZ bUDAVg"
+      className="sc-jKJlTe kuDUsE"
       disabled={false}
     >
       <span
-        className="sc-jKJlTe eFYypy"
+        className="sc-eNQAEJ hiLfdP"
       >
         $
       </span>
@@ -205,7 +205,7 @@ Array [
 
 exports[`Storyshots TextField With Number formatting 1`] = `
 <div
-  className="sc-eNQAEJ hdXQwO"
+  className="sc-hMqMXs lcVHiK"
   disabled={false}
   onBlurCapture={[Function]}
   onClick={[Function]}
@@ -215,7 +215,7 @@ exports[`Storyshots TextField With Number formatting 1`] = `
     className="sc-bwzfXH grkVqn"
   >
     <input
-      className="sc-dxgOiQ dxkTXN"
+      className="sc-ckVGcZ gBhdDx"
       disabled={false}
       id={undefined}
       name="min value"

--- a/src/components/Tile/__snapshots__/story.storyshot
+++ b/src/components/Tile/__snapshots__/story.storyshot
@@ -5,7 +5,7 @@ exports[`Storyshots Tile Default 1`] = `
   className="sc-bwzfXH efqLmO"
 >
   <div
-    className="sc-jnlKLf eJIbRA"
+    className="sc-fYxtnH bKdTjx"
   >
     <div
       className="sc-bwzfXH gYXXqF"

--- a/src/components/Toaster/__snapshots__/story.storyshot
+++ b/src/components/Toaster/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Toaster Default 1`] = `
 <div
-  className="sc-gPEVay iwzqGY"
+  className="sc-iRbamj csmlRs"
 >
   <div
     style={
@@ -12,13 +12,13 @@ exports[`Storyshots Toaster Default 1`] = `
     }
   >
     <div
-      className="sc-fYxtnH dlkCOS"
+      className="sc-tilXH kMPENQ"
     >
       <div
         className="sc-bwzfXH cbcpsK"
       >
         <div
-          className="sc-tilXH cCFWJY"
+          className="sc-hEsumM dckXUS"
         >
           <div
             className="sc-bwzfXH jQmHZh"
@@ -90,7 +90,7 @@ exports[`Storyshots Toaster Default 1`] = `
 
 exports[`Storyshots Toaster With action button 1`] = `
 <div
-  className="sc-gPEVay iwzqGY"
+  className="sc-iRbamj csmlRs"
 >
   <div
     style={
@@ -100,13 +100,13 @@ exports[`Storyshots Toaster With action button 1`] = `
     }
   >
     <div
-      className="sc-fYxtnH dlkCOS"
+      className="sc-tilXH kMPENQ"
     >
       <div
         className="sc-bwzfXH cbcpsK"
       >
         <div
-          className="sc-tilXH ixSjMq"
+          className="sc-hEsumM eaYoif"
         >
           <div
             className="sc-bwzfXH jQmHZh"

--- a/src/components/Toggle/__snapshots__/story.storyshot
+++ b/src/components/Toggle/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Toggle Default 1`] = `
 <div
-  className="sc-kkGfuU jvfvYf"
+  className="sc-iAyFgw DLXvm"
   onClick={[Function]}
 >
   <div
@@ -13,12 +13,12 @@ exports[`Storyshots Toggle Default 1`] = `
     >
       <div
         checked={false}
-        className="sc-kEYyzF brBMbf"
+        className="sc-kkGfuU kGlPwr"
         disabled={false}
       >
         <input
           checked={false}
-          className="sc-hMqMXs iiejKk"
+          className="sc-kEYyzF dpVfOt"
           disabled={false}
           id={undefined}
           name="Toggle"

--- a/src/components/TransitionAnimation/__snapshots__/story.storyshot
+++ b/src/components/TransitionAnimation/__snapshots__/story.storyshot
@@ -5,10 +5,10 @@ exports[`Storyshots TransitionAnimation Default 1`] = `
   className="sc-bwzfXH bQfpwP"
 >
   <div
-    className="sc-gPEVay iwzqGY"
+    className="sc-iRbamj csmlRs"
   >
     <div
-      className="sc-ktHwxA dvMpAQ"
+      className="sc-cIShpX eUJFYD"
     >
       <div
         className="sc-fjdhpX jPMeup"


### PR DESCRIPTION
### This PR:

The default offset on the `Checkbox` has been removed in this PR. The offset was often unnecessary, but always required in the FormRow. 
The FormRow style now adds this offset on the checkbox. 

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)
- [x] Appropriate tests have been added for my functionality (check if not applicable)
- [x] A designer has seen and approved my changes (check if not applicable)
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers)

**Changes** 🌀
- Checkbox has no default offset
- Checkbox in Table aligns correctly
