### PR TITLE
Fixed select StyledWrapper z-index bug

### DIFF
--- a/src/components/Popover/__snapshots__/story.storyshot
+++ b/src/components/Popover/__snapshots__/story.storyshot
@@ -1,34 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Popover Default 1`] = `
-<div
-  className="sc-bwzfXH fnbwCb"
->
-  <div
-    className="sc-bwzfXH kOFNQl"
-  >
-    <div>
-      <div
-        className="sc-fBuWsC lnEvtg"
-      >
-        <button
-          className="sc-htoDjs fAnDzT"
-          color={undefined}
-          disabled={undefined}
-          icon={undefined}
-          id={undefined}
-          onClick={[Function]}
-          title="Toggle"
-          type="button"
-        >
-          Toggle
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Storyshots Popover External state 1`] = `
 <div
   className="sc-bwzfXH fnbwCb"

--- a/src/components/Select/__snapshots__/story.storyshot
+++ b/src/components/Select/__snapshots__/story.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots Select Custom rendering 1`] = `
 <div
-  className="sc-ksYbfQ ciLspu"
+  className="sc-ksYbfQ bRUtDX"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDownCapture={[Function]}
@@ -291,7 +291,7 @@ exports[`Storyshots Select Custom rendering 1`] = `
 
 exports[`Storyshots Select Default 1`] = `
 <div
-  className="sc-ksYbfQ ciLspu"
+  className="sc-ksYbfQ bRUtDX"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDownCapture={[Function]}

--- a/src/components/Select/style.tsx
+++ b/src/components/Select/style.tsx
@@ -56,6 +56,7 @@ const StyledWrapper = withProps<WrapperProps, HTMLDivElement>(styled.div)`
     background: ${({ theme }): string => theme.Select.common.backgroundColor};
     border-radius: ${({ theme }): string => theme.Select.common.borderRadius};
     box-shadow: none;
+    z-index: 1;
 
     &:before {
         content: '';
@@ -82,11 +83,11 @@ const StyledWrapper = withProps<WrapperProps, HTMLDivElement>(styled.div)`
     }
 
     ${({ theme, isDisabled, isOpen }): string => {
-        return !isDisabled  || !isOpen
-        ? `&:focus {
+        return !isDisabled || !isOpen
+            ? `&:focus {
             box-shadow: ${theme.Select.wrapper.focus.boxShadow};
         }`
-        : '';
+            : '';
     }}
 `;
 


### PR DESCRIPTION
### This PR:

There were some issues with the grey background/focus thing of `Select` not showing up when using it in other pages due to the `StyledWrapper` z-index. This is a fix.

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)
- [x] Appropriate tests have been added for my functionality (check if not applicable)
- [x] A designer has seen and approved my changes (check if not applicable)
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers)


**Changes** 🌀
- z-index of `StyledWrapper` in `Select`