### PR TITLE
Fixed TextField.Number to allow it to be empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,10 +81,10 @@
     "webpack-visualizer-plugin": "^0.1.11"
   },
   "peerDependencies": {
-    "@types/react": "^16.3.11",
-    "@types/react-dom": "^16.0.5",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2",
+    "@types/react": "^16.7.6",
+    "@types/react-dom": "^16.0.9",
+    "react": "^16.6.3",
+    "react-dom": "^16.6.3",
     "styled-components": "^3.2.3"
   },
   "scripts": {

--- a/src/components/TextField/formatters/withNumberFormatting/index.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/index.tsx
@@ -11,8 +11,7 @@ type PropsType = Pick<TextFieldPropsType, Exclude<keyof TextFieldPropsType, Omit
 
 type StateType = {
     value: string;
-    savedValue: string;
-    inputLength: number;
+    savedValue: number;
 };
 
 type WithNumberFormattingType = ComponentClass<PropsType>;
@@ -24,14 +23,13 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
 
             this.state = {
                 value: `${this.props.value}`,
-                savedValue: `${this.props.value}`,
-                inputLength: 0,
+                savedValue: this.props.value,
             };
         }
 
         public static getDerivedStateFromProps(nextProps: PropsType, prevState: StateType): StateType {
-            if (isNaN(nextProps.value)) {
-                return { ...prevState, value: prevState.value === '' ? '' : prevState.savedValue };
+            if (nextProps.value === prevState.savedValue) {
+                return { ...prevState, value: prevState.value === '' ? '' : prevState.savedValue.toString() };
             }
 
             return {
@@ -44,7 +42,7 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
             const parsedValue = parseInt(value, 10);
             if (isNaN(parsedValue)) {
                 this.setState({ value: '' });
-                this.props.onChange(NaN);
+                this.props.onChange(this.state.savedValue);
             } else if (parsedValue < 0 && this.props.disableNegative) {
                 this.props.onChange(0);
             } else {
@@ -60,7 +58,7 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
                 this.props.onBlur();
             }
 
-            if (!isNaN(this.props.value)) this.setState({ savedValue: `${this.props.value}` });
+            if (this.props.value !== this.state.savedValue) this.setState({ savedValue: this.props.value });
         };
 
         public render(): JSX.Element {

--- a/src/components/TextField/formatters/withNumberFormatting/index.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/index.tsx
@@ -11,6 +11,8 @@ type PropsType = Pick<TextFieldPropsType, Exclude<keyof TextFieldPropsType, Omit
 
 type StateType = {
     value: string;
+    savedValue: string;
+    inputLength: number;
 };
 
 type WithNumberFormattingType = ComponentClass<PropsType>;
@@ -22,20 +24,27 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
 
             this.state = {
                 value: `${this.props.value}`,
+                savedValue: `${this.props.value}`,
+                inputLength: 0,
             };
         }
 
         public static getDerivedStateFromProps(nextProps: PropsType, prevState: StateType): StateType {
+            if (isNaN(nextProps.value)) {
+                return { ...prevState, value: prevState.value === '' ? '' : prevState.savedValue };
+            }
+
             return {
+                ...prevState,
                 value: `${nextProps.value}`,
             };
         }
 
         private handleChange = (value: string): void => {
             const parsedValue = parseInt(value, 10);
-
             if (isNaN(parsedValue)) {
                 this.setState({ value: '' });
+                this.props.onChange(NaN);
             } else if (parsedValue < 0 && this.props.disableNegative) {
                 this.props.onChange(0);
             } else {
@@ -50,6 +59,8 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
             if (this.props.onBlur !== undefined) {
                 this.props.onBlur();
             }
+
+            if (!isNaN(this.props.value)) this.setState({ savedValue: `${this.props.value}` });
         };
 
         public render(): JSX.Element {

--- a/src/components/TextField/formatters/withNumberFormatting/index.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/index.tsx
@@ -44,8 +44,12 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
                 this.setState({ value: '' });
                 this.props.onChange(this.state.savedValue);
             } else if (parsedValue < 0 && this.props.disableNegative) {
+                this.setState({ savedValue: 0 });
                 this.props.onChange(0);
             } else {
+                if (parsedValue !== this.state.savedValue || this.state.value.length === 0) {
+                    this.setState({ value: '0', savedValue: parsedValue });
+                }
                 this.props.onChange(parsedValue);
             }
         };
@@ -57,8 +61,6 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
             if (this.props.onBlur !== undefined) {
                 this.props.onBlur();
             }
-
-            if (this.props.value !== this.state.savedValue) this.setState({ savedValue: this.props.value });
         };
 
         public render(): JSX.Element {

--- a/src/components/TextField/formatters/withNumberFormatting/test.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/test.tsx
@@ -39,4 +39,28 @@ describe('withNumberFormatting', () => {
 
         expect(changeMock).toHaveBeenCalledWith(0);
     });
+
+    it('should save the input on every change', () => {
+        /* tslint:disable */
+        const changeMock = jest.fn(value => {
+            component.setProps({ value });
+        });
+        /*tslint:enable */
+        const NumberField = withNumberFormatting(TextField);
+        const component = mountWithTheme(
+            <NumberField
+                name=""
+                value={123}
+                onChange={(value: number): void => {
+                    changeMock(value);
+                }}
+            />,
+        );
+
+        component.find('input').simulate('change', { target: { value: '12' } });
+        expect(component.state('savedValue')).toEqual(12);
+
+        component.find('input').simulate('change', { target: { value: '1' } });
+        expect(component.state('savedValue')).toEqual(1);
+    });
 });

--- a/src/components/TextField/formatters/withNumberFormatting/test.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/test.tsx
@@ -17,7 +17,7 @@ describe('withNumberFormatting', () => {
     it('should restore the savedValue on blur when the input is not numeric', () => {
         /* tslint:disable */
         const changeMock = jest.fn(() => {
-            component.setProps({ value: NaN });
+            component.setProps({ value: 123 });
         });
         /*tslint:enable */
         const NumberField = withNumberFormatting(TextField);

--- a/src/components/TextField/formatters/withNumberFormatting/test.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/test.tsx
@@ -14,15 +14,19 @@ describe('withNumberFormatting', () => {
         expect(changeMock).toHaveBeenCalledWith(20);
     });
 
-    it('should only allow numeric values as input', () => {
-        const changeMock = jest.fn();
+    it('should restore the savedValue on blur when the input is not numeric', () => {
+        /* tslint:disable */
+        const changeMock = jest.fn(() => {
+            component.setProps({ value: NaN });
+        });
+        /*tslint:enable */
         const NumberField = withNumberFormatting(TextField);
-        const component = mountWithTheme(<NumberField name="" value={19} onChange={changeMock} />);
+        const component = mountWithTheme(<NumberField name="" value={123} onChange={changeMock} />);
 
-        component.find('input').simulate('change', { target: { value: 'eee' } });
+        component.find('input').simulate('change', { target: { value: 'abcd' } });
         component.find('input').simulate('blur');
 
-        expect(component.find('input').prop('value')).toEqual('19');
+        expect(component.find('input').prop('value')).toEqual('123');
     });
 
     it('should not allow negative numbers when negativeDisabled is true', () => {

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -47,10 +47,7 @@ class Demo extends Component<DemoPropsType, DemoStateType> {
                     disableNegative={boolean('disable negative numbers', false)}
                     disabled={boolean('disabled', false)}
                     value={this.state.numberValue}
-                    onChange={(value: number): void => {
-                        console.log(value);
-                        this.setState({ numberValue: value });
-                    }}
+                    onChange={(value: number): void => this.setState({ numberValue: value })}
                 />
             );
         }

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -47,7 +47,10 @@ class Demo extends Component<DemoPropsType, DemoStateType> {
                     disableNegative={boolean('disable negative numbers', false)}
                     disabled={boolean('disabled', false)}
                     value={this.state.numberValue}
-                    onChange={(value: number): void => this.setState({ numberValue: value })}
+                    onChange={(value: number): void => {
+                        console.log(value);
+                        this.setState({ numberValue: value });
+                    }}
                 />
             );
         }


### PR DESCRIPTION
### This PR:

Fixes a behavior in `TextField.Number` that didn't allow it to be empty. It also saves the last valid input and restores that on blur when invalid input is given (as discussed with luuk).

proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)
- [x] Appropriate tests have been added for my functionality (check if not applicable)
- [x] A designer has seen and approved my changes (check if not applicable)
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers)

**Changes** 🌀
- Fixes `Textfield.Number` behavior.
