### PR TITLE
Removed z-index from RadioButton center

### DIFF
--- a/src/components/FormRow/__snapshots__/story.storyshot
+++ b/src/components/FormRow/__snapshots__/story.storyshot
@@ -289,7 +289,7 @@ exports[`Storyshots FormRow Default 1`] = `
             >
               <div
                 checked={true}
-                className="sc-dxgOiQ cmdPra"
+                className="sc-dxgOiQ gVutUx"
                 disabled={undefined}
               >
                 <input
@@ -568,7 +568,7 @@ exports[`Storyshots FormRow No Descriptions 1`] = `
             >
               <div
                 checked={true}
-                className="sc-dxgOiQ cmdPra"
+                className="sc-dxgOiQ gVutUx"
                 disabled={undefined}
               >
                 <input

--- a/src/components/RadioButton/__snapshots__/story.storyshot
+++ b/src/components/RadioButton/__snapshots__/story.storyshot
@@ -10,7 +10,7 @@ exports[`Storyshots RadioButton Default 1`] = `
   >
     <div
       checked={true}
-      className="sc-dxgOiQ cmdPra"
+      className="sc-dxgOiQ gVutUx"
       disabled={false}
     >
       <input

--- a/src/components/RadioButton/style.tsx
+++ b/src/components/RadioButton/style.tsx
@@ -93,7 +93,6 @@ const StyledRadioButtonSkin = withProps<RadioButtonSkinPropsType, HTMLDivElement
                     transform: translate(-50%,-50%);
                     content: '';
                     background-color: ${theme.RadioButton.idle.backgroundColor};
-                    z-index: 99999;
                 }`
             : ''}
 `;

--- a/src/components/RadioButtonGroup/__snapshots__/story.storyshot
+++ b/src/components/RadioButtonGroup/__snapshots__/story.storyshot
@@ -19,7 +19,7 @@ exports[`Storyshots RadioButtonGroup ⚠️ Default 1`] = `
         >
           <div
             checked={true}
-            className="sc-dxgOiQ cmdPra"
+            className="sc-dxgOiQ gVutUx"
             disabled={undefined}
           >
             <input


### PR DESCRIPTION
### This PR:

Resolves a layering bug with the RadioButton. The center circle is rendered on top of the overlay due to the OVER 9000!! z-index:

![image](https://user-images.githubusercontent.com/10552400/49140183-e94e5600-f2f3-11e8-8292-459647642fff.png)


proposed release: `patch`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)
- [x] Appropriate tests have been added for my functionality (check if not applicable)
- [x] A designer has seen and approved my changes (check if not applicable)
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers)

**Removes** 👋
- `z-index` from center circle in RadioButton
