### PR TITLE
Added disableNegative prop to CurrencyFormatter

### DIFF
--- a/src/components/TextField/formatters/withCurrencyFormatting/index.tsx
+++ b/src/components/TextField/formatters/withCurrencyFormatting/index.tsx
@@ -56,9 +56,11 @@ const withCurrencyFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Com
         private parse(direction: 'in', value: string): string;
         private parse(direction: 'out', value: string): number;
         private parse(direction: 'in' | 'out', value: string): string | number {
-            const stripped = this.props.disableNegative
-                ? value.replace(new RegExp(`[^0-9${this.state.decimalSeperator}]`, 'g'), '')
-                : value.replace(new RegExp(`[^\-0-9${this.state.decimalSeperator}]`, 'g'), '');
+            const negatedValues = this.props.disableNegative
+                ? `[^0-9${this.state.decimalSeperator}]`
+                : `[^\-0-9${this.state.decimalSeperator}]`;
+
+            const stripped = value.replace(new RegExp(negatedValues, 'g'), '');
 
             if (direction === 'out') {
                 const parsed = parseFloat(stripped.replace(this.state.decimalSeperator, '.'));

--- a/src/components/TextField/formatters/withCurrencyFormatting/index.tsx
+++ b/src/components/TextField/formatters/withCurrencyFormatting/index.tsx
@@ -7,6 +7,7 @@ type PropsType = Pick<TextFieldPropsType, Exclude<keyof TextFieldPropsType, Omit
     value: number;
     locale: string;
     currency: string;
+    disableNegative?: boolean;
     onChange(value: number): void;
 };
 
@@ -55,7 +56,9 @@ const withCurrencyFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Com
         private parse(direction: 'in', value: string): string;
         private parse(direction: 'out', value: string): number;
         private parse(direction: 'in' | 'out', value: string): string | number {
-            const stripped = value.replace(new RegExp(`[^0-9${this.state.decimalSeperator}]`, 'g'), '');
+            const stripped = this.props.disableNegative
+                ? value.replace(new RegExp(`[^0-9${this.state.decimalSeperator}]`, 'g'), '')
+                : value.replace(new RegExp(`[^\-0-9${this.state.decimalSeperator}]`, 'g'), '');
 
             if (direction === 'out') {
                 const parsed = parseFloat(stripped.replace(this.state.decimalSeperator, '.'));
@@ -130,9 +133,15 @@ const withCurrencyFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Com
         };
 
         public componentDidUpdate(prevProps: PropsType): void {
-            if (prevProps.currency !== this.props.currency || prevProps.locale !== this.props.locale) {
+            if (
+                prevProps.currency !== this.props.currency ||
+                prevProps.locale !== this.props.locale ||
+                prevProps.disableNegative !== this.props.disableNegative
+            ) {
                 this.setFormatter(this.props.locale, this.props.currency);
-                this.setState({ value: this.format(this.state.value) });
+                this.setState({ value: this.format(this.state.value) }, () =>
+                    this.props.onChange(parseInt(this.state.value, 0)),
+                );
             }
         }
 

--- a/src/components/TextField/formatters/withCurrencyFormatting/test.tsx
+++ b/src/components/TextField/formatters/withCurrencyFormatting/test.tsx
@@ -225,4 +225,52 @@ describe('withCurrencyFormatting', () => {
 
         expect(component.find('input').prop('value')).toEqual('19.12');
     });
+
+    it('should allow negative input when disableNegative prop is false', () => {
+        const changeMock = jest.fn();
+        const CurrencyField = withCurrencyFormatting(TextField);
+
+        const component = mountWithTheme(
+            <CurrencyField
+                disableNegative={false}
+                name=""
+                value={19.12}
+                locale="nl-NL"
+                currency="EUR"
+                onChange={changeMock}
+            />,
+        );
+
+        component.find('input').simulate('change', {
+            target: {
+                value: '-19.12',
+            },
+        });
+
+        expect(component.find('input').prop('value')).toEqual('-19.12');
+    });
+
+    it('should change a negative value to positive when the disableNegative prop is changed from false to true', () => {
+        const changeMock = jest.fn();
+        const CurrencyField = withCurrencyFormatting(TextField);
+
+        const component = mountWithTheme(
+            <CurrencyField
+                disableNegative={false}
+                name=""
+                value={-19.12}
+                locale="nl-NL"
+                currency="EUR"
+                onChange={changeMock}
+            />,
+        );
+
+        component.setProps({
+            disableNegative: true,
+        });
+        
+        component.update();
+
+        expect(component.find('input').prop('value')).toEqual('19.12');
+    });
 });

--- a/src/components/TextField/formatters/withCurrencyFormatting/test.tsx
+++ b/src/components/TextField/formatters/withCurrencyFormatting/test.tsx
@@ -201,4 +201,28 @@ describe('withCurrencyFormatting', () => {
 
         expect(fn).not.toThrow();
     });
+
+    it('should not allow negative input when disableNegative prop is true', () => {
+        const changeMock = jest.fn();
+        const CurrencyField = withCurrencyFormatting(TextField);
+
+        const component = mountWithTheme(
+            <CurrencyField
+                disableNegative={true}
+                name=""
+                value={19.12}
+                locale="nl-NL"
+                currency="EUR"
+                onChange={changeMock}
+            />,
+        );
+
+        component.find('input').simulate('change', {
+            target: {
+                value: '-19.12',
+            },
+        });
+
+        expect(component.find('input').prop('value')).toEqual('19.12');
+    });
 });

--- a/src/components/TextField/formatters/withCurrencyFormatting/test.tsx
+++ b/src/components/TextField/formatters/withCurrencyFormatting/test.tsx
@@ -249,28 +249,4 @@ describe('withCurrencyFormatting', () => {
 
         expect(component.find('input').prop('value')).toEqual('-19.12');
     });
-
-    it('should change a negative value to positive when the disableNegative prop is changed from false to true', () => {
-        const changeMock = jest.fn();
-        const CurrencyField = withCurrencyFormatting(TextField);
-
-        const component = mountWithTheme(
-            <CurrencyField
-                disableNegative={false}
-                name=""
-                value={-19.12}
-                locale="nl-NL"
-                currency="EUR"
-                onChange={changeMock}
-            />,
-        );
-
-        component.setProps({
-            disableNegative: true,
-        });
-        
-        component.update();
-
-        expect(component.find('input').prop('value')).toEqual('19.12');
-    });
 });

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -30,6 +30,7 @@ class Demo extends Component<DemoPropsType, DemoStateType> {
                 <TextField.Currency
                     name="first name"
                     disabled={boolean('disabled', false)}
+                    disableNegative={boolean('disableNegative', false)}
                     currency={this.props.currency ? this.props.currency : 'USD'}
                     feedback={{
                         severity: 'info',


### PR DESCRIPTION
### This PR:

resolves #271 

proposed release: `patch`

**Checklist** 🛡
- [ x ] I have exported my addition from `src/index.ts` (check if not applicable)
- [ x ] Appropriate tests have been added for my functionality (check if not applicable)
- [ x ] A designer has seen and approved my changes (check if not applicable)
- [ x ] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers)


**Adds** ✨
- disableNegative prop, just like the NumberFormatter
