### PR TITLE
Select handles change events

### DIFF
--- a/src/components/Select/__snapshots__/story.storyshot
+++ b/src/components/Select/__snapshots__/story.storyshot
@@ -4,6 +4,7 @@ exports[`Storyshots Select Custom rendering 1`] = `
 <div
   className="sc-ksYbfQ bRUtDX"
   onBlur={[Function]}
+  onChange={[Function]}
   onFocus={[Function]}
   onKeyDownCapture={[Function]}
   tabIndex={0}
@@ -293,6 +294,7 @@ exports[`Storyshots Select Default 1`] = `
 <div
   className="sc-ksYbfQ bRUtDX"
   onBlur={[Function]}
+  onChange={[Function]}
   onFocus={[Function]}
   onKeyDownCapture={[Function]}
   tabIndex={0}

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, KeyboardEvent, Component, RefObject, createRef } from 'react';
+import React, { ChangeEvent, KeyboardEvent, Component, RefObject, createRef, FormEvent } from 'react';
 import { createPortal } from 'react-dom';
 import Box from '../Box';
 import ScrollBox from '../ScrollBox';
@@ -105,6 +105,11 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
         this.setState({ isOpen: false, optionPointer: -1 });
     };
 
+    private handleChangeEvent = (event: FormEvent<HTMLDivElement>): void => {
+        // tslint:disable-next-line
+        this.handleChange((event as any).target.value);
+    };
+
     private handleInput = (input: string): void => {
         this.setState({ input, optionPointer: -1 });
     };
@@ -178,6 +183,7 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
                 isDisabled={this.props.disabled}
                 isOpen={this.state.isOpen}
                 onKeyDownCapture={this.handleKeyPress}
+                onChange={this.handleChangeEvent}
                 onFocus={this.handleFocus}
                 onBlur={this.handleBlur}
                 tabIndex={this.props.disabled ? -1 : 0}

--- a/src/components/Select/test.tsx
+++ b/src/components/Select/test.tsx
@@ -435,4 +435,17 @@ describe('Select', () => {
 
         expect(component.find(StyledWindow).prop('isOpen')).toEqual(false);
     });
+
+    it('should handle a simulated change event', () => {
+        const changeMock = jest.fn();
+        const component = mountWithTheme(<Select onChange={changeMock} value="" emptyText="" options={options} />);
+
+        component.simulate('change', {
+            target: {
+                value: options[0].value,
+            },
+        });
+
+        expect(changeMock).toHaveBeenCalledWith(options[0].value);
+    });
 });


### PR DESCRIPTION
### This PR:

Add handling of a (simulated) change event to the Select. This makes it easier to test and possibly makes it more interchangeable with an actual html select

proposed release: `minor`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable)
- [x] Appropriate tests have been added for my functionality (check if not applicable)
- [x] A designer has seen and approved my changes (check if not applicable)
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers)


**Adds** ✨
- Change event handling for Select
- A test to cover this