### PR TITLE
Select no longer triggers a change when a value is entered

### DIFF
--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -205,9 +205,10 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
                                     type="text"
                                     placeholder={this.props.placeholder}
                                     value={this.state.input}
-                                    onChange={(event: ChangeEvent<HTMLInputElement>): void =>
-                                        this.handleInput(event.target.value)
-                                    }
+                                    onChange={(event: ChangeEvent<HTMLInputElement>): void => {
+                                        event.stopPropagation();
+                                        this.handleInput(event.target.value);
+                                    }}
                                 />
                             </Box>
                         )) ||

--- a/src/components/Select/test.tsx
+++ b/src/components/Select/test.tsx
@@ -448,4 +448,23 @@ describe('Select', () => {
 
         expect(changeMock).toHaveBeenCalledWith(options[0].value);
     });
+
+    it('should not change the selected value when the input value changes', () => {
+        const changeMock = jest.fn();
+        const component = mountWithTheme(<Select onChange={changeMock} value="" emptyText="" options={options} />);
+
+        component
+            .find(StyledInput)
+            .find(Box)
+            .at(1)
+            .simulate('click');
+
+        component.find('input[type="text"]').simulate('change', {
+            target: {
+                value: 'Foo',
+            },
+        });
+
+        expect(changeMock).toHaveBeenCalledTimes(0);
+    });
 });


### PR DESCRIPTION
### This PR:

**Bugfixes/Changed internals** 🎈
- `Select` instantly triggered the `onChange` callback once you started entering a value. This is fixed.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (check if not applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
