### PR TITLE
Textfield.Currency supports minor units

### DIFF
--- a/src/components/TextField/formatters/withCurrencyFormatting/index.tsx
+++ b/src/components/TextField/formatters/withCurrencyFormatting/index.tsx
@@ -8,6 +8,7 @@ type PropsType = Pick<TextFieldPropsType, Exclude<keyof TextFieldPropsType, Omit
     locale: string;
     currency: string;
     disableNegative?: boolean;
+    minor?: boolean;
     onChange(value: number): void;
 };
 
@@ -41,7 +42,9 @@ const withCurrencyFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Com
 
             this.state = {
                 cursorPosition: 0,
-                value: `${props.value / Math.pow(10, this.formatter.resolvedOptions().maximumFractionDigits)}`,
+                value: !this.props.minor
+                    ? `${props.value}`
+                    : `${props.value / Math.pow(10, this.formatter.resolvedOptions().maximumFractionDigits)}`,
                 currency: '',
                 currencyAlignment: 'left',
                 decimalSeperator: '.',
@@ -107,10 +110,11 @@ const withCurrencyFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Com
         }
 
         private handleChange = (value: string, event?: ChangeEvent<HTMLInputElement>): void => {
-            const valueInCents =
-                this.parse('out', value) * Math.pow(10, this.formatter.resolvedOptions().maximumFractionDigits);
-
-            this.props.onChange(valueInCents);
+            this.props.minor
+                ? this.props.onChange(
+                      this.parse('out', value) * Math.pow(10, this.formatter.resolvedOptions().maximumFractionDigits),
+                  )
+                : this.props.onChange(this.parse('out', value));
 
             if (event) {
                 const target = event.target;
@@ -145,7 +149,8 @@ const withCurrencyFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Com
             if (
                 prevProps.currency !== this.props.currency ||
                 prevProps.locale !== this.props.locale ||
-                prevProps.disableNegative !== this.props.disableNegative
+                prevProps.disableNegative !== this.props.disableNegative ||
+                prevProps.minor !== this.props.minor
             ) {
                 this.setFormatter(this.props.locale, this.props.currency);
                 this.setState({ value: this.format(this.state.value) }, () => this.handleChange(this.state.value));

--- a/src/components/TextField/formatters/withCurrencyFormatting/test.tsx
+++ b/src/components/TextField/formatters/withCurrencyFormatting/test.tsx
@@ -250,7 +250,7 @@ describe('withCurrencyFormatting', () => {
         expect(component.find('input').prop('value')).toEqual('-19.12');
     });
 
-    it("should divide the value property by ten to the power of the maximum fraction digits, when the 'minor' property is true", () => {
+    it('should use the value in minor units, when the "minor" prop is set', () => {
         const CurrencyField = withCurrencyFormatting(TextField);
         // Work-around because the Intl polyfil doesn't support resolvedOptions()
         CurrencyField.prototype.setFormatter = () => {
@@ -265,7 +265,6 @@ describe('withCurrencyFormatting', () => {
 
         const component = mountWithTheme(
             <CurrencyField
-                disableNegative={false}
                 name=""
                 value={2554}
                 locale="nl-NL"
@@ -284,5 +283,6 @@ describe('withCurrencyFormatting', () => {
         });
 
         expect(component.find('input').prop('value')).toEqual('1908');
+        expect(changeMock).toHaveBeenCalledWith(190800);
     });
 });

--- a/src/components/TextField/formatters/withCurrencyFormatting/test.tsx
+++ b/src/components/TextField/formatters/withCurrencyFormatting/test.tsx
@@ -249,4 +249,40 @@ describe('withCurrencyFormatting', () => {
 
         expect(component.find('input').prop('value')).toEqual('-19.12');
     });
+
+    it("should divide the value property by ten to the power of the maximum fraction digits, when the 'minor' property is true", () => {
+        const CurrencyField = withCurrencyFormatting(TextField);
+        // Work-around because the Intl polyfil doesn't support resolvedOptions()
+        CurrencyField.prototype.setFormatter = () => {
+            CurrencyField.prototype.formatter = {
+                resolvedOptions: () => ({
+                    maximumFractionDigits: 2,
+                }),
+            };
+        };
+
+        const changeMock = jest.fn();
+
+        const component = mountWithTheme(
+            <CurrencyField
+                disableNegative={false}
+                name=""
+                value={2554}
+                locale="nl-NL"
+                currency="EUR"
+                onChange={changeMock}
+                minor
+            />,
+        );
+
+        expect(component.find('input').prop('value')).toEqual('25.54');
+
+        component.find('input').simulate('change', {
+            target: {
+                value: '1908',
+            },
+        });
+
+        expect(component.find('input').prop('value')).toEqual('1908');
+    });
 });

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -39,6 +39,7 @@ class Demo extends Component<DemoPropsType, DemoStateType> {
                     locale={this.props.locale ? this.props.locale : 'en-US'}
                     value={this.state.numberValue}
                     onChange={(value: number): void => this.setState({ numberValue: value })}
+                    minor={boolean('minor', false)}
                 />
             );
         } else if (this.props.formatter === 'withNumber') {


### PR DESCRIPTION
### This PR:

When dealing with currency values, it is best practice to work with the the amount in minor values. This pr adds a prop that internalizes this behavior in the input.

**Backwards compatible additions** ✨
- Component `TextField.Currency` now also supports an optional `minor` prop, to enable working with minor units.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (check if not applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
