### PR TITLE
Improved modal responsiveness

### DIFF
--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -8,32 +8,52 @@ type PropsType = {
 };
 
 const ButtonGroup: FunctionComponent<PropsType> = (props): JSX.Element => {
-    return (
-        <BreakpointProvider
-            breakpoints={{
-                small: 0,
-                medium: 0,
-                large: 375,
-            }}
-        >
-            {(breakpoint): JSX.Element => {
-                const direction = props.stacked || (props.stacked === undefined && breakpoint === 'small') ? 'column' : 'row-reverse';
+    if (props.stacked === undefined) {
+        return (
+            <BreakpointProvider
+                breakpoints={{
+                    small: 0,
+                    medium: 0,
+                    large: 375,
+                }}
+            >
+                {(breakpoint): JSX.Element => {
+                    const direction = breakpoint === 'small' ? 'column' : 'row-reverse';
 
-                return (
-                    <Box direction={direction} justifyContent="flex-start" alignItems="stretch" wrap margin={trbl(-6)}>
-                        {Children.map(props.children, (child): JSX.Element => (
-                            <Box
-                                direction={direction === 'row-reverse' ? 'row' : 'column'}
-                                alignSelf="stretch"
-                                margin={trbl(6)}
-                            >
-                                {child}
-                            </Box>
-                        ))}
-                    </Box>
-                );
-            }}
-        </BreakpointProvider>
+                    return (
+                        <Box
+                            direction={direction}
+                            justifyContent="flex-start"
+                            alignItems="stretch"
+                            wrap
+                            margin={trbl(-6)}
+                        >
+                            {Children.map(props.children, (child): JSX.Element => (
+                                <Box
+                                    direction={direction === 'row-reverse' ? 'row' : 'column'}
+                                    alignSelf="stretch"
+                                    margin={trbl(6)}
+                                >
+                                    {child}
+                                </Box>
+                            ))}
+                        </Box>
+                    );
+                }}
+            </BreakpointProvider>
+        );
+    }
+
+    const direction = props.stacked === true ? 'column' : 'row-reverse';
+
+    return (
+        <Box direction={direction} justifyContent="flex-start" alignItems="stretch" wrap margin={trbl(-6)}>
+            {Children.map(props.children, (child): JSX.Element => (
+                <Box direction={direction === 'row-reverse' ? 'row' : 'column'} alignSelf="stretch" margin={trbl(6)}>
+                    {child}
+                </Box>
+            ))}
+        </Box>
     );
 };
 

--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -44,7 +44,7 @@ const ButtonGroup: FunctionComponent<PropsType> = (props): JSX.Element => {
         );
     }
 
-    const direction = props.stacked === true ? 'column' : 'row-reverse';
+    const direction = props.stacked ? 'column' : 'row-reverse';
 
     return (
         <Box direction={direction} justifyContent="flex-start" alignItems="stretch" wrap margin={trbl(-6)}>

--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -4,7 +4,7 @@ import Box from '../Box';
 import BreakpointProvider from '../BreakpointProvider';
 
 type PropsType = {
-    useLargeButtons?: boolean;
+    stacked?: boolean;
 };
 
 const ButtonGroup: FunctionComponent<PropsType> = (props): JSX.Element => {
@@ -17,7 +17,7 @@ const ButtonGroup: FunctionComponent<PropsType> = (props): JSX.Element => {
             }}
         >
             {(breakpoint): JSX.Element => {
-                const direction = props.useLargeButtons || (props.useLargeButtons === undefined && breakpoint === 'small') ? 'column' : 'row-reverse';
+                const direction = props.stacked || (props.stacked === undefined && breakpoint === 'small') ? 'column' : 'row-reverse';
 
                 return (
                     <Box direction={direction} justifyContent="flex-start" alignItems="stretch" wrap margin={trbl(-6)}>

--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -3,7 +3,11 @@ import trbl from '../../utility/trbl';
 import Box from '../Box';
 import BreakpointProvider from '../BreakpointProvider';
 
-const ButtonGroup: FunctionComponent = (props): JSX.Element => {
+type PropsType = {
+    useLargeButtons?: boolean;
+};
+
+const ButtonGroup: FunctionComponent<PropsType> = (props): JSX.Element => {
     return (
         <BreakpointProvider
             breakpoints={{
@@ -13,13 +17,13 @@ const ButtonGroup: FunctionComponent = (props): JSX.Element => {
             }}
         >
             {(breakpoint): JSX.Element => {
-                const direction = breakpoint === 'small' ? 'column' : 'row-reverse';
+                const direction = props.useLargeButtons || (props.useLargeButtons === undefined && breakpoint === 'small') ? 'column' : 'row-reverse';
 
                 return (
                     <Box direction={direction} justifyContent="flex-start" alignItems="stretch" wrap margin={trbl(-6)}>
                         {Children.map(props.children, (child): JSX.Element => (
                             <Box
-                                direction={breakpoint === 'small' ? 'column' : 'row'}
+                                direction={direction === 'row-reverse' ? 'row' : 'column'}
                                 alignSelf="stretch"
                                 margin={trbl(6)}
                             >

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -98,7 +98,7 @@ class Modal extends Component<PropsType> {
                                         {this.props.children}
                                     </Box>
                                 </ScrollBox>
-                                {this.props.renderFixed || this.props.buttons && (
+                                {(this.props.renderFixed || this.props.buttons) && (
                                     <Contrast>
                                         <Box
                                             direction="column"
@@ -106,9 +106,7 @@ class Modal extends Component<PropsType> {
                                             shrink={0}
                                             padding={breakpoint === 'small' ? trbl(18) : trbl(18, 36)}
                                         >
-                                            {this.props.renderFixed && (
-                                                this.props.renderFixed
-                                            )}
+                                            {this.props.renderFixed && this.props.renderFixed()}
                                             {this.props.buttons && (
                                                 <ButtonGroup stacked={breakpoint === 'small'}>
                                                     {this.props.buttons}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -48,9 +48,6 @@ class Modal extends Component<PropsType> {
         document.removeEventListener('mousedown', this.handleClickOutside, false);
     }
 
-    /**
-     * @deprecated using renderFixed to pass a buttonGroup is deprecated from version 1.0. Use the buttons prop to send an array of buttons instead.
-     */
     public render(): JSX.Element {
         return (
             <StyledModalWrapper
@@ -101,7 +98,7 @@ class Modal extends Component<PropsType> {
                                         {this.props.children}
                                     </Box>
                                 </ScrollBox>
-                                {this.props.renderFixed && (
+                                {this.props.renderFixed || this.props.buttons && (
                                     <Contrast>
                                         <Box
                                             direction="column"
@@ -109,22 +106,14 @@ class Modal extends Component<PropsType> {
                                             shrink={0}
                                             padding={breakpoint === 'small' ? trbl(18) : trbl(18, 36)}
                                         >
-                                            { console.warn('Using "renderFixed" in modals will be deprecated in v1.0!') }
-                                            {this.props.renderFixed()}
-                                        </Box>
-                                    </Contrast>
-                                )}
-                                {this.props.buttons && (
-                                    <Contrast>
-                                        <Box
-                                            direction="column"
-                                            alignItems="stretch"
-                                            shrink={0}
-                                            padding={breakpoint === 'small' ? trbl(18) : trbl(18, 36)}
-                                        >
-                                            <ButtonGroup useLargeButtons={breakpoint === 'small'}>
-                                                {this.props.buttons}
-                                            </ButtonGroup>
+                                            {this.props.renderFixed && (
+                                                this.props.renderFixed
+                                            )}
+                                            {this.props.buttons && (
+                                                <ButtonGroup stacked={breakpoint === 'small'}>
+                                                    {this.props.buttons}
+                                                </ButtonGroup>
+                                            )}
                                         </Box>
                                     </Contrast>
                                 )}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, ReactNode } from 'react';
 import { StyledType } from '../../utility/styled';
 import trbl from '../../utility/trbl';
 import Box from '../Box';
@@ -10,11 +10,13 @@ import Icon from '../Icon';
 import ScrollBox from '../ScrollBox';
 import TransitionAnimation from '../TransitionAnimation';
 import StyledModal, { StyledModalWrapper } from './style';
+import ButtonGroup from '../ButtonGroup';
 
 type PropsType = StyledType & {
     show: boolean;
     title: string;
     size?: 'small' | 'medium' | 'large';
+    buttons?: Array<ReactNode>;
     closeAction?(): void;
     renderFixed?(): JSX.Element;
 };
@@ -46,6 +48,9 @@ class Modal extends Component<PropsType> {
         document.removeEventListener('mousedown', this.handleClickOutside, false);
     }
 
+    /**
+     * @deprecated using renderFixed to pass a buttonGroup is deprecated from version 1.0. Use the buttons prop to send an array of buttons instead.
+     */
     public render(): JSX.Element {
         return (
             <StyledModalWrapper
@@ -65,7 +70,7 @@ class Modal extends Component<PropsType> {
                             >
                                 <Box
                                     shrink={0}
-                                    margin={breakpoint === 'small' ? trbl(24) : trbl(24, 36)}
+                                    margin={breakpoint === 'small' ? trbl(18) : trbl(24, 36)}
                                     alignItems="flex-start"
                                     alignContent="center"
                                     justifyContent="space-between"
@@ -92,14 +97,34 @@ class Modal extends Component<PropsType> {
                                     )}
                                 </Box>
                                 <ScrollBox>
-                                    <Box padding={breakpoint === 'small' ? trbl(0, 24, 24, 24) : trbl(0, 36, 36, 36)}>
+                                    <Box padding={breakpoint === 'small' ? trbl(0, 18, 18, 18) : trbl(0, 36, 36, 36)}>
                                         {this.props.children}
                                     </Box>
                                 </ScrollBox>
                                 {this.props.renderFixed && (
                                     <Contrast>
-                                        <Box direction="column" alignItems="stretch" shrink={0} padding={trbl(24, 36)}>
+                                        <Box
+                                            direction="column"
+                                            alignItems="stretch"
+                                            shrink={0}
+                                            padding={breakpoint === 'small' ? trbl(18) : trbl(18, 36)}
+                                        >
+                                            { console.warn('Using "renderFixed" in modals will be deprecated in v1.0!') }
                                             {this.props.renderFixed()}
+                                        </Box>
+                                    </Contrast>
+                                )}
+                                {this.props.buttons && (
+                                    <Contrast>
+                                        <Box
+                                            direction="column"
+                                            alignItems="stretch"
+                                            shrink={0}
+                                            padding={breakpoint === 'small' ? trbl(18) : trbl(18, 36)}
+                                        >
+                                            <ButtonGroup useLargeButtons={breakpoint === 'small'}>
+                                                {this.props.buttons}
+                                            </ButtonGroup>
                                         </Box>
                                     </Contrast>
                                 )}

--- a/src/components/Modal/story.tsx
+++ b/src/components/Modal/story.tsx
@@ -6,8 +6,7 @@ import Button from '../Button';
 import ButtonGroup from '../ButtonGroup';
 import Text from '../Text';
 
-const demoContent = `
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut mi ligula. Phasellus tellus nulla,
+const demoContent = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut mi ligula. Phasellus tellus nulla,
 cursus sit amet dolor eu, sodales facilisis tortor. Maecenas sed arcu quis est pharetra molestie sed
 eu leo. Mauris consequat mauris et eros gravida vestibulum. Phasellus convallis ipsum quis nisl lacinia,
 a pulvinar est porta. Nunc tempus vulputate dapibus. In eget venenatis orci. Pellentesque habitant morbi
@@ -33,14 +32,12 @@ storiesOf('Modal', module)
             <Modal
                 show={boolean('show', true)}
                 size={select('size', ['small', 'medium', 'large'], 'large')}
-                title="Would you like me to be your role modal?"
+                title={text('title', 'Would you like me to be your role modal?')}
                 closeAction={(): boolean => confirm('You are now closing this modal, do you wish to continue?')}
-                renderFixed={(): JSX.Element => (
-                    <ButtonGroup>
-                        <Button variant="primary" title="Activate" />
-                        <Button variant="plain" title="Close" />
-                    </ButtonGroup>
-                )}
+                buttons={[
+                    <Button key="activate" variant="primary" title="Activate" />,
+                    <Button key="close" variant="plain" title="Close" />
+                ]}
             >
                 <Text>{text('contents', demoContent)}</Text>
             </Modal>
@@ -51,13 +48,11 @@ storiesOf('Modal', module)
             <Modal
                 show={boolean('show', true)}
                 size={select('size', ['small', 'medium', 'large'], 'large')}
-                title="Would you like me to be your role modal?"
-                renderFixed={(): JSX.Element => (
-                    <ButtonGroup>
-                        <Button variant="primary" title="Activate" />
-                        <Button variant="plain" title="Close" />
-                    </ButtonGroup>
-                )}
+                title={text('title', 'Would you like me to be your role modal?')}
+                buttons={[
+                    <Button key="activate" variant="primary" title="Activate" />,
+                    <Button key="close" variant="plain" title="Close" />
+                ]}
             >
                 <Text>{text('contents', demoContent)}</Text>
             </Modal>

--- a/src/components/Modal/story.tsx
+++ b/src/components/Modal/story.tsx
@@ -35,7 +35,7 @@ storiesOf('Modal', module)
                 closeAction={(): boolean => confirm('You are now closing this modal, do you wish to continue?')}
                 buttons={[
                     <Button key="activate" variant="primary" title="Activate" />,
-                    <Button key="close" variant="plain" title="Close" />
+                    <Button key="close" variant="plain" title="Close" />,
                 ]}
             >
                 <Text>{text('contents', demoContent)}</Text>
@@ -50,7 +50,7 @@ storiesOf('Modal', module)
                 title={text('title', 'Would you like me to be your role modal?')}
                 buttons={[
                     <Button key="activate" variant="primary" title="Activate" />,
-                    <Button key="close" variant="plain" title="Close" />
+                    <Button key="close" variant="plain" title="Close" />,
                 ]}
             >
                 <Text>{text('contents', demoContent)}</Text>

--- a/src/components/Modal/story.tsx
+++ b/src/components/Modal/story.tsx
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import Modal from '.';
 import Button from '../Button';
-import ButtonGroup from '../ButtonGroup';
 import Text from '../Text';
 
 const demoContent = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut mi ligula. Phasellus tellus nulla,

--- a/src/components/Modal/style.tsx
+++ b/src/components/Modal/style.tsx
@@ -25,7 +25,7 @@ const StyledModalWrapper = withProps<ModalWrapperPropsType>(styled.div)`
     position: fixed;
     height: 100%;
     width: 100%;
-    padding: 12px;
+    padding: 9px;
     top: 0;
     left: 0;
     box-sizing: border-box;

--- a/src/components/Modal/test.tsx
+++ b/src/components/Modal/test.tsx
@@ -17,6 +17,37 @@ jest.mock('../BreakpointProvider', () =>
 );
 
 describe('Modal', () => {
+    it('should render with renderFixed', () => {
+        const component = mountWithTheme(
+            <Modal
+                show={true}
+                renderFixed={(): JSX.Element => <div data-testid="bar">renderFixed element</div>}
+                title="Foo"
+            />,
+        );
+
+        expect(component.find('div[data-testid="bar"]').length).toBe(1);
+    });
+
+    it('should render with a buttons prop', () => {
+        const component = mountWithTheme(
+            <Modal
+                show={true}
+                buttons={[
+                    <button key="b1" data-testid="button">
+                        button 1
+                    </button>,
+                    <button key="b2" data-testid="button">
+                        button 2
+                    </button>,
+                ]}
+                title="Foo"
+            />,
+        );
+
+        expect(component.find('button[data-testid="button"]').length).toBe(2);
+    });
+
     it('should render with a small breakpoint', () => {
         (BreakpointProvider as jest.Mock<BreakpointProvider>).mockImplementationOnce(
             (props: PropsType): JSX.Element => {


### PR DESCRIPTION
### This PR:

- Added support to render an array of buttons
- Added a way to skip the breakpointprovider in buttongroups
- Made the styling conform design specs
- Made the title editable in storybook
- Deprecation warning in console and docs

**Breaking changes** 🔥
- None.

**Backwards compatible additions** ✨
- Component `modal` now also accepts an array of Reactnodes to use in the button bar.

**Bugfixes/Changed internals** 🎈
- Conformed the styling to the design specs.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (check if not applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
