### PR TITLE
Added shorthand tuple to Box

### DIFF
--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react';
-import { TrblType } from '../../utility/trbl';
+import trbl, { TrblType } from '../../utility/trbl';
 import { StyledDiv, StyledSpan } from './style';
+import { OffsetShorthandType } from '../../types/OffsetType';
 
 type PropsType = JSX.IntrinsicElements['div'] & {
     justifyContent?:
@@ -17,8 +18,8 @@ type PropsType = JSX.IntrinsicElements['div'] & {
     inline?: boolean;
     height?: string;
     width?: string;
-    margin?: TrblType;
-    padding?: TrblType;
+    margin?: TrblType | OffsetShorthandType;
+    padding?: TrblType | OffsetShorthandType;
     maxHeight?: string;
     minHeight?: string;
     maxWidth?: string;
@@ -48,8 +49,13 @@ const Box: FunctionComponent<PropsType> = (props): JSX.Element => {
         maxWidth,
         minWidth,
         ref,
+        margin,
+        padding,
         ...filteredProps
     } = props;
+
+    const shorthandMargin = Array.isArray(margin) ? trbl(...margin) : margin;
+    const shorthandPadding = Array.isArray(padding) ? trbl(...padding) : padding;
 
     const newProps = {
         ...filteredProps,
@@ -62,6 +68,8 @@ const Box: FunctionComponent<PropsType> = (props): JSX.Element => {
         elementMinWidth: minWidth,
         flexDirection: direction,
         flexOrder: order,
+        margin: shorthandMargin,
+        padding: shorthandPadding,
     };
 
     return props.inline ? (

--- a/src/components/Box/story.tsx
+++ b/src/components/Box/story.tsx
@@ -3,7 +3,8 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import styled from 'styled-components';
 import Box, { PropsType } from '.';
-import trbl, { PxCoordinateType } from '../../utility/trbl';
+import trbl from '../../utility/trbl';
+import { OffsetType } from '../../types/OffsetType';
 import Text from '../Text';
 
 const Wrapper = styled.div`
@@ -36,8 +37,8 @@ storiesOf('Box', module).add('Default', () => {
         items.push(
             <Box
                 key={i}
-                margin={trbl(select('margin', [0, 6, 12], 0, 'Child') as PxCoordinateType)}
-                padding={trbl(select('padding', [0, 6, 12], 0, 'Child') as PxCoordinateType)}
+                margin={trbl(select('margin', [0, 6, 12], 0, 'Child') as OffsetType)}
+                padding={trbl(select('padding', [0, 6, 12], 0, 'Child') as OffsetType)}
                 grow={number('grow', 1, {}, 'Child')}
                 shrink={number('shrink', 1, {}, 'Child')}
                 basis={text('basis', 'auto', 'Child')}
@@ -67,8 +68,8 @@ storiesOf('Box', module).add('Default', () => {
     return (
         <Wrapper>
             <Box
-                margin={trbl(select('margin', [-12, -6, 0, 6, 12], 0, 'Parent') as PxCoordinateType)}
-                padding={trbl(select('padding', [-12, -6, 0, 6, 12], 0, 'Parent') as PxCoordinateType)}
+                margin={trbl(select('margin', [-12, -6, 0, 6, 12], 0, 'Parent') as OffsetType)}
+                padding={trbl(select('padding', [-12, -6, 0, 6, 12], 0, 'Parent') as OffsetType)}
                 justifyContent={
                     select('justifyContent', justifyOptions, justifyOptions[0], 'Parent') as PropsType['justifyContent']
                 }

--- a/src/components/Box/style.tsx
+++ b/src/components/Box/style.tsx
@@ -3,6 +3,7 @@ import { StyledComponentClass as _S } from 'styled-components';
 import { PropsType } from '.';
 import _T from '../../types/ThemeType';
 import styled, { withProps } from '../../utility/styled';
+import { TrblType } from '../../utility/trbl';
 
 type BoxPropsType = PropsType & {
     flexWrap?: PropsType['wrap'];
@@ -14,6 +15,8 @@ type BoxPropsType = PropsType & {
     elementMinWidth?: PropsType['minWidth'];
     flexDirection?: PropsType['direction'];
     flexOrder?: PropsType['order'];
+    margin?: TrblType;
+    padding?: TrblType;
 };
 
 const StyledDiv = withProps<BoxPropsType, HTMLDivElement>(styled.div)`

--- a/src/components/Box/test.tsx
+++ b/src/components/Box/test.tsx
@@ -55,10 +55,32 @@ describe('Box', () => {
         /* tslint:enable */
     });
 
+    it('should be able to use a tuple as shorthand for margin', () => {
+        const component = shallow(<Box margin={[24, 0, 'auto']} />);
+
+        /* tslint:disable */
+        (expect(component) as any).toHaveStyleRule('margin-top', '24px');
+        (expect(component) as any).toHaveStyleRule('margin-right', '0px');
+        (expect(component) as any).toHaveStyleRule('margin-bottom', 'auto');
+        (expect(component) as any).toHaveStyleRule('margin-left', '0px');
+        /* tslint:enable */
+    });
+
     it('can have padding', () => {
         const component = shallow(<Box padding={trbl(24, 0, 'auto')} />);
 
         /*tslint:disable */
+        (expect(component) as any).toHaveStyleRule('padding-top', '24px');
+        (expect(component) as any).toHaveStyleRule('padding-right', '0px');
+        (expect(component) as any).toHaveStyleRule('padding-bottom', 'auto');
+        (expect(component) as any).toHaveStyleRule('padding-left', '0px');
+        /* tslint:enable */
+    });
+
+    it('should be able to use a tuple as shorthand for padding', () => {
+        const component = shallow(<Box padding={[24, 0, 'auto']} />);
+
+        /* tslint:disable */
         (expect(component) as any).toHaveStyleRule('padding-top', '24px');
         (expect(component) as any).toHaveStyleRule('padding-right', '0px');
         (expect(component) as any).toHaveStyleRule('padding-bottom', 'auto');

--- a/src/types/OffsetType.ts
+++ b/src/types/OffsetType.ts
@@ -1,0 +1,7 @@
+export type OffsetType = 0 | 6 | 9 | 12 | 18 | 24 | 36 | 48 | -6 | -9 | -12 | -18 | -24 | -36 | -48 | 'auto';
+
+export type OffsetShorthandType =
+    | [OffsetType, OffsetType, OffsetType, OffsetType]
+    | [OffsetType, OffsetType, OffsetType]
+    | [OffsetType, OffsetType]
+    | [OffsetType];

--- a/src/utility/trbl/index.ts
+++ b/src/utility/trbl/index.ts
@@ -1,3 +1,5 @@
+import { OffsetType } from '../../types/OffsetType';
+
 type TrblType = {
     top: string;
     right: string;
@@ -5,74 +7,30 @@ type TrblType = {
     left: string;
 };
 
-type PxCoordinateType =
-    | 0
-    | 6
-    | 9
-    | 12
-    | 18
-    | 24
-    | 36
-    | 48
-    | -6
-    | -9
-    | -12
-    | -18
-    | -24
-    | -36
-    | -48
-    | 'auto';
-
 const coordinatesFromShorthand = <GenericCoordinate>(
     ...coordinates: Array<GenericCoordinate>
-): [
-    GenericCoordinate,
-    GenericCoordinate,
-    GenericCoordinate,
-    GenericCoordinate
-] => {
+): [GenericCoordinate, GenericCoordinate, GenericCoordinate, GenericCoordinate] => {
     switch (coordinates.length) {
         case 1:
-            return [
-                coordinates[0],
-                coordinates[0],
-                coordinates[0],
-                coordinates[0],
-            ];
+            return [coordinates[0], coordinates[0], coordinates[0], coordinates[0]];
         case 2:
-            return [
-                coordinates[0],
-                coordinates[1],
-                coordinates[0],
-                coordinates[1],
-            ];
+            return [coordinates[0], coordinates[1], coordinates[0], coordinates[1]];
         case 3:
-            return [
-                coordinates[0],
-                coordinates[1],
-                coordinates[2],
-                coordinates[1],
-            ];
+            return [coordinates[0], coordinates[1], coordinates[2], coordinates[1]];
         case 4:
-            return [
-                coordinates[0],
-                coordinates[1],
-                coordinates[2],
-                coordinates[3],
-            ];
+            return [coordinates[0], coordinates[1], coordinates[2], coordinates[3]];
         default:
             throw new Error('Incorrect amount of coordinates provided.');
     }
 };
 
-const trbl = (...coordinates: Array<PxCoordinateType>): TrblType => {
+const trbl = (...coordinates: Array<OffsetType>): TrblType => {
     const px = coordinatesFromShorthand(...coordinates).map(
-        (coordinate): string =>
-            coordinate === 'auto' ? coordinate : `${coordinate}px`,
+        (coordinate): string => (coordinate === 'auto' ? coordinate : `${coordinate}px`),
     );
 
     return { top: px[0], right: px[1], bottom: px[2], left: px[3] };
 };
 
 export default trbl;
-export { TrblType, PxCoordinateType };
+export { TrblType };


### PR DESCRIPTION
### This PR:

resolves #280 

**Backwards compatible additions** ✨
- `Box` now supports an array directly in it's `margin` and `padding` prop. 
`<Box margin={trbl(0, 12} />` now becomes: `<Box margin={[0, 12]} />`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (check if not applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
