### PR TITLE
Added html support to Toaster

### DIFF
--- a/src/components/Link/style.tsx
+++ b/src/components/Link/style.tsx
@@ -1,7 +1,7 @@
 import _R from 'react';
-import { StyledComponentClass as _S } from 'styled-components';
-import _T from '../../types/ThemeType';
+import { css, StyledComponentClass as _S } from 'styled-components';
 import styled from '../../utility/styled';
+import ThemeType from '../../types/ThemeType';
 
 type LinkThemeType = {
     default: {
@@ -14,16 +14,22 @@ type LinkThemeType = {
     };
 };
 
-const StyledLink = styled.a`
-    color: ${({ theme }): string => theme.Link.default.color};
-    text-decoration: ${({ theme }): string => theme.Link.default.textDecoration};
+type ThemePropsType = { theme: ThemeType };
+
+const LinkStyles = css`
+    color: ${({ theme }: ThemePropsType): string => theme.Link.default.color};
+    text-decoration: ${({ theme }: ThemePropsType): string => theme.Link.default.textDecoration};
     transition: color 100ms;
     background-color: transparent;
 
     &:hover {
-        color: ${({ theme }): string => theme.Link.hover.color};
+        color: ${({ theme }: ThemePropsType): string => theme.Link.hover.color};
         background-color: transparent;
     }
+`;
+
+const StyledLink = styled.a`
+    ${LinkStyles}
 `;
 
 const StyledButton = styled.button`
@@ -44,4 +50,4 @@ const StyledButton = styled.button`
 `;
 
 export default StyledLink;
-export { LinkThemeType, StyledButton };
+export { LinkThemeType, StyledButton, LinkStyles };

--- a/src/components/Toaster/index.tsx
+++ b/src/components/Toaster/index.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import StyledToaster, { StyledToasterWrapper } from './style';
 import Button from '../Button';
 import Box from '../Box';
@@ -72,8 +72,14 @@ class Toaster extends Component<PropsType> {
                                             margin={breakpoint === 'small' ? trbl(12) : trbl(18, 12)}
                                             style={{ display: 'block' }}
                                         >
-                                            <Text strong>{this.props.title}</Text>
-                                            <Text>{this.props.message}</Text>
+                                            <Text strong>
+                                                <span dangerouslySetInnerHTML={{ __html: this.props.title }} />
+                                            </Text>
+                                            {this.props.message && (
+                                                <Text>
+                                                    <span dangerouslySetInnerHTML={{ __html: this.props.message }} />
+                                                </Text>
+                                            )}
                                         </Box>
                                         {this.props.buttonTitle && (
                                             <Box

--- a/src/components/Toaster/style.tsx
+++ b/src/components/Toaster/style.tsx
@@ -3,6 +3,7 @@ import { StyledComponentClass as _S } from 'styled-components';
 import _T from '../../types/ThemeType';
 import styled, { withProps } from '../../utility/styled';
 import SeverityType from '../../types/SeverityType';
+import { LinkStyles } from '../Link/style';
 
 type ToasterPropsType = {
     severity: SeverityType;
@@ -35,6 +36,10 @@ const StyledToaster = withProps<ToasterPropsType, HTMLDivElement>(styled.div)`
     border-radius: ${({ theme }): string => theme.Toaster.borderRadius}
     background-color: ${({ theme }): string => theme.Toaster.backgroundColor}
     border-left: ${({ severity, theme }): string => `4px solid ${theme.Text.severity[severity].color};`}
+
+    a {
+       ${LinkStyles}
+    }
 `;
 
 export default StyledToaster;


### PR DESCRIPTION
### This PR:
[issue description]

**Backwards compatible additions** ✨
- `Toaster` now supports html as message and title.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (check if not applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
