### PR TITLE
Fixed rendering of the button prop on EmptyState

### DIFF
--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -53,7 +53,7 @@ const EmptyState: FunctionComponent<PropsType> = (props): JSX.Element => {
                 <Box direction="column" grow={75} margin={[0, 0, 0, 24]}>
                     {title}
                     <Box margin={[9, 0, 0, 0]}>{message}</Box>
-                    {hasChildren && (
+                    {(hasChildren || props.button) && (
                         <Box margin={[24, 0, 0, 0]}>
                             {props.children}
                             {props.button && props.button}
@@ -69,7 +69,7 @@ const EmptyState: FunctionComponent<PropsType> = (props): JSX.Element => {
             {illustration}
             <Box padding={[18, 0, 0, 0]}>{title}</Box>
             <Box margin={[12, 0, 0, 0]}>{message}</Box>
-            {hasChildren && (
+            {(hasChildren || props.button) && (
                 <Box margin={[24, 0, 0, 0]}>
                     {props.children}
                     {props.button && props.button}

--- a/src/components/EmptyState/test.tsx
+++ b/src/components/EmptyState/test.tsx
@@ -5,6 +5,7 @@ import Heading from '../Heading';
 import Text from '../Text';
 import Illustration from '../Illustration';
 import Box from '../Box';
+import { Button } from '../..';
 
 describe('EmptyState', () => {
     it('should render its children', () => {
@@ -36,6 +37,13 @@ describe('EmptyState', () => {
         const component = mountWithTheme(<EmptyState title="foo" message="bar" illustration={illustration} />);
 
         expect(component.find(Illustration).matchesElement(illustration)).toBe(true);
+    });
+
+    it('should render the passed through button', () => {
+        const button = <Button variant="primary" title="foo" href="" />;
+        const component = mountWithTheme(<EmptyState title="foo" message="bar" button={button} />);
+
+        expect(component.find(Button).matchesElement(button)).toBe(true);
     });
 
     it('should render in a vertical fashion', () => {


### PR DESCRIPTION
### This PR:
Fixed rendering of the button prop on EmptyState when no children are present in the EmptyState

**Bugfixes/Changed internals** 🎈
- the button wasn't rendered when children where also rendered in the EmptyState.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
