### PR TITLE
Changed h4 from bodyFont to headingFont

### DIFF
--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -451,7 +451,7 @@ const theme: ThemeType = {
             },
             hierarchy4: {
                 color: grey.base,
-                fontFamily: bodyFont,
+                fontFamily: headingFont,
                 fontSize: '20px',
                 fontWeight: '400',
                 lineHeight: '1.25',


### PR DESCRIPTION
### This PR:

h4 used wrong font

**Bugfixes/Changed internals** 🎈
- Component `Heading` h4 now uses the correct font.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
