### PR TITLE
Added decimal to prevent precision issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3809,6 +3809,15 @@
       "integrity": "sha512-fOM/Jhv51iyugY7KOBZz2ThfT1gwvsGCfWxpLpZDgkGjpEO4Le9cld07OdskikLjDUQJ43dzDaVRSFwQlpdqVg==",
       "dev": true
     },
+    "@types/decimal.js": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/decimal.js/-/decimal.js-7.4.0.tgz",
+      "integrity": "sha512-TiP45voN8GdDib9QkkdMprTfs86xxHInqTxNPSGbF0m6X0LXVBjkFEKbbL9fqm4ZPoVFkG1p4F26on2MWGvW5w==",
+      "dev": true,
+      "requires": {
+        "decimal.js": "*"
+      }
+    },
     "@types/deepmerge": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/deepmerge/-/deepmerge-2.1.0.tgz",
@@ -7658,6 +7667,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "decimal.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.0.2.tgz",
+      "integrity": "sha512-qL5tUTXAWjB5cSBfm0V2a4jO5FaDLumCfwc/0f7WaTOT3WU8pIeq2HHrd98eXHtbey4qFWlaPzfml1JWIoO9TQ=="
     },
     "decode-uri-component": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "components"
   ],
   "dependencies": {
+    "decimal.js": "^10.0.2",
     "deepmerge": "^2.1.0",
     "react-beautiful-dnd": "^8.0.3",
     "react-input-range": "^1.3.0",
@@ -36,6 +37,7 @@
     "@storybook/addons": "^4.1.2",
     "@storybook/react": "^4.1.2",
     "@storybook/storybook-deployer": "^2.8.1",
+    "@types/decimal.js": "^7.4.0",
     "@types/deepmerge": "^2.1.0",
     "@types/enzyme": "^3.1.15",
     "@types/enzyme-adapter-react-16": "^1.0.3",

--- a/src/components/TextField/formatters/withCurrencyFormatting/index.tsx
+++ b/src/components/TextField/formatters/withCurrencyFormatting/index.tsx
@@ -1,5 +1,6 @@
 import React, { Component, ComponentClass, ComponentType, ChangeEvent } from 'react';
 import { PropsType as TextFieldPropsType } from '../../';
+import { Decimal } from 'decimal.js';
 
 type OmittedKeys = 'onChange' | 'value';
 
@@ -112,7 +113,9 @@ const withCurrencyFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Com
         private handleChange = (value: string, event?: ChangeEvent<HTMLInputElement>): void => {
             this.props.minor
                 ? this.props.onChange(
-                      this.parse('out', value) * Math.pow(10, this.formatter.resolvedOptions().maximumFractionDigits),
+                      new Decimal(this.parse('out', value))
+                          .times(Math.pow(10, this.formatter.resolvedOptions().maximumFractionDigits))
+                          .toNumber(),
                   )
                 : this.props.onChange(this.parse('out', value));
 


### PR DESCRIPTION
### This PR:

**Bugfixes/Changed internals** 🎈
- TextField.Currency now handles float percision better

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
