### PR TITLE
Removed light font weight

### DIFF
--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -26,7 +26,7 @@ const Breadcrumbs: FunctionComponent<PropsType> = (props): JSX.Element => {
             </Text>
             {index < props.breadcrumbs.length - 1 && (
                 <Box margin={[0, 9]}>
-                    <Text>
+                    <Text severity="info">
                         <Icon icon="chrevronRight" size="small" />
                     </Text>
                 </Box>

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -27,18 +27,19 @@ type PropsType = {
 };
 
 const Heading = styled.div.attrs(() => ({ role: 'heading' }))<PropsType>`
-    color: ${({ hierarchy, theme }): string => (!hierarchy ? theme.Heading[0].color : theme.Heading[hierarchy].color)};
+    color: ${({ hierarchy, theme }): string =>
+        !hierarchy ? theme.Heading[0].color : theme.Heading[hierarchy - 1].color};
     font-family: ${({ hierarchy, theme }): string =>
-        !hierarchy ? theme.Heading[0].fontFamily : theme.Heading[hierarchy].fontFamily};
+        !hierarchy ? theme.Heading[0].fontFamily : theme.Heading[hierarchy - 1].fontFamily};
     font-size: ${({ hierarchy, theme }): string =>
-        !hierarchy ? theme.Heading[0].fontSize : theme.Heading[hierarchy].fontSize};
+        !hierarchy ? theme.Heading[0].fontSize : theme.Heading[hierarchy - 1].fontSize};
     font-weight: ${({ hierarchy, theme }): string => {
-        if (hierarchy) return theme.Heading[hierarchy].fontWeight;
+        if (hierarchy) return theme.Heading[hierarchy - 1].fontWeight;
 
         return theme.Heading[0].fontWeight;
     }};
     line-height: ${({ hierarchy, theme }): string =>
-        !hierarchy ? theme.Heading[0].lineHeight : theme.Heading[hierarchy].lineHeight};
+        !hierarchy ? theme.Heading[0].lineHeight : theme.Heading[hierarchy - 1].lineHeight};
 
     text-align: ${({ textAlign }): string => (textAlign !== undefined ? textAlign : '')};
     margin: 0;

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -6,10 +6,7 @@ type HierarchyType = 1 | 2 | 3 | 4 | 5 | 6;
 type HeadingHierarchyThemeType = {
     fontFamily: string;
     fontSize: string;
-    fontWeight: {
-        light: string;
-        default: string;
-    };
+    fontWeight: string;
     lineHeight: string;
     color: string;
 };
@@ -28,7 +25,6 @@ type PropsType = {
     hierarchy?: HierarchyType;
     as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'div' | 'span' | 'p';
     textAlign?: 'left' | 'right' | 'center' | 'justify';
-    light?: boolean;
 };
 
 const Heading = styled.div.attrs(() => ({ role: 'heading' }))<PropsType>`
@@ -38,12 +34,10 @@ const Heading = styled.div.attrs(() => ({ role: 'heading' }))<PropsType>`
         !hierarchy ? theme.Heading.hierarchy1.fontFamily : theme.Heading[`hierarchy${hierarchy}`].fontFamily};
     font-size: ${({ hierarchy, theme }): string =>
         !hierarchy ? theme.Heading.hierarchy1.fontSize : theme.Heading[`hierarchy${hierarchy}`].fontSize};
-    font-weight: ${({ light, hierarchy, theme }): string => {
-        if (light && hierarchy) return theme.Heading[`hierarchy${hierarchy}`].fontWeight.light;
-        if (!light && hierarchy) return theme.Heading[`hierarchy${hierarchy}`].fontWeight.default;
-        if (light && !hierarchy) return theme.Heading.hierarchy1.fontWeight.light;
+    font-weight: ${({ hierarchy, theme }): string => {
+        if (hierarchy) return theme.Heading[`hierarchy${hierarchy}`].fontWeight;
 
-        return theme.Heading.hierarchy1.fontWeight.default;
+        return theme.Heading.hierarchy1.fontWeight;
     }};
     line-height: ${({ hierarchy, theme }): string =>
         !hierarchy ? theme.Heading.hierarchy1.lineHeight : theme.Heading[`hierarchy${hierarchy}`].lineHeight};

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -11,15 +11,14 @@ type HeadingHierarchyThemeType = {
     color: string;
 };
 
-type HeadingThemeType = {
-    hierarchy1: HeadingHierarchyThemeType;
-    hierarchy2: HeadingHierarchyThemeType;
-    hierarchy3: HeadingHierarchyThemeType;
-    hierarchy4: HeadingHierarchyThemeType;
-    hierarchy5: HeadingHierarchyThemeType;
-    hierarchy6: HeadingHierarchyThemeType;
-    [key: string]: HeadingHierarchyThemeType;
-};
+type HeadingThemeType = [
+    HeadingHierarchyThemeType,
+    HeadingHierarchyThemeType,
+    HeadingHierarchyThemeType,
+    HeadingHierarchyThemeType,
+    HeadingHierarchyThemeType,
+    HeadingHierarchyThemeType
+];
 
 type PropsType = {
     hierarchy?: HierarchyType;
@@ -28,19 +27,18 @@ type PropsType = {
 };
 
 const Heading = styled.div.attrs(() => ({ role: 'heading' }))<PropsType>`
-    color: ${({ hierarchy, theme }): string =>
-        !hierarchy ? theme.Heading.hierarchy1.color : theme.Heading[`hierarchy${hierarchy}`].color};
+    color: ${({ hierarchy, theme }): string => (!hierarchy ? theme.Heading[0].color : theme.Heading[hierarchy].color)};
     font-family: ${({ hierarchy, theme }): string =>
-        !hierarchy ? theme.Heading.hierarchy1.fontFamily : theme.Heading[`hierarchy${hierarchy}`].fontFamily};
+        !hierarchy ? theme.Heading[0].fontFamily : theme.Heading[hierarchy].fontFamily};
     font-size: ${({ hierarchy, theme }): string =>
-        !hierarchy ? theme.Heading.hierarchy1.fontSize : theme.Heading[`hierarchy${hierarchy}`].fontSize};
+        !hierarchy ? theme.Heading[0].fontSize : theme.Heading[hierarchy].fontSize};
     font-weight: ${({ hierarchy, theme }): string => {
-        if (hierarchy) return theme.Heading[`hierarchy${hierarchy}`].fontWeight;
+        if (hierarchy) return theme.Heading[hierarchy].fontWeight;
 
-        return theme.Heading.hierarchy1.fontWeight;
+        return theme.Heading[0].fontWeight;
     }};
     line-height: ${({ hierarchy, theme }): string =>
-        !hierarchy ? theme.Heading.hierarchy1.lineHeight : theme.Heading[`hierarchy${hierarchy}`].lineHeight};
+        !hierarchy ? theme.Heading[0].lineHeight : theme.Heading[hierarchy].lineHeight};
 
     text-align: ${({ textAlign }): string => (textAlign !== undefined ? textAlign : '')};
     margin: 0;

--- a/src/components/Heading/story.tsx
+++ b/src/components/Heading/story.tsx
@@ -7,12 +7,10 @@ storiesOf('Heading', module).add('Default', () => {
     const hierarchy = select('Hierarchy', [1, 2, 3, 4, 5, 6], 1) as PropsType['hierarchy'];
     const as = select('As', ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'div', 'span', 'p'], 'h1') as PropsType['as'];
     const textAlign = select('Text-align', ['left', 'right', 'center', 'justify'], 'left') as PropsType['textAlign'];
-    const light = boolean('light', false) as PropsType['light'];
 
     return (
-        <Heading hierarchy={hierarchy} as={as} textAlign={textAlign} light={light}>
-            This is an {as !== undefined ? `${as}` : 'div'} element, with{' '}
-            {hierarchy !== undefined ? `h${hierarchy}` : 'h1'} styling.
+        <Heading hierarchy={hierarchy} as={as} textAlign={textAlign}>
+            Happy Selling!
         </Heading>
     );
 });

--- a/src/components/Heading/test.tsx
+++ b/src/components/Heading/test.tsx
@@ -13,11 +13,11 @@ describe('Heading', () => {
         const h5 = mountWithTheme(<Heading hierarchy={5} />);
         const h6 = mountWithTheme(<Heading hierarchy={6} />);
 
-        expect(h1).toHaveStyleRule('font-size', MosTheme.Heading.hierarchy1.fontSize);
-        expect(h2).toHaveStyleRule('font-size', MosTheme.Heading.hierarchy2.fontSize);
-        expect(h3).toHaveStyleRule('font-size', MosTheme.Heading.hierarchy3.fontSize);
-        expect(h4).toHaveStyleRule('font-size', MosTheme.Heading.hierarchy4.fontSize);
-        expect(h5).toHaveStyleRule('font-size', MosTheme.Heading.hierarchy5.fontSize);
-        expect(h6).toHaveStyleRule('font-size', MosTheme.Heading.hierarchy6.fontSize);
+        expect(h1).toHaveStyleRule('font-size', MosTheme.Heading[0].fontSize);
+        expect(h2).toHaveStyleRule('font-size', MosTheme.Heading[1].fontSize);
+        expect(h3).toHaveStyleRule('font-size', MosTheme.Heading[2].fontSize);
+        expect(h4).toHaveStyleRule('font-size', MosTheme.Heading[3].fontSize);
+        expect(h5).toHaveStyleRule('font-size', MosTheme.Heading[4].fontSize);
+        expect(h6).toHaveStyleRule('font-size', MosTheme.Heading[5].fontSize);
     });
 });

--- a/src/components/Heading/test.tsx
+++ b/src/components/Heading/test.tsx
@@ -20,22 +20,4 @@ describe('Heading', () => {
         expect(h5).toHaveStyleRule('font-size', MosTheme.Heading.hierarchy5.fontSize);
         expect(h6).toHaveStyleRule('font-size', MosTheme.Heading.hierarchy6.fontSize);
     });
-
-    it('should render a Heading component with light fontWeight', () => {
-        const h1Light = mountWithTheme(<Heading hierarchy={1} light />);
-        const h2Light = mountWithTheme(<Heading hierarchy={2} light />);
-        const h3Light = mountWithTheme(<Heading hierarchy={3} light />);
-        const h4Light = mountWithTheme(<Heading hierarchy={4} light />);
-        const h5Light = mountWithTheme(<Heading hierarchy={5} light />);
-        const h6Light = mountWithTheme(<Heading hierarchy={6} light />);
-        const defaultLight = mountWithTheme(<Heading light />);
-
-        expect(h1Light).toHaveStyleRule('font-weight', MosTheme.Heading.hierarchy1.fontWeight.light);
-        expect(h2Light).toHaveStyleRule('font-weight', MosTheme.Heading.hierarchy2.fontWeight.light);
-        expect(h3Light).toHaveStyleRule('font-weight', MosTheme.Heading.hierarchy3.fontWeight.light);
-        expect(h4Light).toHaveStyleRule('font-weight', MosTheme.Heading.hierarchy4.fontWeight.light);
-        expect(h5Light).toHaveStyleRule('font-weight', MosTheme.Heading.hierarchy5.fontWeight.light);
-        expect(h6Light).toHaveStyleRule('font-weight', MosTheme.Heading.hierarchy6.fontWeight.light);
-        expect(defaultLight).toHaveStyleRule('font-weight', MosTheme.Heading.hierarchy1.fontWeight.light);
-    });
 });

--- a/src/components/Text/story.tsx
+++ b/src/components/Text/story.tsx
@@ -37,7 +37,7 @@ storiesOf('Text', module).add('Default', () => (
         severity={
             select('severity', [undefined, 'error', 'success', 'info', 'warning'], undefined) as PropsType['severity']
         }
-        textAlign={select('text-align', ['left', 'right', 'center', 'justify'], 'center') as PropsType['textAlign']}
+        textAlign={select('text-align', ['left', 'right', 'center', 'justify'], 'left') as PropsType['textAlign']}
         compact={boolean('compact', false)}
         strong={boolean('strong', false)}
     >

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -292,50 +292,50 @@ const theme: ThemeType = {
             },
         },
     },
-    Heading: {
-        hierarchy1: {
+    Heading: [
+        {
             fontFamily: headingFont,
-            fontSize: '36px',
+            fontSize: fontSize.larger6,
             fontWeight: fontWeight.regular,
             lineHeight: '45px',
             color: grey.base,
         },
-        hierarchy2: {
+        {
             fontFamily: headingFont,
-            fontSize: '30px',
+            fontSize: fontSize.larger5,
             fontWeight: fontWeight.regular,
             lineHeight: '36px',
             color: grey.base,
         },
-        hierarchy3: {
+        {
             fontFamily: headingFont,
-            fontSize: '27px',
+            fontSize: fontSize.larger4,
             fontWeight: fontWeight.regular,
             color: grey.base,
             lineHeight: '33px',
         },
-        hierarchy4: {
+        {
             fontFamily: headingFont,
-            fontSize: '24px',
+            fontSize: fontSize.larger3,
             fontWeight: fontWeight.regular,
             lineHeight: '30px',
             color: grey.base,
         },
-        hierarchy5: {
+        {
             fontFamily: headingFont,
-            fontSize: '21px',
+            fontSize: fontSize.larger2,
             fontWeight: fontWeight.regular,
             lineHeight: '27px',
             color: grey.base,
         },
-        hierarchy6: {
+        {
             fontFamily: headingFont,
-            fontSize: '18px',
+            fontSize: fontSize.larger1,
             fontWeight: fontWeight.regular,
             lineHeight: '21px',
             color: grey.base,
         },
-    },
+    ],
     IconButton: {
         primary: {
             color: grey.darker1,
@@ -619,7 +619,7 @@ const theme: ThemeType = {
             },
             large: {
                 fontFamily: bodyFont,
-                fontSize: '18px',
+                fontSize: fontSize.larger1,
                 fontWeight: fontWeight.regular,
                 lineHeight: {
                     default: '27px',
@@ -628,7 +628,7 @@ const theme: ThemeType = {
             },
             extraLarge: {
                 fontFamily: bodyFont,
-                fontSize: '21px',
+                fontSize: fontSize.larger2,
                 fontWeight: fontWeight.regular,
                 lineHeight: {
                     default: '30px',

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -7,10 +7,13 @@ const headingFont = 'Melbourne,sans-serif';
 
 const fontSize = {
     smaller1: '12px',
-    base: '14px',
-    larger1: '22px',
-    larger2: '28px',
-    larger3: '36px',
+    base: '15px',
+    larger1: '18px',
+    larger2: '21px',
+    larger3: '24px',
+    larger4: '27px',
+    larger5: '30px',
+    larger6: '36px',
 };
 
 const fontWeight = {
@@ -293,61 +296,43 @@ const theme: ThemeType = {
         hierarchy1: {
             fontFamily: headingFont,
             fontSize: '36px',
-            fontWeight: {
-                light: fontWeight.light,
-                default: fontWeight.bold,
-            },
+            fontWeight: fontWeight.regular,
             lineHeight: '45px',
             color: grey.base,
         },
         hierarchy2: {
             fontFamily: headingFont,
             fontSize: '30px',
-            fontWeight: {
-                light: fontWeight.light,
-                default: fontWeight.bold,
-            },
+            fontWeight: fontWeight.regular,
             lineHeight: '36px',
             color: grey.base,
         },
         hierarchy3: {
             fontFamily: headingFont,
-            fontSize: '24px',
-            fontWeight: {
-                light: fontWeight.light,
-                default: fontWeight.bold,
-            },
-            lineHeight: '30px',
+            fontSize: '27px',
+            fontWeight: fontWeight.regular,
             color: grey.base,
+            lineHeight: '33px',
         },
         hierarchy4: {
             fontFamily: headingFont,
-            fontSize: '21px',
-            fontWeight: {
-                light: fontWeight.light,
-                default: fontWeight.bold,
-            },
-            lineHeight: '27px',
+            fontSize: '24px',
+            fontWeight: fontWeight.regular,
+            lineHeight: '30px',
             color: grey.base,
         },
         hierarchy5: {
             fontFamily: headingFont,
-            fontSize: '18px',
-            fontWeight: {
-                light: fontWeight.bold,
-                default: fontWeight.bold,
-            },
-            lineHeight: '21px',
+            fontSize: '21px',
+            fontWeight: fontWeight.regular,
+            lineHeight: '27px',
             color: grey.base,
         },
         hierarchy6: {
-            fontFamily: bodyFont,
-            fontSize: '15px',
-            fontWeight: {
-                light: fontWeight.regular,
-                default: fontWeight.regular,
-            },
-            lineHeight: '18px',
+            fontFamily: headingFont,
+            fontSize: '18px',
+            fontWeight: fontWeight.regular,
+            lineHeight: '21px',
             color: grey.base,
         },
     },
@@ -616,8 +601,8 @@ const theme: ThemeType = {
         variant: {
             small: {
                 fontFamily: bodyFont,
-                fontSize: '12px',
-                fontWeight: fontWeight.light,
+                fontSize: fontSize.smaller1,
+                fontWeight: fontWeight.regular,
                 lineHeight: {
                     default: '18px',
                     compact: '15px',
@@ -625,8 +610,8 @@ const theme: ThemeType = {
             },
             regular: {
                 fontFamily: bodyFont,
-                fontSize: '15px',
-                fontWeight: fontWeight.light,
+                fontSize: fontSize.base,
+                fontWeight: fontWeight.regular,
                 lineHeight: {
                     default: '21px',
                     compact: '18px',
@@ -635,7 +620,7 @@ const theme: ThemeType = {
             large: {
                 fontFamily: bodyFont,
                 fontSize: '18px',
-                fontWeight: fontWeight.light,
+                fontWeight: fontWeight.regular,
                 lineHeight: {
                     default: '27px',
                     compact: '21px',
@@ -644,7 +629,7 @@ const theme: ThemeType = {
             extraLarge: {
                 fontFamily: bodyFont,
                 fontSize: '21px',
-                fontWeight: fontWeight.light,
+                fontWeight: fontWeight.regular,
                 lineHeight: {
                     default: '30px',
                     compact: '27px',
@@ -653,7 +638,7 @@ const theme: ThemeType = {
             display: {
                 fontFamily: headingFont,
                 fontSize: '60px',
-                fontWeight: fontWeight.bold,
+                fontWeight: fontWeight.regular,
                 lineHeight: {
                     default: '75px',
                     compact: '75px',


### PR DESCRIPTION
### This PR:

resolves #315 

**Breaking changes** 🔥
- A new hierarchy is introduced to the Heading.
- The Heading key in the theme is now an array.
- light is removed as a prop on Heading.

**Bugfixes/Changed internals** 🎈
- Breadcrumbs now have the correct color

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
