### PR TITLE
fix: added focus styles to MosTheme for flat Button variant

### DIFF
--- a/src/components/Button/style.tsx
+++ b/src/components/Button/style.tsx
@@ -15,6 +15,7 @@ type FlatButtonStylesType = {
     idle: FlatButtonVariantStylesType;
     active: FlatButtonVariantStylesType;
     hover: FlatButtonVariantStylesType;
+    focus: FlatButtonVariantStylesType;
 };
 
 type ButtonVariantStylesType = {
@@ -123,11 +124,17 @@ const StyledButton = withProps<ButtonPropsType>(styled.button)`
 
             &:focus {
                 ${
+                    !loading
+                        ? `
+                            color: ${color ? color : theme.Button[variant][subVariant].focus.color};
+                            background-color: ${theme.Button[variant][subVariant].focus.backgroundColor};
+                            text-decoration: ${theme.Button[variant][subVariant].focus.textDecoration};
+                        `
+                        : ''
+                }
+                ${
                     !flat && !loading
                         ? `
-                            color: ${color ? color : theme.Button[variant].regular.focus.color};
-                            background-color: ${theme.Button[variant].regular.focus.backgroundColor};
-                            text-decoration: ${theme.Button[variant].regular.focus.textDecoration};
                             border-color: ${theme.Button[variant].regular.focus.borderColor};
                             box-shadow: ${theme.Button[variant].regular.focus.boxShadow};
                         `

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -138,6 +138,11 @@ const theme: ThemeType = {
                     color: grey.darker1,
                     textDecoration: 'none',
                 },
+                focus: {
+                    backgroundColor: 'transparent',
+                    color: grey.darker1,
+                    textDecoration: 'none',
+                },
             },
         },
         secondary: {
@@ -178,6 +183,11 @@ const theme: ThemeType = {
                     textDecoration: 'none',
                 },
                 hover: {
+                    backgroundColor: 'transparent',
+                    color: grey.darker1,
+                    textDecoration: 'none',
+                },
+                focus: {
                     backgroundColor: 'transparent',
                     color: grey.darker1,
                     textDecoration: 'none',
@@ -231,6 +241,11 @@ const theme: ThemeType = {
                     color: grey.darker1,
                     textDecoration: 'none',
                 },
+                focus: {
+                    backgroundColor: 'transparent',
+                    color: grey.darker1,
+                    textDecoration: 'none',
+                },
                 active: {
                     backgroundColor: 'transparent',
                     color: grey.darker1,
@@ -280,6 +295,11 @@ const theme: ThemeType = {
                     color: red.base,
                     textDecoration: 'none',
                 },
+                focus: {
+                    backgroundColor: 'transparent',
+                    color: grey.darker1,
+                    textDecoration: 'none',
+                },
                 active: {
                     backgroundColor: 'transparent',
                     color: red.base,
@@ -325,6 +345,11 @@ const theme: ThemeType = {
                     textDecoration: 'none',
                 },
                 hover: {
+                    backgroundColor: 'transparent',
+                    color: grey.darker1,
+                    textDecoration: 'none',
+                },
+                focus: {
                     backgroundColor: 'transparent',
                     color: grey.darker1,
                     textDecoration: 'none',


### PR DESCRIPTION
### This PR:

resolves #313

**Bugfixes/Changed internals** 🎈
- MosTheme now supports focus state for Buttons with `flat` variant (styling same as hover state)

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [ ] A designer has seen and approved my changes (tag `@LuukHorsmans` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
