### PR TITLE
Added min-width to fix rendering issue in firefox

### DIFF
--- a/src/components/TextField/style.tsx
+++ b/src/components/TextField/style.tsx
@@ -58,6 +58,7 @@ const StyledInput = withProps<InputProps, HTMLInputElement>(styled.input)`
     padding: 6px 12px;
     line-height: 1.572;
     outline: none;
+    min-width: 10px;
 
     ${({ theme, disabled }): string =>
         disabled

--- a/src/components/TextField/style.tsx
+++ b/src/components/TextField/style.tsx
@@ -58,7 +58,7 @@ const StyledInput = withProps<InputProps, HTMLInputElement>(styled.input)`
     padding: 6px 12px;
     line-height: 1.572;
     outline: none;
-    min-width: 10px;
+    min-width: 12px;
 
     ${({ theme, disabled }): string =>
         disabled


### PR DESCRIPTION
### This PR:

resolves #310

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- None

**Bugfixes/Changed internals** 🎈
- Added a min-width to the input field. Firefox has an internal/default minimal width that caused this issue. By setting it to a much lower value the issue is resolved.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
