### PR TITLE
Removed translate3d from Button idle state

### DIFF
--- a/src/components/Button/story.tsx
+++ b/src/components/Button/story.tsx
@@ -43,7 +43,8 @@ storiesOf('Button', module)
                         'primary',
                     ) as PropsType['variant']
                 }
-                href="http://www.google.com"
+                href="#"
+                target="_self"
                 title={text('title', 'Click me')}
                 disabled={boolean('disabled', false)}
                 compact={boolean('compact', false)}

--- a/src/components/Button/style.tsx
+++ b/src/components/Button/style.tsx
@@ -91,7 +91,7 @@ const StyledButton = withProps<ButtonPropsType>(styled.button)`
     position: relative;
     text-decoration: none;
     display: inline-block;
-    transform: translateZ(0) translate3d(0, 0, 0);
+    transform: none;
     transition: transform 0.1s, background 0.3s, box-shadow 0.1s, border 0.3s;
     padding: ${({ compact }): string => (compact ? '11px 12px' : '11px 24px')};
     font-family: ${({ theme }): string => theme.Button.common.fontFamily};


### PR DESCRIPTION
### This PR:

resolves #130 

With `translate3d`:
![schermafbeelding 2019-02-05 om 14 26 01](https://user-images.githubusercontent.com/10552400/52276764-506f3300-2953-11e9-9b60-ca91564cb889.png)

without `translate3d`:
![schermafbeelding 2019-02-05 om 14 25 40](https://user-images.githubusercontent.com/10552400/52276778-5cf38b80-2953-11e9-9026-8a339a7d24e7.png)

**Bugfixes/Changed internals** 🎈
- Button transform property is changed to `none` to fix Safari anti-aliasing issue

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
