### PR TITLE
Explicit state styling on (Icon)Button

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -123,15 +123,15 @@ const Button = styled(BareButton).attrs((props: PropsType) => {
             ${variant === 'plain' ? `text-decoration: ${theme.Button.plain.idle.textDecoration}` : ''}
 
             &:hover {
-                ${!loading ? hover : idle}
+                ${!loading && !disabled ? hover : idle}
             }
 
             &:focus {
-                ${!loading ? focus : idle}
+                ${!loading && !disabled ? focus : idle}
             }
 
             &:active {
-                ${!loading ? active : idle}
+                ${!loading && !disabled ? active : idle}
             }
 
             &::before {

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -91,40 +91,47 @@ const Button = styled(BareButton).attrs((props: PropsType) => {
     };
 })<PropsType>`
     ${({ theme, variant, compact, disabled, loading }): string => {
+        const idle = `
+            background-color: ${theme.Button[variant].idle.backgroundColor};
+            box-shadow: ${theme.Button[variant].idle.boxShadow};
+            color: ${theme.Button[variant].idle.color};
+        `;
+
         const hover = `
             background-color: ${theme.Button[variant].hover.backgroundColor};
             box-shadow: ${theme.Button[variant].hover.boxShadow};
+            color: ${theme.Button[variant].hover.color};
         `;
 
         const active = `
             transform: translateY(2px);
             background-color: ${theme.Button[variant].active.backgroundColor};
             box-shadow: ${theme.Button[variant].active.boxShadow};
+            color: ${theme.Button[variant].active.color};
         `;
 
         const focus = `
             background-color: ${theme.Button[variant].focus.backgroundColor};
             box-shadow: ${theme.Button[variant].focus.boxShadow};
+            color: ${theme.Button[variant].focus.color};
         `;
 
         return `
+            ${idle}
             padding: 11px ${compact ? ' 12px' : '24px'};
-            color: ${disabled ? theme.Button.disabled.color : theme.Button[variant].idle.color};
-            background-color: ${theme.Button[variant].idle.backgroundColor};
             border-radius: ${theme.Button.common.borderRadius};
-            box-shadow: ${theme.Button[variant].idle.boxShadow}
             ${variant === 'plain' ? `text-decoration: ${theme.Button.plain.idle.textDecoration}` : ''}
 
             &:hover {
-                ${!loading ? hover : ''}
+                ${!loading ? hover : idle}
             }
 
             &:focus {
-                ${focus}
+                ${!loading ? focus : idle}
             }
 
             &:active {
-                ${!loading ? active : ''}
+                ${!loading ? active : idle}
             }
 
             &::before {

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -51,7 +51,7 @@ const IconButton = styled(BareButton).attrs((props: PropsType) => {
 
     return { children };
 })<PropsType>`
-    ${({ theme, variant, loading }): string => {
+    ${({ theme, variant, loading, disabled }): string => {
         const buttonVariant = variant ? variant : 'primary';
 
         const idle = `
@@ -83,15 +83,15 @@ const IconButton = styled(BareButton).attrs((props: PropsType) => {
             padding: 9px;
 
             &:hover {
-                ${!loading ? hover : idle}
+                ${!loading && !disabled ? hover : idle}
             }
 
             &:focus {
-                ${!loading ? focus : idle}
+                ${!loading && !disabled ? focus : idle}
             }
 
             &:active {
-                ${!loading ? active : idle}
+                ${!loading && !disabled ? active : idle}
             }
     `;
     }}

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -8,14 +8,21 @@ import Box from '../Box';
 import { MediumIcons } from '../Icon/types';
 import { withTheme } from 'styled-components';
 
+type CommonType = {
+    backgroundColor: string;
+    color: string;
+};
+
+type ComponentStateTypes = {
+    idle: CommonType;
+    hover: CommonType;
+    focus: CommonType;
+    active: CommonType;
+};
+
 type IconButtonThemeType = {
-    primary: {
-        color: string;
-        backgroundColor: string;
-    };
-    destructive: {
-        color: string;
-    };
+    primary: ComponentStateTypes;
+    destructive: ComponentStateTypes;
 };
 
 type PropsType = BareButtonPropsType & {
@@ -47,20 +54,48 @@ const IconButton = styled(BareButton).attrs((props: PropsType) => {
 
     return { children };
 })<PropsType>`
-    padding: 9px;
-    color: ${({ theme }) => theme.IconButton.primary.color};
-    background-color: ${({ theme }) => theme.IconButton.primary.backgroundColor};
-    transform: none;
+    ${({ theme, variant, loading }): string => {
+        const idle = `
+            transform: none;
+            background-color: ${theme.IconButton[variant].idle.backgroundColor};
+            color: ${theme.IconButton[variant].idle.color};
+        `;
 
-    &:hover {
-        ${({ loading }) => (!loading ? 'transform: scale(1.1);' : '')};
-        ${({ variant, theme, loading }) =>
-            variant === 'destructive' && !loading ? `color: ${theme.IconButton.destructive.color}` : ''};
-    }
+        const hover = `
+            transform: scale(1.1);
+            background-color: ${theme.IconButton[variant].hover.backgroundColor};
+            color: ${theme.IconButton[variant].hover.color};
+        `;
 
-    &:active {
-        ${({ loading }) => (!loading ? 'transform: scale(0.9);' : '')};
-    }
+        const active = `
+            transform: scale(0.9);
+            background-color: ${theme.IconButton[variant].active.backgroundColor};
+            color: ${theme.IconButton[variant].active.color};
+        `;
+
+        const focus = `
+            transform: scale(1.1);
+            background-color: ${theme.IconButton[variant].focus.backgroundColor};
+            color: ${theme.IconButton[variant].focus.color};
+        `;
+
+        return `
+            ${idle}
+            padding: 9px;
+
+            &:hover {
+                ${!loading ? hover : idle}
+            }
+
+            &:focus {
+                ${!loading ? focus : idle}
+            }
+
+            &:active {
+                ${!loading ? active : idle}
+            }
+    `;
+    }}
 `;
 
 export default withTheme(IconButton);

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -9,15 +9,12 @@ import { MediumIcons } from '../Icon/types';
 import { withTheme } from 'styled-components';
 
 type CommonType = {
-    backgroundColor: string;
     color: string;
 };
 
 type ComponentStateTypes = {
     idle: CommonType;
     hover: CommonType;
-    focus: CommonType;
-    active: CommonType;
 };
 
 type IconButtonThemeType = {
@@ -28,7 +25,7 @@ type IconButtonThemeType = {
 type PropsType = BareButtonPropsType & {
     theme?: ThemeType;
     icon: keyof typeof MediumIcons;
-    variant: 'primary' | 'destructive';
+    variant?: 'primary' | 'destructive';
 };
 
 const IconButton = styled(BareButton).attrs((props: PropsType) => {
@@ -55,28 +52,30 @@ const IconButton = styled(BareButton).attrs((props: PropsType) => {
     return { children };
 })<PropsType>`
     ${({ theme, variant, loading }): string => {
+        const buttonVariant = variant ? variant : 'primary';
+
         const idle = `
             transform: none;
-            background-color: ${theme.IconButton[variant].idle.backgroundColor};
-            color: ${theme.IconButton[variant].idle.color};
+            background-color: transparent;
+            color: ${theme.IconButton[buttonVariant].idle.color};
         `;
 
         const hover = `
             transform: scale(1.1);
-            background-color: ${theme.IconButton[variant].hover.backgroundColor};
-            color: ${theme.IconButton[variant].hover.color};
+            background-color: transparent;
+            color: ${theme.IconButton[buttonVariant].hover.color};
         `;
 
         const active = `
             transform: scale(0.9);
-            background-color: ${theme.IconButton[variant].active.backgroundColor};
-            color: ${theme.IconButton[variant].active.color};
+            background-color: transparent;
+            color: ${theme.IconButton[buttonVariant].hover.color};
         `;
 
         const focus = `
             transform: scale(1.1);
-            background-color: ${theme.IconButton[variant].focus.backgroundColor};
-            color: ${theme.IconButton[variant].focus.color};
+            background-color: transparent;
+            color: ${theme.IconButton[buttonVariant].hover.color};
         `;
 
         return `

--- a/src/components/IconButton/story.tsx
+++ b/src/components/IconButton/story.tsx
@@ -14,7 +14,8 @@ storiesOf('IconButton', module).add('Default', () => {
         <IconButton
             icon={select('icon', mediumIconKeys, 'cart') as PropsType['icon']}
             loading={boolean('loading', false)}
-            variant={select('variant', ['default', 'destructive'], 'default') as PlainPropsType['variant']}
+            disabled={boolean('disabled', false)}
+            variant={select('variant', ['primary', 'destructive'], 'primary') as PlainPropsType['variant']}
             title={text('title', 'Click me')}
         />
     );

--- a/src/components/IconButton/story.tsx
+++ b/src/components/IconButton/story.tsx
@@ -2,7 +2,7 @@ import { boolean, select, text } from '@storybook/addon-knobs/react';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import { PropsType } from '.';
-import IconButton, { PropsType as PlainPropsType } from '../IconButton';
+import IconButton from '../IconButton';
 import { MediumIcons } from '../Icon/types';
 
 /* tslint:disable */
@@ -15,7 +15,7 @@ storiesOf('IconButton', module).add('Default', () => {
             icon={select('icon', mediumIconKeys, 'cart') as PropsType['icon']}
             loading={boolean('loading', false)}
             disabled={boolean('disabled', false)}
-            variant={select('variant', ['primary', 'destructive'], 'primary') as PlainPropsType['variant']}
+            variant={select('variant', ['primary', 'destructive'], 'primary')}
             title={text('title', 'Click me')}
         />
     );

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -339,37 +339,17 @@ const theme: ThemeType = {
     IconButton: {
         primary: {
             idle: {
-                backgroundColor: 'transparent',
-                color: grey.base,
+                color: grey.lighter1,
             },
             hover: {
-                backgroundColor: 'transparent',
-                color: grey.darker1,
-            },
-            focus: {
-                backgroundColor: 'transparent',
-                color: grey.darker1,
-            },
-            active: {
-                backgroundColor: 'transparent',
-                color: grey.darker1,
+                color: grey.base,
             },
         },
         destructive: {
             idle: {
-                backgroundColor: 'transparent',
-                color: red.base,
+                color: grey.lighter1,
             },
             hover: {
-                backgroundColor: 'transparent',
-                color: red.base,
-            },
-            focus: {
-                backgroundColor: 'transparent',
-                color: red.base,
-            },
-            active: {
-                backgroundColor: 'transparent',
                 color: red.base,
             },
         },

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -338,11 +338,40 @@ const theme: ThemeType = {
     ],
     IconButton: {
         primary: {
-            color: grey.darker1,
-            backgroundColor: 'transparent',
+            idle: {
+                backgroundColor: 'transparent',
+                color: grey.base,
+            },
+            hover: {
+                backgroundColor: 'transparent',
+                color: grey.darker1,
+            },
+            focus: {
+                backgroundColor: 'transparent',
+                color: grey.darker1,
+            },
+            active: {
+                backgroundColor: 'transparent',
+                color: grey.darker1,
+            },
         },
         destructive: {
-            color: red.base,
+            idle: {
+                backgroundColor: 'transparent',
+                color: red.base,
+            },
+            hover: {
+                backgroundColor: 'transparent',
+                color: red.base,
+            },
+            focus: {
+                backgroundColor: 'transparent',
+                color: red.base,
+            },
+            active: {
+                backgroundColor: 'transparent',
+                color: red.base,
+            },
         },
     },
     Illustration: {


### PR DESCRIPTION
### This PR:

Resolves: #313

The `IconButton` in the `1.x` branch had no focus state styling. Therefor it inherited styling which is commonly defined in applications, like `background` and `color`. It now has explicit styling for hover, focus, and active states. This inludes a fallback to `idle` when in a `loading` state, which was undefined before. This is fallback is also applied to `Button`.

**Breaking changes** 🔥
- Adjusted IconButtonThemeType

**Bugfixes/Changed internals** 🎈
- Button & IconButton have explicit styling

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
