### PR TITLE
Fixed rem based dots

### DIFF
--- a/src/components/Range/style.tsx
+++ b/src/components/Range/style.tsx
@@ -73,8 +73,8 @@ const StyledWrapper = withProps<wrapperProps, HTMLDivElement>(styled.div)`
             background: ${({ theme }): string => theme.Range.default.slider.background};
             border: ${({ theme }): string => theme.Range.default.slider.border};
             margin-top: -14px;
-            width: 18px;
-            height: 18px;
+            width: 16px;
+            height: 16px;
             transition: none;
         }
 

--- a/src/components/Range/style.tsx
+++ b/src/components/Range/style.tsx
@@ -73,6 +73,8 @@ const StyledWrapper = withProps<wrapperProps, HTMLDivElement>(styled.div)`
             background: ${({ theme }): string => theme.Range.default.slider.background};
             border: ${({ theme }): string => theme.Range.default.slider.border};
             margin-top: -14px;
+            width: 18px;
+            height: 18px;
             transition: none;
         }
 


### PR DESCRIPTION
### This PR:

Dot where sized by REM, which made them have an alternative size based on font-size used in applications.

**Bugfixes/Changed internals** 🎈
- The dots on the `Range` component now het a fixed size.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
