### PR TITLE
Toaster : Added pointer events to fullscreen wrapper

### DIFF
--- a/src/components/Toast/style.tsx
+++ b/src/components/Toast/style.tsx
@@ -23,6 +23,7 @@ const StyledToastWrapper = styled.div`
     display: flex;
     justify-content: center;
     align-items: flex-start;
+    pointer-events: none;
 `;
 
 const StyledToast = withProps<ToastPropsType, HTMLDivElement>(styled.div)`

--- a/src/components/Toast/style.tsx
+++ b/src/components/Toast/style.tsx
@@ -37,6 +37,7 @@ const StyledToast = withProps<ToastPropsType, HTMLDivElement>(styled.div)`
     border-radius: ${({ theme }): string => theme.Toaster.borderRadius}
     background-color: ${({ theme }): string => theme.Toaster.backgroundColor}
     border-left: ${({ severity, theme }): string => `4px solid ${theme.Text.severity[severity].color};`}
+    pointer-events: auto;
 
     a {
        ${LinkStyles}


### PR DESCRIPTION
### This PR:
resolves SCS-340

**Breaking changes** 🔥
- none

**Backwards compatible additions** ✨
- none

**Bugfixes/Changed internals** 🎈
- The wrapper element gets a `pointer-events: none` to prevent getting stuck in IE11.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
