### PR TITLE
Improved keyboard navigation

### DIFF
--- a/src/components/Range/index.tsx
+++ b/src/components/Range/index.tsx
@@ -155,11 +155,16 @@ class Range extends Component<PropsType, StateType> {
                         value={this.props.value}
                         disabled={this.props.disabled}
                         onChange={(values): void => {
-                            this.setState({
-                                inputFocus: false,
-                                inputValues: values as RangeType,
-                            });
-                            if (this.props.onChange !== undefined) this.props.onChange(values as RangeType);
+                            if (
+                                isWithinRange(this.props.minLimit, this.getMaxLowValue(), (values as RangeType).min) &&
+                                isWithinRange(this.getMinHighValue(), this.props.maxLimit, (values as RangeType).max)
+                            ) {
+                                this.setState({
+                                    inputFocus: false,
+                                    inputValues: values as RangeType,
+                                });
+                                if (this.props.onChange !== undefined) this.props.onChange(values as RangeType);
+                            }
                         }}
                         minValue={this.props.minLimit}
                         maxValue={this.props.maxLimit}

--- a/src/components/Table/TableHeaders/index.tsx
+++ b/src/components/Table/TableHeaders/index.tsx
@@ -123,6 +123,15 @@ class Headers extends Component<PropsType, StateType> {
                         ? () => this.cycleSorting(key)
                         : undefined
                 }
+                onKeyDown={(event: React.KeyboardEvent) => {
+                    if (
+                        this.props.onSort !== undefined &&
+                        this.state.columns[key].sorting !== undefined &&
+                        event.key === 'Enter'
+                    )
+                        this.cycleSorting(key);
+                }}
+                tabIndex={0}
             >
                 <Box
                     alignItems="center"


### PR DESCRIPTION
### This PR:

To (slighty) improve a11y I checked which components are usable with only the keyboard. All of them were apart from `Table` and there was a slight bug in `Range` when using the keyboard. Both of these issues are fixed in this PR.

**Bugfixes/Changed internals** 🎈
- It is now possible to sort a `Table` using only the keyboard
- It is no longer possible to enter a value outside of the min/max limit on the Range using the keyboard

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
