### PR TITLE
Added test-id to multiple components

### DIFF
--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -20,7 +20,7 @@ type VariantStyleType = {
     fontFamily: string;
 };
 
-const StyledBadge = styled.div<PropsType>`
+const Badge = styled.div<PropsType>`
     display: inline-block;
     box-sizing: border-box;
     min-width: 18px;
@@ -41,5 +41,5 @@ const StyledBadge = styled.div<PropsType>`
     white-space: nowrap;
 `;
 
-export default StyledBadge;
+export default Badge;
 export { PropsType, BadgeThemeType };

--- a/src/components/Badge/test.tsx
+++ b/src/components/Badge/test.tsx
@@ -21,4 +21,10 @@ describe('Badge', () => {
         expect(errorBadge).toHaveStyleRule('background', '#ed2157');
         expect(infoBadge).toHaveStyleRule('background', '#88979d');
     });
+
+    it('should be testable with a testid', () => {
+        const component = mountWithTheme(<Badge data-testid="badge" />);
+
+        expect(component.find('[data-testid="box"]').hostNodes()).toHaveLength(1);
+    });
 });

--- a/src/components/Badge/test.tsx
+++ b/src/components/Badge/test.tsx
@@ -25,6 +25,6 @@ describe('Badge', () => {
     it('should be testable with a testid', () => {
         const component = mountWithTheme(<Badge data-testid="badge" />);
 
-        expect(component.find('[data-testid="box"]').hostNodes()).toHaveLength(1);
+        expect(component.find('[data-testid="badge"]').hostNodes()).toHaveLength(1);
     });
 });

--- a/src/components/Box/test.tsx
+++ b/src/components/Box/test.tsx
@@ -142,4 +142,10 @@ describe('Box', () => {
 
         expect(component).toHaveStyleRule('min-width', '50px');
     });
+
+    it('should be testable with a testid', () => {
+        const component = mount(<Box data-testid="box" />);
+
+        expect(component.find('[data-testid="box"]').hostNodes()).toHaveLength(1);
+    });
 });

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -26,7 +26,7 @@ const Breadcrumbs: FunctionComponent<PropsType> = (props): JSX.Element => (
                         data-testid={props['data-testid'] ? `${props['data-testid']}-crumb-${index}` : undefined}
                     >
                         <Text>
-                            {(breadcrumb.url === undefined && <span aria-current="page">breadcrumb.name</span>) || (
+                            {(breadcrumb.url === undefined && <span aria-current="page">{breadcrumb.name}</span>) || (
                                 <Link title={breadcrumb.name} href={breadcrumb.url}>
                                     {breadcrumb.name}
                                 </Link>

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -8,6 +8,7 @@ import chrevronRight from '../../assets/icons/chevron-right-small.svg';
 
 type PropsType = {
     breadcrumbs: Array<BreadcrumbType>;
+    'data-testid'?: string;
 };
 
 type BreadcrumbType = {
@@ -15,31 +16,34 @@ type BreadcrumbType = {
     name: string;
 };
 
-const Breadcrumbs: FunctionComponent<PropsType> = (props): JSX.Element => {
-    const renderBreadcrumb = (breadcrumb: BreadcrumbType, index: number): JSX.Element => (
-        <StyledBreadcrumb key={index} aria-label="Breadcrumb">
-            <Text>
-                {(breadcrumb.url === undefined && breadcrumb.name) || (
-                    <Link title={breadcrumb.name} href={breadcrumb.url}>
-                        {breadcrumb.name}
-                    </Link>
-                )}
-            </Text>
-            {index < props.breadcrumbs.length - 1 && (
-                <Box margin={[0, 9]}>
-                    <Text severity="info">
-                        <Icon icon={chrevronRight} size="small" />
-                    </Text>
-                </Box>
+const Breadcrumbs: FunctionComponent<PropsType> = (props): JSX.Element => (
+    <nav aria-label="Breadcrumb">
+        <StyledBreadcrumbs data-testid={props['data-testid']}>
+            {props.breadcrumbs.map(
+                (breadcrumb, index): JSX.Element => (
+                    <StyledBreadcrumb
+                        key={index}
+                        data-testid={props['data-testid'] ? `${props['data-testid']}-crumb-${index}` : undefined}
+                    >
+                        <Text>
+                            {(breadcrumb.url === undefined && <span aria-current="page">breadcrumb.name</span>) || (
+                                <Link title={breadcrumb.name} href={breadcrumb.url}>
+                                    {breadcrumb.name}
+                                </Link>
+                            )}
+                        </Text>
+                        {index < props.breadcrumbs.length - 1 && (
+                            <Box margin={[0, 9]}>
+                                <Text severity="info">
+                                    <Icon icon={chrevronRight} size="small" />
+                                </Text>
+                            </Box>
+                        )}
+                    </StyledBreadcrumb>
+                ),
             )}
-        </StyledBreadcrumb>
-    );
-
-    return (
-        <nav aria-label="Breadcrumb">
-            <StyledBreadcrumbs>{props.breadcrumbs.map(renderBreadcrumb)}</StyledBreadcrumbs>
-        </nav>
-    );
-};
+        </StyledBreadcrumbs>
+    </nav>
+);
 
 export default Breadcrumbs;

--- a/src/components/Breadcrumbs/test.tsx
+++ b/src/components/Breadcrumbs/test.tsx
@@ -6,9 +6,9 @@ import { StyledBreadcrumb } from './style';
 describe('Breadcrumbs', () => {
     it('renders breadcrumbs with and without urls', () => {
         const crumbs = [
-            { url: 'http://www.google.com', name: 'dashboard' },
-            { url: 'http://www.google.com', name: 'level 1' },
-            { name: 'no url' },
+            { url: 'http://www.google.com', name: 'A' },
+            { url: 'http://www.google.com', name: 'B' },
+            { name: 'C' },
         ];
 
         const component = mountWithTheme(<Breadcrumbs breadcrumbs={crumbs} />);
@@ -18,16 +18,31 @@ describe('Breadcrumbs', () => {
                 .find('a')
                 .first()
                 .text(),
-        ).toEqual('dashboard');
+        ).toEqual('A');
 
         expect(component.find(StyledBreadcrumb).length).toBe(3);
     });
 
     it('should not render an anchor tag if no url is provided', () => {
-        const crumbs = [{ name: 'no url' }];
+        const crumbs = [{ name: 'A' }];
         const component = mountWithTheme(<Breadcrumbs breadcrumbs={crumbs} />);
 
         expect(component.find(StyledBreadcrumb).exists()).toEqual(true);
         expect(component.find('a').exists()).toEqual(false);
+    });
+
+    it('should be testable with testids', () => {
+        const crumbs = [
+            { url: 'http://www.google.com', name: 'A' },
+            { url: 'http://www.google.com', name: 'B' },
+            { name: 'C' },
+        ];
+
+        const component = mountWithTheme(<Breadcrumbs data-testid="breadcrumbs" breadcrumbs={crumbs} />);
+
+        expect(component.find('[data-testid="breadcrumbs"]').hostNodes()).toHaveLength(1);
+        expect(component.find('[data-testid="breadcrumbs-crumb-0"]').hostNodes()).toHaveLength(1);
+        expect(component.find('[data-testid="breadcrumbs-crumb-1"]').hostNodes()).toHaveLength(1);
+        expect(component.find('[data-testid="breadcrumbs-crumb-2"]').hostNodes()).toHaveLength(1);
     });
 });

--- a/src/components/Button/base/index.tsx
+++ b/src/components/Button/base/index.tsx
@@ -11,7 +11,7 @@ type PropsType = {
     disabled?: boolean;
     id?: string;
     loading?: boolean;
-    'data-test-id'?: string;
+    'data-testid'?: string;
     onClick?(): void;
 };
 
@@ -33,7 +33,7 @@ const ButtonBase: FunctionComponent<PropsType> = (props): JSX.Element => {
                 disabled={props.disabled}
                 id={props.id}
                 loading={props.loading}
-                data-test-id={props['data-test-id']}
+                data-testid={props['data-testid']}
             >
                 {props.children}
             </StyledAnchor>
@@ -49,7 +49,7 @@ const ButtonBase: FunctionComponent<PropsType> = (props): JSX.Element => {
             disabled={props.disabled}
             id={props.id}
             loading={props.loading}
-            data-test-id={props['data-test-id']}
+            data-testid={props['data-testid']}
         >
             {props.children}
         </StyledButton>

--- a/src/components/Button/base/index.tsx
+++ b/src/components/Button/base/index.tsx
@@ -11,6 +11,7 @@ type PropsType = {
     disabled?: boolean;
     id?: string;
     loading?: boolean;
+    'data-test-id'?: string;
     onClick?(): void;
 };
 
@@ -32,6 +33,7 @@ const ButtonBase: FunctionComponent<PropsType> = (props): JSX.Element => {
                 disabled={props.disabled}
                 id={props.id}
                 loading={props.loading}
+                data-test-id={props['data-test-id']}
             >
                 {props.children}
             </StyledAnchor>
@@ -47,6 +49,7 @@ const ButtonBase: FunctionComponent<PropsType> = (props): JSX.Element => {
             disabled={props.disabled}
             id={props.id}
             loading={props.loading}
+            data-test-id={props['data-test-id']}
         >
             {props.children}
         </StyledButton>

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,7 +1,7 @@
 import React, { Children, ReactNode } from 'react';
 import styled from '../../utility/_styled';
-import BareButton, { PropsType as BareButtonPropsType } from './base';
 import Icon from '../Icon';
+import BareButton, { PropsType as BaseButtonPropsType } from './base';
 import Box from '../Box';
 import Spinner from '../Spinner';
 
@@ -49,7 +49,7 @@ type ButtonThemeType = {
     };
 };
 
-type PropsType = BareButtonPropsType & {
+type PropsType = BaseButtonPropsType & {
     loading?: boolean;
     variant: 'primary' | 'destructive' | 'warning' | 'secondary' | 'plain';
     compact?: boolean;

--- a/src/components/Button/test.tsx
+++ b/src/components/Button/test.tsx
@@ -4,6 +4,7 @@ import Button from '.';
 import MosTheme from '../../themes/MosTheme';
 import { mountWithTheme } from '../../utility/_styled/testing';
 import 'jest-styled-components';
+import console = require('console');
 
 describe('Button', () => {
     it('should render a link with children', () => {
@@ -81,5 +82,15 @@ describe('Button', () => {
         );
 
         expect(component.find(Button)).toHaveStyleRule('padding', '11px 12px');
+    });
+
+    it('should be testable with a test-id', () => {
+        const component = mount(
+            <MosTheme>
+                <Button variant="primary" title="button title" data-test-id="foo" />
+            </MosTheme>,
+        );
+
+        expect(component.find('[data-test-id="foo"]').hostNodes().length).toBe(1);
     });
 });

--- a/src/components/Button/test.tsx
+++ b/src/components/Button/test.tsx
@@ -4,7 +4,6 @@ import Button from '.';
 import MosTheme from '../../themes/MosTheme';
 import { mountWithTheme } from '../../utility/_styled/testing';
 import 'jest-styled-components';
-import console = require('console');
 
 describe('Button', () => {
     it('should render a link with children', () => {
@@ -87,10 +86,10 @@ describe('Button', () => {
     it('should be testable with a test-id', () => {
         const component = mount(
             <MosTheme>
-                <Button variant="primary" title="button title" data-test-id="foo" />
+                <Button variant="primary" title="button title" data-testid="foo" />
             </MosTheme>,
         );
 
-        expect(component.find('[data-test-id="foo"]').hostNodes().length).toBe(1);
+        expect(component.find('[data-testid="foo"]').hostNodes().length).toBe(1);
     });
 });

--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -3,13 +3,21 @@ import Box from '../Box';
 
 type PropsType = {
     stacked?: boolean;
+    'data-tesid'?: string;
 };
 
 const ButtonGroup: FunctionComponent<PropsType> = (props): JSX.Element => {
     const direction = props.stacked ? 'column' : 'row-reverse';
 
     return (
-        <Box direction={direction} justifyContent="flex-start" alignItems="stretch" wrap margin={[-6]}>
+        <Box
+            direction={direction}
+            justifyContent="flex-start"
+            alignItems="stretch"
+            wrap
+            margin={[-6]}
+            data-testid={props['data-tesid']}
+        >
             {Children.map(
                 props.children,
                 (child): JSX.Element => (

--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -3,7 +3,7 @@ import Box from '../Box';
 
 type PropsType = {
     stacked?: boolean;
-    'data-tesid'?: string;
+    'data-testid'?: string;
 };
 
 const ButtonGroup: FunctionComponent<PropsType> = (props): JSX.Element => {
@@ -16,7 +16,7 @@ const ButtonGroup: FunctionComponent<PropsType> = (props): JSX.Element => {
             alignItems="stretch"
             wrap
             margin={[-6]}
-            data-testid={props['data-tesid']}
+            data-testid={props['data-testid']}
         >
             {Children.map(
                 props.children,

--- a/src/components/ButtonGroup/test.tsx
+++ b/src/components/ButtonGroup/test.tsx
@@ -40,4 +40,10 @@ describe('ButtonGroup', () => {
 
         expect(component.find(Button).length).toBe(1);
     });
+
+    it('should be testable with a testid', () => {
+        const component = mountWithTheme(<ButtonGroup data-testid="buttongroup" />);
+
+        expect(component.find('[data-testid="buttongroup"]').hostNodes()).toHaveLength(1);
+    });
 });

--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -16,6 +16,7 @@ type PropsType = {
     value: string;
     name: string;
     id?: string;
+    'data-testid'?: string;
     onChange(change: { checked: boolean | 'indeterminate'; event: MouseEvent<HTMLDivElement> }): void;
 };
 
@@ -48,6 +49,7 @@ class Checkbox extends Component<PropsType, StateType> {
                 elementFocus={this.state.focus}
                 disabled={this.props.disabled}
                 error={this.props.error}
+                data-testid={this.props['data-testid']}
             >
                 <Box justifyContent="center" alignItems="center" height="100%">
                     {this.props.checked === true && <Icon size="small" color="#fff" icon={checkmark} />}

--- a/src/components/Checkbox/test.tsx
+++ b/src/components/Checkbox/test.tsx
@@ -76,4 +76,12 @@ describe('Checkbox', () => {
             `1px solid ${mosTheme.Checkbox.error.borderColor}`,
         );
     });
+
+    it('should be testable with a testid', () => {
+        const component = mountWithTheme(
+            <Checkbox checked onChange={jest.fn()} name="demo" value="A" data-testid="checkbox" />,
+        );
+
+        expect(component.find('[data-testid="checkbox"]').hostNodes()).toHaveLength(1);
+    });
 });

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -62,7 +62,7 @@ const EmptyState: FunctionComponent<PropsType> = (props): JSX.Element => {
     }
 
     return (
-        <Box direction="column" alignItems="center" justifyContent="space-around">
+        <Box direction="column" alignItems="center" justifyContent="space-around" data-testid={props['data-testid']}>
             {illustration}
             <Box padding={[18, 0, 0, 0]}>{title}</Box>
             <Box margin={[12, 0, 0, 0]}>{message}</Box>

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -11,6 +11,7 @@ type PropsType = {
     message: string | ReactNode;
     horizontal?: boolean;
     button?: ReactNode;
+    'data-testid'?: string;
 };
 
 const branchString = (value: string | ReactNode, node: (value: string) => ReactNode): ReactNode => {
@@ -42,7 +43,7 @@ const EmptyState: FunctionComponent<PropsType> = (props): JSX.Element => {
 
     if (props.horizontal) {
         return (
-            <Box direction="row" alignItems="center" justifyContent="space-around">
+            <Box direction="row" alignItems="center" justifyContent="space-around" data-testid={props['data-testid']}>
                 <Box basis="120px" shrink={0} grow={25}>
                     {illustration}
                 </Box>

--- a/src/components/EmptyState/test.tsx
+++ b/src/components/EmptyState/test.tsx
@@ -59,4 +59,10 @@ describe('EmptyState', () => {
                 .prop('direction'),
         ).toEqual('row');
     });
+
+    it('should be testable with a testid', () => {
+        const component = mountWithTheme(<EmptyState title="foo" message="bar" data-testid="empty" />);
+
+        expect(component.find('[data-testid="empty"]').hostNodes()).toHaveLength(1);
+    });
 });

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -5,7 +5,7 @@ type PropsType = {
     href?: string;
     title: string;
     target?: '_blank' | '_self';
-    'data-test-id'?: string;
+    'data-testid'?: string;
     onClick?(): void;
 };
 
@@ -24,7 +24,7 @@ const Link: FunctionComponent<PropsType> = (props): JSX.Element => {
                 title={props.title}
                 target={props.target}
                 href={props.href}
-                data-test-id={props['data-test-id']}
+                data-testid={props['data-testid']}
             >
                 {Children.count(props.children) > 0 ? props.children : props.title}
             </StyledLink>
@@ -32,7 +32,7 @@ const Link: FunctionComponent<PropsType> = (props): JSX.Element => {
     }
 
     return (
-        <StyledButton type="button" onClick={clickAction} title={props.title} data-test-id={props['data-test-id']}>
+        <StyledButton type="button" onClick={clickAction} title={props.title} data-testid={props['data-testid']}>
             {Children.count(props.children) > 0 ? props.children : props.title}
         </StyledButton>
     );

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -5,6 +5,7 @@ type PropsType = {
     href?: string;
     title: string;
     target?: '_blank' | '_self';
+    'data-test-id'?: string;
     onClick?(): void;
 };
 
@@ -19,14 +20,19 @@ const Link: FunctionComponent<PropsType> = (props): JSX.Element => {
 
     if (isLink) {
         return (
-            <StyledLink title={props.title} target={props.target} href={props.href}>
+            <StyledLink
+                title={props.title}
+                target={props.target}
+                href={props.href}
+                data-test-id={props['data-test-id']}
+            >
                 {Children.count(props.children) > 0 ? props.children : props.title}
             </StyledLink>
         );
     }
 
     return (
-        <StyledButton type="button" onClick={clickAction} title={props.title}>
+        <StyledButton type="button" onClick={clickAction} title={props.title} data-test-id={props['data-test-id']}>
             {Children.count(props.children) > 0 ? props.children : props.title}
         </StyledButton>
     );

--- a/src/components/Link/test.tsx
+++ b/src/components/Link/test.tsx
@@ -31,4 +31,11 @@ describe('Link', () => {
 
         expect(fn).not.toThrow();
     });
+
+    it('should be testable with a test-id', () => {
+        const clickMock = jest.fn();
+        const component = mountWithTheme(<Link title="title" onClick={clickMock} data-test-id="foo" />);
+
+        expect(component.find('[data-test-id="foo"]').hostNodes().length).toBe(1);
+    });
 });

--- a/src/components/Link/test.tsx
+++ b/src/components/Link/test.tsx
@@ -34,8 +34,8 @@ describe('Link', () => {
 
     it('should be testable with a test-id', () => {
         const clickMock = jest.fn();
-        const component = mountWithTheme(<Link title="title" onClick={clickMock} data-test-id="foo" />);
+        const component = mountWithTheme(<Link title="title" onClick={clickMock} data-testid="foo" />);
 
-        expect(component.find('[data-test-id="foo"]').hostNodes().length).toBe(1);
+        expect(component.find('[data-testid="foo"]').hostNodes().length).toBe(1);
     });
 });

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -51,12 +51,12 @@ class Modal extends Component<PropsType> {
 
     public componentDidMount(): void {
         document.addEventListener('mousedown', this.handleClickOutside, false);
-        document.addEventListener('keydown', (event: KeyboardEvent) => this.handleKeyDown(event), false);
+        document.addEventListener('keydown', this.handleKeyDown, false);
     }
 
     public componentWillUnmount(): void {
         document.removeEventListener('mousedown', this.handleClickOutside, false);
-        document.removeEventListener('keydown', (event: KeyboardEvent) => this.handleKeyDown(event), false);
+        document.removeEventListener('keydown', this.handleKeyDown, false);
     }
 
     public render(): JSX.Element {

--- a/src/components/Select/Option/index.tsx
+++ b/src/components/Select/Option/index.tsx
@@ -11,6 +11,7 @@ type PropsType = {
     isSelected: boolean;
     isTargeted: boolean;
     content?: JSX.Element;
+    'data-testid'?: string;
     onClick(): void;
     onMouseEnter(): void;
 };
@@ -34,6 +35,7 @@ const Option: FunctionComponent<PropsType> = (props): JSX.Element => {
             onClick={clickAction}
             onMouseEnter={hoverAction}
             aria-selected={props.isSelected}
+            data-testid={props['data-testid']}
         >
             <Box padding={trbl(6, 18)}>
                 {(props.content !== undefined && props.content) || (

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -200,27 +200,21 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
                 onFocus={this.handleFocus}
                 onBlur={this.handleBlur}
                 tabIndex={this.props.disabled ? -1 : 0}
-<<<<<<< HEAD
                 role="combobox"
                 aria-label={'select'}
                 aria-expanded={this.state.isOpen}
-=======
                 data-testid={this.props['data-testid']}
->>>>>>> a551f43... Added id to Select
             >
                 <StyledInput
                     open={this.state.isOpen}
                     hasFocus={this.state.hasFocus}
                     disabled={!this.props.disabled ? false : this.props.disabled}
                     ref={this.inputWrapperRef}
-<<<<<<< HEAD
                     role="searchbox"
                     aria-autocomplete="list"
                     aria-controls={this.state.isOpen ? 'select-window' : undefined}
-=======
                     data-testid={this.props['data-testid'] ? `${this.props['data-testid']}-input` : undefined}
                     onClick={!this.state.isOpen ? this.open : undefined}
->>>>>>> a551f43... Added id to Select
                 >
                     <Box alignItems="stretch">
                         {(this.state.isOpen && (
@@ -287,15 +281,12 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
                                 : undefined
                         }
                         inputHeight={this.state.inputHeight}
-<<<<<<< HEAD
                         role="listbox"
-=======
                         data-testid={
                             this.props['data-testid']
                                 ? `${this.props['data-testid']}-window${this.state.isOpen ? '-open' : '-closed'}`
                                 : undefined
                         }
->>>>>>> a551f43... Added id to Select
                     >
                         <ScrollBox autoHideScrollBar={false} showInsetShadow={false}>
                             <div style={{ overflow: 'hidden', display: this.state.isOpen ? 'block' : 'none' }}>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -38,6 +38,7 @@ type PropsType<GenericOptionType extends OptionBaseType> = {
     options: Array<GenericOptionType>;
     emptyText: string;
     disabled?: boolean;
+    'data-testid'?: string;
     onChange(value: string): void;
     renderOption?(option: GenericOptionType, state: OptionStateType): JSX.Element;
     renderSelected?(option: GenericOptionType): JSX.Element;
@@ -126,7 +127,9 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
     };
 
     private handleFocus = (): void => {
-        this.setState({ hasFocus: true });
+        if (!this.props.disabled) {
+            this.setState({ hasFocus: true });
+        }
     };
 
     private handleBlur = (): void => {
@@ -197,22 +200,31 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
                 onFocus={this.handleFocus}
                 onBlur={this.handleBlur}
                 tabIndex={this.props.disabled ? -1 : 0}
+<<<<<<< HEAD
                 role="combobox"
                 aria-label={'select'}
                 aria-expanded={this.state.isOpen}
+=======
+                data-testid={this.props['data-testid']}
+>>>>>>> a551f43... Added id to Select
             >
                 <StyledInput
                     open={this.state.isOpen}
                     hasFocus={this.state.hasFocus}
                     disabled={!this.props.disabled ? false : this.props.disabled}
                     ref={this.inputWrapperRef}
+<<<<<<< HEAD
                     role="searchbox"
                     aria-autocomplete="list"
                     aria-controls={this.state.isOpen ? 'select-window' : undefined}
+=======
+                    data-testid={this.props['data-testid'] ? `${this.props['data-testid']}-input` : undefined}
+                    onClick={!this.state.isOpen ? this.open : undefined}
+>>>>>>> a551f43... Added id to Select
                 >
                     <Box alignItems="stretch">
                         {(this.state.isOpen && (
-                            <Box alignItems="center" padding={trbl(6, 12)} grow={1} onClick={this.open}>
+                            <Box alignItems="center" padding={trbl(6, 12)} grow={1}>
                                 <Box alignItems="center" margin={trbl(0, 6, 0, 0)}>
                                     <Icon icon={search} size="small" color={'#d2d7e0'} />
                                 </Box>
@@ -221,6 +233,11 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
                                     type="text"
                                     placeholder={this.props.placeholder}
                                     value={this.state.input}
+                                    data-testid={
+                                        this.props['data-testid']
+                                            ? `${this.props['data-testid']}-input-field`
+                                            : undefined
+                                    }
                                     onChange={(event: ChangeEvent<HTMLInputElement>): void => {
                                         event.stopPropagation();
                                         this.handleInput(event.target.value);
@@ -229,14 +246,22 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
                             </Box>
                         )) ||
                             (this.props.renderSelected !== undefined && (
-                                <Box padding={trbl(6, 12)} alignItems="center" grow={1} onClick={this.open}>
+                                <Box padding={trbl(6, 12)} alignItems="center" grow={1}>
                                     {this.props.renderSelected(selectedOption as GenericOptionType)}
                                 </Box>
                             )) || (
                                 <Box alignItems="center" padding={trbl(6, 12)} grow={1} onClick={this.open}>
                                     {(this.props.value !== '' && <Text>{selectedOption.label}</Text>) || (
                                         <Text severity="info">
-                                            <StyledPlaceholder>{this.props.placeholder}</StyledPlaceholder>
+                                            <StyledPlaceholder
+                                                data-testid={
+                                                    this.props['data-testid']
+                                                        ? `${this.props['data-testid']}-placeholder`
+                                                        : undefined
+                                                }
+                                            >
+                                                {this.props.placeholder}
+                                            </StyledPlaceholder>
                                         </Text>
                                     )}
                                 </Box>
@@ -262,13 +287,18 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
                                 : undefined
                         }
                         inputHeight={this.state.inputHeight}
+<<<<<<< HEAD
                         role="listbox"
+=======
+                        data-testid={
+                            this.props['data-testid']
+                                ? `${this.props['data-testid']}-window${this.state.isOpen ? '-open' : '-closed'}`
+                                : undefined
+                        }
+>>>>>>> a551f43... Added id to Select
                     >
                         <ScrollBox autoHideScrollBar={false} showInsetShadow={false}>
-                            <div
-                                data-test="bricks-select-collapse"
-                                style={{ overflow: 'hidden', display: this.state.isOpen ? 'block' : 'none' }}
-                            >
+                            <div style={{ overflow: 'hidden', display: this.state.isOpen ? 'block' : 'none' }}>
                                 {(this.filterOptions().length === 0 && (
                                     <Box padding={trbl(12, 18)}>
                                         <Text>{this.props.emptyText}</Text>
@@ -276,17 +306,25 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
                                 )) ||
                                     this.filterOptions().map((option, index) => {
                                         const optionState = { isSelected: option.value === this.props.value };
+                                        const isTargeted = index === this.state.optionPointer;
 
                                         return (
                                             <Option
                                                 label={option.label}
                                                 isSelected={optionState.isSelected}
-                                                isTargeted={index === this.state.optionPointer}
+                                                isTargeted={isTargeted}
                                                 key={`${option.value}-${option.label}`}
                                                 onMouseEnter={(): void => this.cycleTo(index)}
                                                 onClick={(): void => {
                                                     this.handleChange(option.value);
                                                 }}
+                                                data-testid={
+                                                    this.props['data-testid']
+                                                        ? `${this.props['data-testid']}-option-${option.value}${
+                                                              isTargeted ? '-targeted' : ''
+                                                          }`
+                                                        : undefined
+                                                }
                                                 content={
                                                     this.props.renderOption !== undefined
                                                         ? this.props.renderOption(option, optionState)

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -250,7 +250,7 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
                                     {this.props.renderSelected(selectedOption as GenericOptionType)}
                                 </Box>
                             )) || (
-                                <Box alignItems="center" padding={trbl(6, 12)} grow={1} onClick={this.open}>
+                                <Box alignItems="center" padding={trbl(6, 12)} grow={1}>
                                     {(this.props.value !== '' && <Text>{selectedOption.label}</Text>) || (
                                         <Text severity="info">
                                             <StyledPlaceholder

--- a/src/components/Select/story.tsx
+++ b/src/components/Select/story.tsx
@@ -80,6 +80,7 @@ class Demo extends Component<PropsType, StateType> {
                 emptyText={text('emptyText', 'No results')}
                 onChange={this.handleChange}
                 disabled={boolean('disabled', false)}
+                data-testid="foo"
                 options={object('options', options)}
             />
         );

--- a/src/components/Select/test.tsx
+++ b/src/components/Select/test.tsx
@@ -52,60 +52,79 @@ const options = [
 
 describe('Select', () => {
     it('should open when the spacebar is pressed', () => {
-        const preventDefaultMock = jest.fn();
         const component = mountWithTheme(
-            <Select onChange={(): void => undefined} value="" emptyText="empty" options={options} />,
+            <Select
+                onChange={(): void => undefined}
+                value=""
+                emptyText="empty"
+                options={options}
+                data-testid="select"
+            />,
         );
 
         component.find(Select).simulate('keyDown', {
             key: ' ',
         });
 
-        expect(component.find('[data-test="bricks-select-collapse"]').prop('style')).toHaveProperty('display', 'block');
-
-        component.find(Select).simulate('keyDown', {
-            key: 'Tab',
-            preventDefault: preventDefaultMock,
-        });
-
-        expect(component.find('[data-test="bricks-select-collapse"]').prop('style')).toHaveProperty('display', 'block');
+        expect(component.find('[data-testid="select-window-open"]').hostNodes()).toHaveLength(1);
     });
 
     it('should show focus when the select is open', () => {
         const component = mountWithTheme(
-            <Select onChange={(): void => undefined} value="" emptyText="empty" options={options} />,
+            <Select
+                onChange={(): void => undefined}
+                value=""
+                emptyText="empty"
+                options={options}
+                data-testid="select"
+            />,
         );
 
         component.find(Select).simulate('focus');
 
-        expect(component.find(StyledInput)).toHaveStyleRule(
+        expect(component.find('[data-testid="select-input"]')).toHaveStyleRule(
             'border',
             `solid 1px ${mosTheme.Select.wrapper.focus.borderColor}`,
         );
 
         component.find(Select).simulate('blur');
 
-        expect(component.find(StyledInput)).toHaveStyleRule('border', `solid 1px ${mosTheme.Select.input.borderColor}`);
+        expect(component.find('[data-testid="select-input"]')).toHaveStyleRule(
+            'border',
+            `solid 1px ${mosTheme.Select.input.borderColor}`,
+        );
     });
 
     it('should open the arrowDown or arrowUp is pressed and close when escape is pressed', () => {
         const component = mountWithTheme(
-            <Select onChange={(): void => undefined} value="" emptyText="empty" options={options} />,
+            <Select
+                onChange={(): void => undefined}
+                value=""
+                emptyText="empty"
+                options={options}
+                data-testid="select"
+            />,
         );
 
         component.find(Select).simulate('keyDown', { key: 'ArrowDown' });
-        expect(component.find('[data-test="bricks-select-collapse"]').prop('style')).toHaveProperty('display', 'block');
+        expect(component.find('[data-testid="select-window-open"]').hostNodes()).toHaveLength(1);
 
         component.find(Select).simulate('keyDown', { key: 'Escape' });
-        expect(component.find('[data-test="bricks-select-collapse"]').prop('style')).toHaveProperty('display', 'none');
+        expect(component.find('[data-testid="select-window-closed"]').hostNodes()).toHaveLength(1);
 
         component.find(Select).simulate('keyDown', { key: 'ArrowUp' });
-        expect(component.find('[data-test="bricks-select-collapse"]').prop('style')).toHaveProperty('display', 'block');
+        expect(component.find('[data-testid="select-window-open"]').hostNodes()).toHaveLength(1);
     });
 
     it('should show an input and options on click', () => {
         const component = mountWithTheme(
-            <Select onChange={(): void => undefined} value="" emptyText="empty" options={options} />,
+            <Select
+                onChange={(): void => undefined}
+                value=""
+                emptyText="empty"
+                options={options}
+                data-testid="select"
+            />,
         );
 
         component.find(Select).simulate('keyDown', {
@@ -113,6 +132,7 @@ describe('Select', () => {
         });
 
         expect(component.find('input').length).toBe(1);
+        expect(component.find('[data-testid="select-input-field"]').hostNodes()).toHaveLength(1);
         expect(component.find(Option).length).toBe(options.length);
     });
 
@@ -166,25 +186,28 @@ describe('Select', () => {
         document.addEventListener = jest.fn((event, callback) => (callbackMap[event] = callback));
 
         const component = mountWithTheme(
-            <Select onChange={(): void => undefined} value="" emptyText="empty" options={options} />,
+            <Select
+                onChange={(): void => undefined}
+                value=""
+                emptyText="empty"
+                options={options}
+                data-testid="select"
+            />,
         );
 
         component
-            .find(StyledInput)
-            .find(Box)
-            .at(1)
+            .find('[data-testid="select-input"]')
+            .hostNodes()
             .simulate('click');
 
-        expect(component.find('[data-test="bricks-select-collapse"]').prop('style')).toHaveProperty('display', 'block');
+        expect(component.find('[data-testid="select-window-open"]').hostNodes()).toHaveLength(1);
 
+        // click inside
         callbackMap.mousedown({
             target: component.first().getDOMNode(),
         });
 
-        component.update();
-
-        // click inside
-        expect(component.find('[data-test="bricks-select-collapse"]').prop('style')).toHaveProperty('display', 'block');
+        expect(component.find('[data-testid="select-window-open"]').hostNodes()).toHaveLength(1);
 
         // click outside
         callbackMap.mousedown({
@@ -193,14 +216,14 @@ describe('Select', () => {
 
         component.update();
 
-        expect(component.find('[data-test="bricks-select-collapse"]').prop('style')).toHaveProperty('display', 'none');
+        expect(component.find('[data-testid="select-window-closed"]').hostNodes()).toHaveLength(1);
     });
 
     it('should handle a change', () => {
         const changeHandler = jest.fn();
 
         const component = mountWithTheme(
-            <Select onChange={changeHandler} value="" emptyText="empty" options={options} />,
+            <Select onChange={changeHandler} value="" emptyText="empty" options={options} data-testid="select" />,
         );
 
         component.find(Select).simulate('keyDown', {
@@ -208,8 +231,8 @@ describe('Select', () => {
         });
 
         component
-            .find(Option)
-            .first()
+            .find('[data-testid="select-option-A"]')
+            .hostNodes()
             .simulate('click');
 
         expect(changeHandler).toHaveBeenCalledWith(options[0].value);
@@ -219,7 +242,13 @@ describe('Select', () => {
         const options = [{ value: 'A', label: 'A' }, { value: 'B', label: 'B' }];
 
         const component = mountWithTheme(
-            <Select onChange={(): void => undefined} value="" emptyText="empty" options={options} />,
+            <Select
+                onChange={(): void => undefined}
+                value=""
+                emptyText="empty"
+                options={options}
+                data-testid="select"
+            />,
         );
 
         component.find(Select).simulate('keyDown', {
@@ -234,30 +263,26 @@ describe('Select', () => {
             key: 'ArrowDown',
         });
 
-        expect(
-            component
-                .find(Option)
-                .at(options.length - 1)
-                .prop('isTargeted'),
-        ).toBe(true);
+        expect(component.find('[data-testid="select-option-B-targeted"]').hostNodes()).toHaveLength(1);
 
         component.find(Select).simulate('keyDown', {
             key: 'ArrowDown',
         });
 
-        expect(
-            component
-                .find(Option)
-                .at(0)
-                .prop('isTargeted'),
-        ).toBe(true);
+        expect(component.find('[data-testid="select-option-A-targeted"]').hostNodes()).toHaveLength(1);
     });
 
     it('should target the previous option when arrow up is pressed and target last item on first option', () => {
         const options = [{ value: 'A', label: 'A' }, { value: 'B', label: 'B' }];
 
         const component = mountWithTheme(
-            <Select onChange={(): void => undefined} value="" emptyText="empty" options={options} />,
+            <Select
+                onChange={(): void => undefined}
+                value=""
+                emptyText="empty"
+                options={options}
+                data-testid="select"
+            />,
         );
 
         component.find(Select).simulate('keyDown', {
@@ -276,23 +301,13 @@ describe('Select', () => {
             key: 'ArrowUp',
         });
 
-        expect(
-            component
-                .find(Option)
-                .at(0)
-                .prop('isTargeted'),
-        ).toBe(true);
+        expect(component.find('[data-testid="select-option-A-targeted"]').hostNodes()).toHaveLength(1);
 
         component.find(Select).simulate('keyDown', {
             key: 'ArrowUp',
         });
 
-        expect(
-            component
-                .find(Option)
-                .at(options.length - 1)
-                .prop('isTargeted'),
-        ).toBe(true);
+        expect(component.find('[data-testid="select-option-B-targeted"]').hostNodes()).toHaveLength(1);
     });
 
     it('should set the value of the target option when enter is pressed on a targeted option', () => {
@@ -319,15 +334,21 @@ describe('Select', () => {
 
     it('should handle a selected option', () => {
         const component = mountWithTheme(
-            <Select onChange={(): void => undefined} value={options[1].value} emptyText="empty" options={options} />,
+            <Select
+                onChange={(): void => undefined}
+                value={options[1].value}
+                emptyText="empty"
+                options={options}
+                data-testid="select"
+            />,
         );
 
         expect(
             component
-                .find(StyledInput)
-                .findWhere(node => node.text() === options[1].label && node.type() === 'p')
-                .hostNodes().length,
-        ).toBe(1);
+                .find('[data-testid="select-input"]')
+                .hostNodes()
+                .findWhere(node => node.text() === options[1].label && node.type() === 'p'),
+        ).toHaveLength(1);
     });
 
     it('should render an alternative option rendering', () => {
@@ -385,40 +406,42 @@ describe('Select', () => {
 
     it('should target an Option when mouse enters', () => {
         const component = mountWithTheme(
-            <Select onChange={(): void => undefined} value="" emptyText="" options={options} />,
+            <Select onChange={(): void => undefined} value="" emptyText="" options={options} data-testid="select" />,
         );
 
         component
-            .find(StyledInput)
-            .find(Box)
-            .at(1)
+            .find('[data-testid="select-input"]')
+            .hostNodes()
             .simulate('click');
 
         component
-            .find(Option)
-            .at(2)
+            .find('[data-testid="select-option-C"]')
+            .hostNodes()
             .simulate('mouseEnter');
 
-        expect(
-            component
-                .find(Option)
-                .at(2)
-                .prop('isTargeted'),
-        ).toBe(true);
+        expect(component.find('[data-testid="select-option-C-targeted"]').hostNodes()).toHaveLength(1);
     });
 
     it('should not open the Option-Select window when the component is disabled', () => {
         const component = mountWithTheme(
-            <Select onChange={(): void => undefined} value="" emptyText="" options={options} disabled />,
+            <Select
+                onChange={(): void => undefined}
+                value=""
+                emptyText=""
+                options={options}
+                disabled
+                data-testid="select"
+            />,
         );
 
+        expect(component.find('[data-testid="select-window-closed"]').hostNodes()).toHaveLength(1);
+
         component
-            .find(StyledInput)
-            .find(Box)
-            .at(1)
+            .find('[data-testid="select-input"]')
+            .hostNodes()
             .simulate('click');
 
-        expect(component.find(StyledWindow).prop('open')).toEqual(false);
+        expect(component.find('[data-testid="select-window-closed"]').hostNodes()).toHaveLength(1);
     });
 
     it('should close the Option-Select window when the component gets disabled', () => {
@@ -431,8 +454,8 @@ describe('Select', () => {
                         emptyText=""
                         options={options}
                         disabled={props.disabled}
+                        data-testid="select"
                     />
-                    ,
                 </MosTheme>
             );
         };
@@ -440,15 +463,16 @@ describe('Select', () => {
         const component = mount(<Root />);
 
         component
-            .find(StyledInput)
-            .find(Box)
-            .at(1)
+            .find('[data-testid="select-input"]')
+            .hostNodes()
             .simulate('click');
+
+        expect(component.find('[data-testid="select-window-open"]').hostNodes()).toHaveLength(1);
 
         component.setProps({ disabled: true });
         component.update();
 
-        expect(component.find(StyledWindow).prop('open')).toEqual(false);
+        expect(component.find('[data-testid="select-window-closed"]').hostNodes()).toHaveLength(1);
     });
 
     it('should handle a simulated change event', () => {
@@ -466,19 +490,24 @@ describe('Select', () => {
 
     it('should not change the selected value when the input value changes', () => {
         const changeMock = jest.fn();
-        const component = mountWithTheme(<Select onChange={changeMock} value="" emptyText="" options={options} />);
+
+        const component = mountWithTheme(
+            <Select onChange={changeMock} value="" emptyText="" options={options} data-testid="select" />,
+        );
 
         component
-            .find(StyledInput)
-            .find(Box)
-            .at(1)
+            .find('[data-testid="select-input"]')
+            .hostNodes()
             .simulate('click');
 
-        component.find('input[type="text"]').simulate('change', {
-            target: {
-                value: 'Foo',
-            },
-        });
+        component
+            .find('[data-testid="select-input-field"]')
+            .hostNodes()
+            .simulate('change', {
+                target: {
+                    value: 'Foo',
+                },
+            });
 
         expect(changeMock).toHaveBeenCalledTimes(0);
     });


### PR DESCRIPTION
### This PR:
A little bit of progress for #249

**Breaking changes** 🔥
-  Removed `data-test="bricks-select-collapse"` from Select

**Backwards compatible additions** ✨
- Added `data-testid` as a prop to Select, Button and Link for better testability

**Bugfixes/Changed internals** 🎈
- Refactored some tests.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
