### PR TITLE
Added placeholder prop

### DIFF
--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -20,6 +20,7 @@ type PropsType = {
     prefix?: string;
     suffix?: string;
     disabled?: boolean;
+    placeholder?: string;
     extractRef?(ref: HTMLInputElement): void;
     onChange(value: string, event: ChangeEvent<HTMLInputElement>): void;
     onBlur?(): void;
@@ -72,6 +73,7 @@ class TextField extends Component<PropsType, StateType> {
                     <Box position="relative" width="100%">
                         <StyledInput
                             type={this.props.type ? this.props.type : 'text'}
+                            placeholder={this.props.placeholder}
                             name={this.props.name}
                             disabled={this.props.disabled}
                             value={this.props.value}

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -58,6 +58,7 @@ class Demo extends Component<DemoPropsType, DemoStateType> {
             <TextField
                 prefix={text('Prefix', 'Username')}
                 suffix={text('Suffix', '$')}
+                placeholder={text('Placeholder', 'This is a placeholder')}
                 value={this.state.stringValue}
                 disabled={boolean('disabled', false)}
                 name="firstname"

--- a/src/components/TextField/style.tsx
+++ b/src/components/TextField/style.tsx
@@ -57,6 +57,7 @@ const StyledInput = withProps<InputProps, HTMLInputElement>(styled.input)`
     margin: 0;
     background: ${({ theme, disabled }): string =>
         disabled ? theme.TextField.disabled.background : theme.TextField.idle.common.background};
+    font-family: ${({ theme }): string => theme.TextField.idle.common.fontFamily};
     font-size: inherit;
     padding: 6px 12px;
     line-height: 1.572;

--- a/src/components/TextField/style.tsx
+++ b/src/components/TextField/style.tsx
@@ -14,6 +14,9 @@ type TextFieldThemeType = {
             color: string;
             background: string;
         };
+        placeholder: {
+            color: string;
+        };
         affix: {
             color: string;
             background: string;
@@ -59,9 +62,11 @@ const StyledInput = withProps<InputProps, HTMLInputElement>(styled.input)`
     line-height: 1.572;
     outline: none;
     min-width: 12px;
+    color: ${({ theme, disabled }): string =>
+        disabled ? theme.TextField.disabled.color : theme.TextField.idle.common.color};
 
     &::placeholder {
-        color: #88979D;
+        color: ${({ theme }): string => theme.TextField.idle.placeholder.color};
     }
 
     ${({ theme, disabled }): string =>

--- a/src/components/TextField/style.tsx
+++ b/src/components/TextField/style.tsx
@@ -60,6 +60,10 @@ const StyledInput = withProps<InputProps, HTMLInputElement>(styled.input)`
     outline: none;
     min-width: 12px;
 
+    &::placeholder {
+        color: #88979D;
+    }
+
     ${({ theme, disabled }): string =>
         disabled
             ? `

--- a/src/components/TextField/test.tsx
+++ b/src/components/TextField/test.tsx
@@ -53,4 +53,11 @@ describe('TextField', () => {
 
         expect(changeMock).toHaveBeenCalled();
     });
+
+    it('should show a placeholder', () => {
+        const component = mountWithTheme(
+            <TextField value="" suffix="hi" name="firstName" placeholder="foo" onChange={jest.fn()} />,
+        );
+        expect(component.prop('placeholder')).toEqual('foo');
+    });
 });

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -805,6 +805,9 @@ const theme: ThemeType = {
                 color: grey.lighter3,
                 background: silver.lighter1,
             },
+            placeholder: {
+                color: grey.lighter2,
+            },
             affix: {
                 color: grey.lighter1,
                 background: silver.base,

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -802,7 +802,7 @@ const theme: ThemeType = {
                 borderColor: silver.darker4,
                 fontSize: fontSize.base,
                 fontFamily: bodyFont,
-                color: grey.lighter3,
+                color: grey.base,
                 background: silver.lighter1,
             },
             placeholder: {


### PR DESCRIPTION
### This PR:

**Backwards compatible additions** ✨
- Component `TextField` now also supports an optional `placeholder` prop to show a placeholder value.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
