### PR TITLE
Added badge to FormRow

### DIFF
--- a/src/components/FormRow/index.tsx
+++ b/src/components/FormRow/index.tsx
@@ -5,14 +5,18 @@ import { StyledFormRow } from './style';
 
 type PropsType = {
     label: JSX.Element;
+    badge?: JSX.Element;
     field: JSX.Element;
 };
 
 const FormRow: FunctionComponent<PropsType> = (props): JSX.Element => {
     return (
         <StyledFormRow>
-            <Box basis={'180px'} grow={1} maxWidth="241px" margin={trbl(18, 9, 0, 0)} justifyContent="stretch" wrap>
-                {props.label}
+            <Box basis={'180px'} direction="row" grow={1} maxWidth="241px" margin={trbl(18, 9, 0, 0)} wrap>
+                <Box>{props.label}</Box>
+                <Box margin={[-9, 0]} justifyContent="flex-end">
+                    {props.badge !== undefined && props.badge}
+                </Box>
             </Box>
             <Box basis={'180px'} grow={1} maxWidth="470px" margin={trbl(9, 0)} alignItems="flex-start" wrap>
                 {props.field}

--- a/src/components/FormRow/index.tsx
+++ b/src/components/FormRow/index.tsx
@@ -13,9 +13,9 @@ const FormRow: FunctionComponent<PropsType> = (props): JSX.Element => {
     return (
         <StyledFormRow>
             <Box basis={'180px'} direction="row" grow={1} maxWidth="241px" margin={trbl(18, 9, 0, 0)} wrap>
-                <Box>{props.label}</Box>
-                <Box margin={[-9, 0]} justifyContent="flex-end">
-                    {props.badge !== undefined && props.badge}
+                <Box wrap={false}>
+                    <Box>{props.label}</Box>
+                    <Box margin={[-9, 3]}>{props.badge !== undefined && props.badge}</Box>
                 </Box>
             </Box>
             <Box basis={'180px'} grow={1} maxWidth="470px" margin={trbl(9, 0)} alignItems="flex-start" wrap>

--- a/src/components/FormRow/story.tsx
+++ b/src/components/FormRow/story.tsx
@@ -324,4 +324,7 @@ class DemoComponent extends Component<PropsType, StateType> {
 
 storiesOf('FormRow', module)
     .add('Default', () => <DemoComponent descriptions={true} />)
-    .add('No Descriptions', () => <DemoComponent descriptions={false} />);
+    .add('No Descriptions', () => <DemoComponent descriptions={false} />)
+    .add('With badge', () => (
+        <FormRow label={<Text>Label</Text>} badge={<Text severity="success">PRO</Text>} field={<Text>Field</Text>} />
+    ));

--- a/src/components/FormRow/story.tsx
+++ b/src/components/FormRow/story.tsx
@@ -10,6 +10,7 @@ import TextField from '../TextField';
 import Toggle from '../Toggle';
 import trbl from '../../utility/trbl';
 import Separated from '../Separated';
+import { text } from '@storybook/addon-knobs';
 
 type PropsType = {
     descriptions: boolean;
@@ -326,5 +327,17 @@ storiesOf('FormRow', module)
     .add('Default', () => <DemoComponent descriptions={true} />)
     .add('No Descriptions', () => <DemoComponent descriptions={false} />)
     .add('With badge', () => (
-        <FormRow label={<Text>Label</Text>} badge={<Text severity="success">PRO</Text>} field={<Text>Field</Text>} />
+        <FormRow
+            label={<Text>{text('label', 'Label text')}</Text>}
+            badge={
+                <Text variant="small" severity="success">
+                    {text('badge', 'PRO')}
+                </Text>
+            }
+            field={
+                <Box direction="row" alignItems="center">
+                    <Toggle checked={true} name="storyToggle" value={'true'} onChange={(): string => 'void'} />
+                </Box>
+            }
+        />
     ));


### PR DESCRIPTION
### This PR:

**Backwards compatible additions** ✨
- Component `FormRow` now also supports a `badge` prop to add a badge to the label. This prop takes an element and renders it to the top-right of the label.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
