### PR TITLE
Tweaked modal max-height

### DIFF
--- a/src/components/Modal/style.tsx
+++ b/src/components/Modal/style.tsx
@@ -49,7 +49,7 @@ const StyledModal = styled.div<ModalPropsType>`
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    max-height: calc(300px + 300 * (100vh - 300px) / 350);
+    max-height: calc(300px + 300 * (100vh - 300px) / 400);
     background: ${({ theme }): string => theme.Modal.backgroundColor};
     border-radius: ${({ theme }): string => theme.Modal.borderRadius};
 

--- a/src/components/Modal/style.tsx
+++ b/src/components/Modal/style.tsx
@@ -49,7 +49,7 @@ const StyledModal = styled.div<ModalPropsType>`
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    max-height: calc(300px + (600 - 300) * (100vh - 300px) / (900 - 300));
+    max-height: calc(300px + 300 * (100vh - 300px) / 350);
     background: ${({ theme }): string => theme.Modal.backgroundColor};
     border-radius: ${({ theme }): string => theme.Modal.borderRadius};
 


### PR DESCRIPTION
### This PR:

**Backwards compatible additions** ✨
- Allow the modal to have a greater max-height

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
