### PR TITLE
Add unavailable prop to toggle

### DIFF
--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -12,6 +12,7 @@ type StateType = {
 type PropsType = {
     checked: boolean;
     disabled?: boolean;
+    unavailable?: boolean;
     error?: boolean;
     value: string;
     label?: string;
@@ -74,7 +75,7 @@ class Toggle extends Component<PropsType, StateType> {
                     </StyledToggleSkin>
                 </Box>
                 <Box margin={trbl(9, 0, 0, 0)}>
-                    <Text severity={this.props.disabled ? 'info' : undefined}>
+                    <Text severity={this.props.disabled || this.props.unavailable ? 'info' : undefined}>
                         {this.props.disabledIcon && this.props.disabled && <Icon size="medium" icon="locked" />}{' '}
                         {this.props.label}
                     </Text>

--- a/src/components/Toggle/story.tsx
+++ b/src/components/Toggle/story.tsx
@@ -26,6 +26,7 @@ class Demo extends Component<{}, StateType> {
                 value="foot"
                 checked={boolean('checked', this.state.checked)}
                 disabled={boolean('disabled', false)}
+                unavailable={boolean('unavailable', false)}
                 disabledIcon={boolean('disabled icon', true)}
                 error={boolean('error', false)}
                 label={text('label', 'Turn me on!')}


### PR DESCRIPTION
### This PR:

Sometimes the toggle will not be disabled but it will be unavailable. In this case the label should be greyed out and an alternative action is called on the `onChange` of the toggle.

**Backwards compatible additions** ✨
- Component `Toggle` now also supports an `unavailable` prop which greys out the label

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
