### PR TITLE
fix: missing lock icons

### DIFF
--- a/src/components/RadioButton/index.tsx
+++ b/src/components/RadioButton/index.tsx
@@ -3,6 +3,7 @@ import trbl from '../../utility/trbl';
 import Box from '../Box';
 import Text from '../Text';
 import Icon from '../Icon';
+import lockedIcon from '../../assets/icons/locked.svg';
 import StyledRadioButton, { StyledRadioButtonSkin, StyledRadioWrapper } from './style';
 
 type StateType = {
@@ -67,7 +68,7 @@ class RadioButton extends Component<PropsType, StateType> {
                     <Box inline direction="row" align-items="center">
                         {this.props.disabled && (
                             <Box inline margin={trbl(0, 12, 0, 0)}>
-                                <Icon size="medium" icon="locked" />{' '}
+                                <Icon size="medium" icon={lockedIcon} />{' '}
                             </Box>
                         )}
                         <label id={this.props.name} htmlFor={this.props.name}>

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -7,6 +7,7 @@ import { StyledInput, StyledWrapper, StyledAffix, StyledAffixWrapper } from './s
 import withCurrencyFormatting, { WithCurrencyFormattingType } from './formatters/withCurrencyFormatting';
 import withNumberFormatting, { WithNumberFormattingType } from './formatters/withNumberFormatting';
 import Icon from '../Icon';
+import lockedIcon from '../../assets/icons/locked.svg';
 import questionCircle from '../../assets/icons/question-circle.svg';
 import dangerCircle from '../../assets/icons/danger-circle.svg';
 
@@ -95,7 +96,7 @@ class TextField extends Component<PropsType, StateType> {
                             }}
                         />
                         <Box position="absolute" right="8px" top="8px">
-                            {this.props.disabled && <Icon icon="locked" color="#A6AAB3" size="medium" />}
+                            {this.props.disabled && <Icon icon={lockedIcon} color="#A6AAB3" size="medium" />}
                         </Box>
                     </Box>
                     {this.props.suffix && (

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -3,6 +3,7 @@ import trbl from '../../utility/trbl';
 import Box from '../Box';
 import Text from '../Text';
 import Icon from '../Icon';
+import lockedIcon from '../../assets/icons/locked.svg';
 import StyledToggle, { StyledToggleSkin } from './style';
 
 type StateType = {
@@ -76,7 +77,7 @@ class Toggle extends Component<PropsType, StateType> {
                 </Box>
                 <Box margin={trbl(9, 0, 0, 0)}>
                     <Text severity={this.props.disabled || this.props.unavailable ? 'info' : undefined}>
-                        {this.props.disabledIcon && this.props.disabled && <Icon size="medium" icon="locked" />}{' '}
+                        {this.props.disabledIcon && this.props.disabled && <Icon size="medium" icon={lockedIcon} />}{' '}
                         {this.props.label}
                     </Text>
                 </Box>


### PR DESCRIPTION
### This PR:

Fixes icon props in disabled input components.

**Checklist** 🛡
- [ ] I have exported my addition from `src/index.ts` (check if not applicable).
- [ ] Appropriate tests have been added for my functionality (check if not applicable).
- [ ] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [ ] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
