### PR TITLE
Align RadioButton labels to center

### DIFF
--- a/src/components/RadioButton/story.tsx
+++ b/src/components/RadioButton/story.tsx
@@ -1,4 +1,4 @@
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import RadioButton from '../RadioButton';
@@ -10,7 +10,7 @@ storiesOf('RadioButton', module).add('Default', () => {
             disabled={boolean('disabled', false)}
             error={boolean('error', false)}
             name="demo"
-            label="foo"
+            label={text('label', 'foo')}
             value="demo2"
             onChange={(): void => undefined}
         />

--- a/src/components/RadioButton/style.tsx
+++ b/src/components/RadioButton/style.tsx
@@ -40,6 +40,7 @@ type RadioButtonThemeType = {
 
 const StyledRadioWrapper = styled.div`
     display: flex;
+    align-items: center;
 `;
 
 const StyledRadioButton = styled.input<RadioButtonPropsType>`


### PR DESCRIPTION
### This PR:

I noticed the labels of the RadioButtons were not aligned to the center of the button.

**Bugfixes/Changed internals** 🎈
- Set align-items to center for flex container of `RadioButton`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
