### PR TITLE
Added z-index to box

### DIFF
--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -35,6 +35,7 @@ type PropsType = JSX.IntrinsicElements['div'] & {
     right?: string;
     bottom?: string;
     left?: string;
+    zIndex?: number;
 };
 
 const Box: FunctionComponent<PropsType> = (props): JSX.Element => {

--- a/src/components/Box/story.tsx
+++ b/src/components/Box/story.tsx
@@ -55,6 +55,7 @@ storiesOf('Box', module).add('Default', () => {
                 right={text('right', '', 'Child')}
                 bottom={text('bottom', '', 'Child')}
                 left={text('left', '', 'Child')}
+                zIndex={number('z-index', 0, {}, 'Child')}
             >
                 <Item>
                     <Box padding={trbl(48)}>

--- a/src/components/Box/style.tsx
+++ b/src/components/Box/style.tsx
@@ -60,6 +60,7 @@ const StyledDiv = styled.div<BoxPropsType>`
     ${({ right }): string => (right !== undefined ? `right: ${right}` : '')};
     ${({ bottom }): string => (bottom !== undefined ? `bottom: ${bottom}` : '')};
     ${({ left }): string => (left !== undefined ? `left: ${left}` : '')};
+    ${({ zIndex }): string => (zIndex ? `z-index: ${zIndex}` : '')}
 `;
 
 const StyledSpan = StyledDiv.withComponent('span');

--- a/src/components/Box/test.tsx
+++ b/src/components/Box/test.tsx
@@ -148,4 +148,10 @@ describe('Box', () => {
 
         expect(component.find('[data-testid="box"]').hostNodes()).toHaveLength(1);
     });
+
+    it('should have a z-index', () => {
+        const component = mount(<Box zIndex={10} />);
+
+        expect(component).toHaveStyleRule('z-index', '10');
+    });
 });


### PR DESCRIPTION
### This PR:

Adds z-index as prop to Box

**Backwards compatible additions** ✨
- Component `Box` now also supports an optional `zIndex` props to increase it's z-index.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
