### PR TITLE
passed click event to button components onClick callback

### DIFF
--- a/src/components/Button/base/index.tsx
+++ b/src/components/Button/base/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, MouseEvent } from 'react';
 import StyledButton, { StyledAnchor } from './style';
 
 type PropsType = {
@@ -12,20 +12,21 @@ type PropsType = {
     id?: string;
     loading?: boolean;
     'data-testid'?: string;
-    onClick?(): void;
+    onClick?(event: MouseEvent<HTMLButtonElement>): void;
 };
 
 const ButtonBase: FunctionComponent<PropsType> = (props): JSX.Element => {
     const isLink = props.href !== undefined;
 
-    const clickAction = (): void => {
-        if (props.onClick !== undefined && props.disabled !== true && props.loading !== true) props.onClick();
+    const clickAction = (event: MouseEvent<HTMLButtonElement>): void => {
+        if (props.onClick !== undefined && props.disabled !== true && props.loading !== true) {
+            props.onClick(event);
+        }
     };
 
     if (isLink) {
         return (
             <StyledAnchor
-                // @ts-ignore
                 href={props.href}
                 target={props.target}
                 title={props.title}

--- a/src/components/Button/test.tsx
+++ b/src/components/Button/test.tsx
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme';
-import React from 'react';
+import React, { MouseEvent } from 'react';
 import Button from '.';
 import MosTheme from '../../themes/MosTheme';
 import { mountWithTheme } from '../../utility/styled/testing';
@@ -91,5 +91,25 @@ describe('Button', () => {
         );
 
         expect(component.find('[data-testid="foo"]').hostNodes().length).toBe(1);
+    });
+
+    it('should pass the event to the onClick callback', () => {
+        // tslint:disable-next-line:no-any
+        let clickEvent: any = {};
+
+        const clickMock = jest.fn(event => {
+            clickEvent = event;
+        });
+
+        const component = mount(
+            <MosTheme>
+                <Button variant="primary" title="button title" onClick={clickMock} />
+            </MosTheme>,
+        );
+
+        component.find(Button).simulate('click');
+
+        expect(clickMock).toHaveBeenCalled();
+        expect(clickEvent.target).not.toBe(undefined);
     });
 });

--- a/src/components/Button/test.tsx
+++ b/src/components/Button/test.tsx
@@ -110,6 +110,6 @@ describe('Button', () => {
         component.find(Button).simulate('click');
 
         expect(clickMock).toHaveBeenCalled();
-        expect(clickEvent.target).not.toBe(undefined);
+        expect(clickEvent.target).toBeDefined();
     });
 });

--- a/src/components/Button/test.tsx
+++ b/src/components/Button/test.tsx
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme';
-import React, { MouseEvent } from 'react';
+import React from 'react';
 import Button from '.';
 import MosTheme from '../../themes/MosTheme';
 import { mountWithTheme } from '../../utility/styled/testing';

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,4 +1,4 @@
-import React, { Children, FunctionComponent } from 'react';
+import React, { Children, FunctionComponent, MouseEvent } from 'react';
 import StyledLink, { StyledButton } from './style';
 
 type PropsType = {
@@ -6,15 +6,15 @@ type PropsType = {
     title: string;
     target?: '_blank' | '_self';
     'data-testid'?: string;
-    onClick?(): void;
+    onClick?(event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>): void;
 };
 
 const Link: FunctionComponent<PropsType> = (props): JSX.Element => {
     const isLink = props.href !== undefined;
 
-    const clickAction = (): void => {
+    const clickAction = (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>): void => {
         if (props.onClick !== undefined) {
-            props.onClick();
+            props.onClick(event);
         }
     };
 

--- a/src/components/Link/test.tsx
+++ b/src/components/Link/test.tsx
@@ -38,4 +38,20 @@ describe('Link', () => {
 
         expect(component.find('[data-testid="foo"]').hostNodes().length).toBe(1);
     });
+
+    it('should pass the event to the onClick callback', () => {
+        // tslint:disable-next-line:no-any
+        let clickEvent: any = {};
+
+        const clickMock = jest.fn(event => {
+            clickEvent = event;
+        });
+
+        const component = mountWithTheme(<Link title="title" onClick={clickMock} data-testid="foo" />);
+
+        component.find(Link).simulate('click');
+
+        expect(clickMock).toHaveBeenCalled();
+        expect(clickEvent.target).not.toBe(undefined);
+    });
 });

--- a/src/components/Link/test.tsx
+++ b/src/components/Link/test.tsx
@@ -52,6 +52,6 @@ describe('Link', () => {
         component.find(Link).simulate('click');
 
         expect(clickMock).toHaveBeenCalled();
-        expect(clickEvent.target).not.toBe(undefined);
+        expect(clickEvent.target).toBeDefined();
     });
 });


### PR DESCRIPTION
### This PR:

**Backwards compatible additions** ✨
- The `onClick` prop of `Button`, `IconButton` and `Link` now receives the click event as an argument to the callback.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
