### PR TITLE
Additional Slider props

### DIFF
--- a/src/components/Slider/index.tsx
+++ b/src/components/Slider/index.tsx
@@ -11,33 +11,54 @@ type PropsType = {
     disabled?: boolean;
     value?: number;
     label?: string;
+    hideInputField?: boolean;
+    inputFieldWidth?: string;
     onChange?(value: number): void;
+    onFocus?(): void;
+    onBlur?(): void;
 };
 
 const Slider: FC<PropsType> = props => {
-    const [inputFocus, setInputFocus] = useState(false);
+    const [sliderFocus, setSliderFocus] = useState(false);
     const roundValue = memoize(Math.round.bind(Math));
     const [inputValue, setInputValue] = useState(props.value ? props.value : roundValue(props.value));
 
     const isWithinRange = (min: number, max: number, value: number): boolean => value <= max && value >= min;
 
-    const onBlurValue = () => {
+    const onBlur = () => {
         if (inputValue > props.maxLimit) {
             setInputValue(props.maxLimit);
         } else if (inputValue < props.minLimit) {
             setInputValue(props.minLimit);
         }
+
+        if (props.onBlur !== undefined) {
+            props.onBlur();
+        }
+    };
+
+    const onFocus = () => {
+        if (props.onFocus !== undefined) {
+            props.onFocus();
+        }
+    };
+
+    const onInput = (value: number) => {
+        if (props.disabled !== true) {
+            setInputValue(roundValue(value));
+            if (props.onChange !== undefined) props.onChange(value);
+        }
     };
 
     return (
         <Box width="100%" justifyContent="center" alignItems="baseline">
-            <StyledWrapper grow={1} focus={inputFocus} disabled={props.disabled ? props.disabled : false}>
+            <StyledWrapper grow={1} focus={sliderFocus} disabled={props.disabled ? props.disabled : false}>
                 <InputRange
                     value={inputValue}
                     disabled={props.disabled}
                     onChange={(value: number) => {
                         if (props.disabled !== true) {
-                            setInputFocus(false);
+                            setSliderFocus(false);
                             setInputValue(roundValue(value));
                             if (props.onChange !== undefined) props.onChange(value);
                         }
@@ -47,25 +68,23 @@ const Slider: FC<PropsType> = props => {
                     aria-label={props.label ? props.label : 'slider'}
                 />
             </StyledWrapper>
-            <Box width="100px" shrink={0} padding={[0, 0, 0, 18]}>
-                <TextField.Number
-                    value={inputValue}
-                    disabled={props.disabled}
-                    name="slider-value"
-                    onBlur={onBlurValue}
-                    onChange={(value: number) => {
-                        if (props.disabled !== true) {
-                            setInputValue(roundValue(value));
-                            if (props.onChange !== undefined) props.onChange(value);
+            {props.hideInputField !== true && (
+                <Box width={props.inputFieldWidth ? props.inputFieldWidth : '100px'} shrink={0} padding={[0, 0, 0, 18]}>
+                    <TextField.Number
+                        value={inputValue}
+                        disabled={props.disabled}
+                        name="slider-value"
+                        onBlur={onBlur}
+                        onFocus={onFocus}
+                        onChange={onInput}
+                        feedback={
+                            !isWithinRange(props.minLimit, props.maxLimit, inputValue)
+                                ? { severity: 'error', message: '' }
+                                : undefined
                         }
-                    }}
-                    feedback={
-                        !isWithinRange(props.minLimit, props.maxLimit, inputValue)
-                            ? { severity: 'error', message: '' }
-                            : undefined
-                    }
-                />
-            </Box>
+                    />
+                </Box>
+            )}
         </Box>
     );
 };

--- a/src/components/Slider/story.tsx
+++ b/src/components/Slider/story.tsx
@@ -1,7 +1,7 @@
 import Slider from '.';
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { number, boolean } from '@storybook/addon-knobs';
+import { number, boolean, text } from '@storybook/addon-knobs';
 
 storiesOf('Slider', module).add('Default', () => (
     <Slider
@@ -9,6 +9,8 @@ storiesOf('Slider', module).add('Default', () => (
         minLimit={number('minValue', 5)}
         maxLimit={number('maxValue', 25)}
         onChange={() => undefined}
+        inputFieldWidth={text('inputField width', '100px')}
+        hideInputField={boolean('hide inputField', false)}
         disabled={boolean('disabled', false)}
     />
 ));

--- a/src/components/Slider/test.tsx
+++ b/src/components/Slider/test.tsx
@@ -41,7 +41,11 @@ describe('Slider', () => {
 
     it('should not crash when no onChange is provided', () => {
         const fn = (): void => {
-            mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onChange={undefined} />);
+            const component = mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onChange={undefined} />);
+            component
+                .find('input')
+                .first()
+                .simulate('change', { target: { value: '2' } });
         };
 
         expect(fn).not.toThrow();
@@ -49,7 +53,12 @@ describe('Slider', () => {
 
     it('should not crash when no onFocus is provided', () => {
         const fn = (): void => {
-            mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onFocus={undefined} />);
+            const component = mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onFocus={undefined} />);
+
+            component
+                .find('input')
+                .first()
+                .simulate('focus');
         };
 
         expect(fn).not.toThrow();
@@ -57,7 +66,13 @@ describe('Slider', () => {
 
     it('should not crash when no onBlur is provided', () => {
         const fn = (): void => {
-            mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onBlur={undefined} />);
+            const component = mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onBlur={undefined} />);
+
+            component
+                .find('input')
+                .first()
+                .simulate('focus')
+                .simulate('blur');
         };
 
         expect(fn).not.toThrow();

--- a/src/components/Slider/test.tsx
+++ b/src/components/Slider/test.tsx
@@ -47,6 +47,22 @@ describe('Slider', () => {
         expect(fn).not.toThrow();
     });
 
+    it('should not crash when no onFocus is provided', () => {
+        const fn = (): void => {
+            mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onFocus={() => undefined} />);
+        };
+
+        expect(fn).not.toThrow();
+    });
+
+    it('should not crash when no onBlur is provided', () => {
+        const fn = (): void => {
+            mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onBlur={() => undefined} />);
+        };
+
+        expect(fn).not.toThrow();
+    });
+
     it('should floor and ceil the minLimit and maxLimit respectively', () => {
         const changeMock = jest.fn();
         const component = mountWithTheme(<Slider value={5} minLimit={1.75} maxLimit={15.13} onChange={changeMock} />);

--- a/src/components/Slider/test.tsx
+++ b/src/components/Slider/test.tsx
@@ -41,7 +41,7 @@ describe('Slider', () => {
 
     it('should not crash when no onChange is provided', () => {
         const fn = (): void => {
-            mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onChange={() => undefined} />);
+            mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onChange={undefined} />);
         };
 
         expect(fn).not.toThrow();
@@ -49,7 +49,7 @@ describe('Slider', () => {
 
     it('should not crash when no onFocus is provided', () => {
         const fn = (): void => {
-            mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onFocus={() => undefined} />);
+            mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onFocus={undefined} />);
         };
 
         expect(fn).not.toThrow();
@@ -57,10 +57,39 @@ describe('Slider', () => {
 
     it('should not crash when no onBlur is provided', () => {
         const fn = (): void => {
-            mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onBlur={() => undefined} />);
+            mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onBlur={undefined} />);
         };
 
         expect(fn).not.toThrow();
+    });
+
+    it('should be able to call onBlur when provided', () => {
+        const blurMock = jest.fn();
+        const component = mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onBlur={blurMock} />);
+
+        expect(blurMock).not.toHaveBeenCalled();
+
+        component
+            .find('input')
+            .first()
+            .simulate('focus')
+            .simulate('blur');
+
+        expect(blurMock).toHaveBeenCalled();
+    });
+
+    it('should be able to call onFocus when provided', () => {
+        const focusMock = jest.fn();
+        const component = mountWithTheme(<Slider value={5} minLimit={2} maxLimit={7} onFocus={focusMock} />);
+
+        expect(focusMock).not.toHaveBeenCalled();
+
+        component
+            .find('input')
+            .first()
+            .simulate('focus');
+
+        expect(focusMock).toHaveBeenCalled();
     });
 
     it('should floor and ceil the minLimit and maxLimit respectively', () => {
@@ -70,5 +99,11 @@ describe('Slider', () => {
 
         expect(slider.props().minValue).toBe(1);
         expect(slider.props().maxValue).toBe(16);
+    });
+
+    it('should render the aria-label when provided', () => {
+        const component = mountWithTheme(<Slider label="foo-label" value={5} minLimit={1.75} maxLimit={15.13} />);
+
+        expect(component.find(InputSlider).prop('aria-label')).toBe('foo-label');
     });
 });


### PR DESCRIPTION
### This PR:

resolves [STRF-160](https://myonlinestore.atlassian.net/browse/STRF-160)


**Backwards compatible additions** ✨
- Component `Slider` now also supports a couple of optional props: `hideInputField`, `onFocus`, `onBlur`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
