### PR TITLE
Added support for ISO-15897 locales to pricetag

### DIFF
--- a/src/components/PriceTag/index.tsx
+++ b/src/components/PriceTag/index.tsx
@@ -32,13 +32,20 @@ const deriveStatsFromPart = (initialStats: StatsType, part: Intl.PartType): Stat
     isFree: isFree(part) ? false : initialStats.isFree,
 });
 
+/**
+ * This component renders a span with the locale aware version of the price.
+ * It also allows you to render some common design patterns for prices like
+ * superscripting the fraction or hiding the decimal when they equal 0.
+ */
+
 const PriceTag: FunctionComponent<PropsType> = (props): JSX.Element => {
-    const formatter = new Intl.NumberFormat(props.locale, {
+    const formatter = new Intl.NumberFormat(props.locale.replace('_', '-'), {
         style: 'currency',
         currency: props.currency,
     });
 
     const parts = formatter.formatToParts(props.value);
+
     const stats = parts.reduce(deriveStatsFromPart, {
         isRound: false,
         isFree: true,
@@ -53,7 +60,7 @@ const PriceTag: FunctionComponent<PropsType> = (props): JSX.Element => {
             case 'decimal':
                 return formatDecimalSeperator(part.value, props, stats.isRound);
             case 'literal':
-                return props.hideCurrency && props.hideCurrency === true ? undefined : part.value;
+                return props.hideCurrency === true ? '' : part.value;
             default:
                 return part.value;
         }

--- a/src/components/PriceTag/index.tsx
+++ b/src/components/PriceTag/index.tsx
@@ -60,7 +60,7 @@ const PriceTag: FunctionComponent<PropsType> = (props): JSX.Element => {
             case 'decimal':
                 return formatDecimalSeperator(part.value, props, stats.isRound);
             case 'literal':
-                return props.hideCurrency === true ? '' : part.value;
+                return props.hideCurrency === true ? undefined : part.value;
             default:
                 return part.value;
         }


### PR DESCRIPTION
### This PR:

Like the TextField.Currency, with this PR the `PriceTag` now also support ISO-15897 locales. (nl_NL, en_GB)

**Backwards compatible additions** ✨
- Like the TextField.Currency, with this PR the `PriceTag` now also support ISO-15897 locales. (nl_NL, en_GB)

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
