### PR TITLE
Added doc generation to docs website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,48 +1,87 @@
-# Code conventions
+# Contributing
 
+## Code conventions
+To help maintain a consistent experience for users (and contributors) we have a few conventions around the naming of variables and props.
 
 ### Props 
-Props should be named like html attributes. Just the essence of what it does like `show` or `error`. Only function props should have prefixes.
+We like make sure components resemble html as much as possible. This makes for a familiar experience in usage. Try to keep the naming of props als terse as possible.
 
 ```tsx
-👍 <Checkbox error={this.props.error}>
-----
-👎 <Checkbox errorMessage={this.props.error}>
+// 👍 
+<Checkbox error={this.props.error} />
 ```
 
+```tsx
+// 👎 
+<Checkbox errorMessage={this.props.error} />
+```
 
 ### Callbacks
-Functions should describe what's happening. External callbacks should be prefixed with `on`. Internal functions should respond to the requested action like handleRequestedAction. Prefix should be handle followed by the action like `click`, `hover`, `mouseEnter` etc. Try to avoid ambiguous terms like `action`. 
+When passing a callback to a component. It is important to note that the code is ran in response to a specific event. Therefore we name the property according to the event you are "subscribing" to. If you want a user to be able to act when your component is clicked. You could create a prop called onClick. We try to opt for `on....` since that is a community convention and matches the js runtime best.
 
-*External:*
 ```tsx
-👍 <Button onClick={handleClick} />
-----
-👎 <Button action={handleClick} />
-```
-*Internal:*
-```tsx
-👍 <StyledButton onHover={handleHover} />
-----
-👎 <StyledButton hover={onHover} />
+// 👍
+<Button onClick={handleClick} />
 ```
 
+```tsx
+// 👎 
+<Button action={handleClick} />
+```
 
 ### Types
-Types should end with the `Type` suffix. This makes them easy to identify as such in usage.
-
-```ts
-👍 type ButtonVariantType = {...}
-----
-👎 type ButtonVariant = {...}
-```
-
-### State Variables 
-The variables should provide context to what it does and indirectly explain what is happening in the code. So no single letter variables 🙂. Internal booleans should be prefixed with verbs like `is`, `has`, `should` etc.
+Since types, classes and components share the same capitalization conventions, we add a `Type` suffix to make sure that they are easy to distinguish from eachother.
 
 ```tsx
-👍  <Checkbox checked={this.state.isChecked} />
+// 👍 
+type FooType = {...}
+```
 
-----
-👎  <Checkbox checked={this.state.checked} /> 
+```tsx
+// 👎 
+type Foo = {...}
+```
+
+### Variables
+In contrast to props, regular variables should be easy to distinguish from functions and. They should also properly describe their content. Because of this try to avoid single letter variables since they can obfuscate code for beginners.
+
+```tsx
+// 👍
+const handleClick = (event) => {}
+```
+
+```tsx
+// 👎
+const handleClick = (e) => {}
+```
+
+```tsx
+// 👍
+const isShown = true;
+const show = () => {}
+```
+
+```tsx
+// 👎
+const show = true;
+const open = () => {}
+```
+
+All other conventions will be enforced by prettier. You can set prettier up to run in most IDE's but we will also format your code before you push your code.
+
+## Docs
+Bricks comes with a docs website. This website generates it's content by pulling text from readme.mdx files colocated with components.
+
+### Writing readme's
+Components readme's are written in [MDX](https://mdxjs.com/). This let's you render the component along with your textual content the same way like you would with JSX. To render a component from bricks in your readme. Make sure to add an import statement to the readme.
+
+You should import the component like you would in a external application. You __cannot__ use relative imports in your readme's since the docs install a symlinked version of the bricks build results.
+
+```md
+import { Foo } from '@myonlinestore/bricks';
+
+# Foo
+
+## Examples
+<Foo bar />
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+# Docs
+
+This website is auto generated from mdx files in this repo. The website currently supports the following features:
+
+- [x] Pulling and rendering readme's as react.
+- [ ] Auto generating pages based on mdx files.
+
+## Running the website
+
+Start by running `yarn` in this folder, this make sure all your dependencies are installed and symlinks the your `../../dist` folder to this website's node_modules.
+
+Currently there are 3 scripts that you can run to get te website up and running. 
+
+- `update-bricks`: builds bricks and copies readme to `../../dist` (accessable by importing from `@myonlinestore/bricks`).
+- `update-docs`: just copies the readme's over to the dist.
+- `start`: start the next server. The website is then accessable on [http:localhost:3000](http:localhost:3000)
+
+> Note: The general workflow for this site is very much a work in progress. Feel free to submit a PR improving this experience or leave an issue ✌️.

--- a/docs/components/Page.tsx
+++ b/docs/components/Page.tsx
@@ -5,23 +5,18 @@ import { Box, FoldOut, Link, Text } from '@myonlinestore/bricks';
 const Page: FC = props => {
     return (
         <main>
-            <Box width="100%">
-                <Box basis="300px">
-                    <Nav>
-                        <Box margin={[0, 0, 12, 0]}>
-                            <Text strong variant="large">
-                                Components
-                            </Text>
-                        </Box>
-                        <FoldOut open>
-                            <Text>
-                                <Link href="" title="Button" />
-                            </Text>
-                        </FoldOut>
-                    </Nav>
-                </Box>
-                <Box grow={1} padding={[48, 120 as 0]}>
-                    {props.children}
+            <Box minHeight="100vh">
+                <Box width="100%" alignContent="stretch">
+                    <Box basis="300px">
+                        <Nav>
+                            <Link href="/" title="Home" />
+                            <br />
+                            <Link href="/components" title="Badge" />
+                        </Nav>
+                    </Box>
+                    <Box grow={1} padding={[48, 120 as 0]}>
+                        {props.children}
+                    </Box>
                 </Box>
             </Box>
         </main>

--- a/docs/lib/componentMap.tsx
+++ b/docs/lib/componentMap.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { Heading, Text } from '@myonlinestore/bricks';
 
-const componentMap = {
-    h1: (props: any) => <Heading hierarchy={1}>{props.children}</Heading>,
-    h2: (props: any) => <Heading hierarchy={2}>{props.children}</Heading>,
-    h3: (props: any) => <Heading hierarchy={3}>{props.children}</Heading>,
-    h4: (props: any) => <Heading hierarchy={4}>{props.children}</Heading>,
-    h5: (props: any) => <Heading hierarchy={5}>{props.children}</Heading>,
-    h6: (props: any) => <Heading hierarchy={6}>{props.children}</Heading>,
-    p: (props: any) => <Text>{props.children}</Text>,
+const componentMap: { [key: string]: FC } = {
+    h1: props => <Heading hierarchy={1}>{props.children}</Heading>,
+    h2: props => <Heading hierarchy={2}>{props.children}</Heading>,
+    h3: props => <Heading hierarchy={3}>{props.children}</Heading>,
+    h4: props => <Heading hierarchy={4}>{props.children}</Heading>,
+    h5: props => <Heading hierarchy={5}>{props.children}</Heading>,
+    h6: props => <Heading hierarchy={6}>{props.children}</Heading>,
+    p: props => <Text>{props.children}</Text>,
 };
 
 export default componentMap;

--- a/docs/lib/componentMap.tsx
+++ b/docs/lib/componentMap.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Heading, Text } from '@myonlinestore/bricks';
+
+const componentMap = {
+    h1: (props: any) => <Heading hierarchy={1}>{props.children}</Heading>,
+    h2: (props: any) => <Heading hierarchy={2}>{props.children}</Heading>,
+    h3: (props: any) => <Heading hierarchy={3}>{props.children}</Heading>,
+    h4: (props: any) => <Heading hierarchy={4}>{props.children}</Heading>,
+    h5: (props: any) => <Heading hierarchy={5}>{props.children}</Heading>,
+    h6: (props: any) => <Heading hierarchy={6}>{props.children}</Heading>,
+    p: (props: any) => <Text>{props.children}</Text>,
+};
+
+export default componentMap;

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,2 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+
+declare module '*.mdx' {
+    let MDXComponent: (props) => JSX.Element;
+    export default MDXComponent;
+}

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,0 +1,12 @@
+const images = require('remark-images');
+const emoji = require('remark-emoji');
+
+const withMDX = require('@zeit/next-mdx')({
+    options: {
+        mdPlugins: [images, emoji],
+    },
+});
+
+module.exports = withMDX({
+    pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'mdx'],
+});

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "remark-images": "0.8.1"
   },
   "scripts": {
-      "build-bricks": "cd ../ && yarn build && cd docs",
+      "update-bricks": "cd ../ && yarn build && cd docs",
       "update-docs": "cd ../ && yarn docs && cd docs && rimraf node_modules && yarn",
       "start": "next"
   }

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,10 +5,15 @@
   "license": "MIT",
   "dependencies": {
     "next": "^9.0.2",
-    "@myonlinestore/bricks": "file:../dist"
+    "@myonlinestore/bricks": "file:../dist",
+    "@mdx-js/mdx": "0.15.0-0",
+    "@zeit/next-mdx": "1.1.0",
+    "remark-emoji": "2.0.1",
+    "remark-images": "0.8.1"
   },
   "scripts": {
       "build-bricks": "cd ../ && yarn build && cd docs",
-      "start": "yarn build-bricks && next"
+      "update-docs": "cd ../ && yarn docs && cd docs && rimraf node_modules && yarn",
+      "start": "next"
   }
 }

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import App, { Container } from 'next/app';
 import { Box, MosTheme } from '@myonlinestore/bricks';
 import Head from '../components/Head';
+import Page from '../components/Page';
 
 declare module 'react' {
     interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -18,9 +19,9 @@ class MyApp extends App {
             <MosTheme>
                 <Container>
                     <Head />
-                    <Box direction="column" wrap={false} minHeight="100vh">
+                    <Page>
                         <Component {...pageProps} />
-                    </Box>
+                    </Page>
                 </Container>
             </MosTheme>
         );

--- a/docs/pages/components.tsx
+++ b/docs/pages/components.tsx
@@ -1,0 +1,16 @@
+import React, { FC } from 'react';
+import { Box } from '@myonlinestore/bricks';
+import Document from '@myonlinestore/bricks/components/Badge/readme.mdx';
+import componentMap from '../lib/componentMap';
+
+type PropsType = {};
+
+const Components: FC<PropsType> = props => {
+    return (
+        <Box>
+            <Document components={componentMap} />
+        </Box>
+    );
+};
+
+export default Components;

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -1,18 +1,15 @@
 import React, { FC } from 'react';
 import { Button, Box, Text } from '@myonlinestore/bricks';
-import Page from '../components/Page';
 
 const Index: FC = () => {
     return (
-        <Page>
-            <Box height="100vh" justifyContent="center" direction="column" width="100%">
-                <Text variant="display">Bricks</Text>
-                <Text variant="large">A design system and component library made by MyOnlineStore.</Text>
-                <Box margin={[24, 0, 0, 0]}>
-                    <Button title="Explore" variant="primary" />
-                </Box>
+        <Box height="100vh" justifyContent="center" direction="column" width="100%">
+            <Text variant="display">Bricks</Text>
+            <Text variant="large">A design system and component library made by MyOnlineStore.</Text>
+            <Box margin={[24, 0, 0, 0]}>
+                <Button title="Explore" variant="primary" />
             </Box>
-        </Page>
+        </Box>
     );
 };
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -772,6 +772,31 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@mdx-js/loader@^0.7.0":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-0.7.4.tgz#d673e628b4d9ffcafaa8f8079468d6fc87ac1a7b"
+  integrity sha512-abvR6WgM+nR8rhhaUNgpnxOGtRUN9vjjWrDbFaBSYXGmx4SykJPeVbCLfk4qOKp/vn2X04f7oMkopis0aJkLOg==
+  dependencies:
+    "@mdx-js/tag" "^0.7.2"
+
+"@mdx-js/mdx@0.15.0-0":
+  version "0.15.0-0"
+  resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-0.15.0-0.tgz#ec50dd43a8da98a0b34f4193ade396f866453a16"
+  integrity sha512-lGY2jRqbvclxql1SjWAXCr3qyTx1TlVH9FoUj1vid2HWXSIYCyzgxOmesjY/HcqRsmsu8LzyDdEEUdti7zvciQ==
+  dependencies:
+    mdast-util-to-hast "^3.0.0"
+    remark-parse "^5.0.0"
+    remark-squeeze-paragraphs "^3.0.1"
+    unified "^6.1.6"
+    unist-util-visit "^1.3.0"
+
+"@mdx-js/tag@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@mdx-js/tag/-/tag-0.7.2.tgz#a18d76644089b4a9bb6d489d205cb065051b7c9a"
+  integrity sha512-DNGtzX/YdOT8OSxSdEwvgQYrQrTDmd3BErOG+dQ0m/x/Mq7zIUcWMzGnWK6erW26FGZqvu8uVBcrnd5AMFXyrQ==
+  dependencies:
+    prop-types "^15.6.1"
+
 "@myonlinestore/bricks@file:../dist":
   version "0.0.0"
 
@@ -930,6 +955,13 @@
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
+
+"@zeit/next-mdx@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@zeit/next-mdx/-/next-mdx-1.1.0.tgz#32753243504e475b110e1ad07ff92c9b31366b04"
+  integrity sha512-o+NOgmikHVJQ9/Dc2/ZhNnfFApP0jGNNYD47cT4euPpgF3zl/mY96HTDiqy9MzMP9+463TlwWMloEYEpd8K6Mg==
+  dependencies:
+    "@mdx-js/loader" "^0.7.0"
 
 abbrev@1:
   version "1.1.1"
@@ -1227,6 +1259,11 @@ babel-types@6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
+bail@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.4.tgz#7181b66d508aa3055d3f6c13f0a0c720641dde9b"
+  integrity sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -1456,6 +1493,21 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+character-entities-legacy@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz#3c729991d9293da0ede6dddcaf1f2ce1009ee8b4"
+  integrity sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==
+
+character-entities@^1.0.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.3.tgz#bbed4a52fe7ef98cc713c6d80d9faa26916d54e6"
+  integrity sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==
+
+character-reference-invalid@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz#1647f4f726638d3ea4a750cf5d1975c1c7919a85"
+  integrity sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==
+
 chokidar@^2.0.2, chokidar@^2.0.4:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.6.tgz#b6cad653a929e244ce8a834244164d241fa954c5"
@@ -1509,6 +1561,11 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+collapse-white-space@^1.0.0, collapse-white-space@^1.0.2:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.5.tgz#c2495b699ab1ed380d29a1091e01063e75dbbe3a"
+  integrity sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ==
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -1810,6 +1867,13 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+detab@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/detab/-/detab-2.0.2.tgz#074970d1a807b045d0258a4235df5928dd683561"
+  integrity sha512-Q57yPrxScy816TTE1P/uLRXLDKjXhvYTbfxS/e6lPD+YrqghbsMlGB9nQzj/zVtSPaF0DFPSdO916EWO4sQUyQ==
+  dependencies:
+    repeat-string "^1.5.4"
+
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
@@ -1982,6 +2046,11 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
   dependencies:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
+
+extend@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
 extglob@^2.0.4:
   version "2.0.4"
@@ -2412,6 +2481,19 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.3.tgz#eb04cc47219a8895d8450ace4715abff2258a1f8"
+  integrity sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz#57ae21c374277b3defe0274c640a5704b8f6657c"
+  integrity sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -2424,7 +2506,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -2442,6 +2524,11 @@ is-data-descriptor@^1.0.0:
   integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
   dependencies:
     kind-of "^6.0.0"
+
+is-decimal@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.3.tgz#381068759b9dc807d8c0dc0bfbae2b68e1da48b7"
+  integrity sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -2504,6 +2591,11 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-hexadecimal@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz#e8a426a69b6d31470d3a33a47bb825cda02506ee"
+  integrity sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -2530,6 +2622,11 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
+is-plain-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+  integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -2537,10 +2634,25 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-url@^1.2.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
+
+is-whitespace-character@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz#b3ad9546d916d7d3ffa78204bca0c26b56257fac"
+  integrity sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==
+
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
+is-word-character@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.3.tgz#264d15541cbad0ba833d3992c34e6b40873b08aa"
+  integrity sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -2697,6 +2809,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.toarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
+  integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
+
 lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
@@ -2748,6 +2865,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-escapes@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.3.tgz#6155e10416efaafab665d466ce598216375195f5"
+  integrity sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -2756,6 +2878,42 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+mdast-squeeze-paragraphs@^3.0.0:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-3.0.5.tgz#f428b6b944f8faef454db9b58f170c4183cb2e61"
+  integrity sha512-xX6Vbe348Y/rukQlG4W3xH+7v4ZlzUbSY4HUIQCuYrF2DrkcHx584mCaFxkWoDZKNUfyLZItHC9VAqX3kIP7XA==
+  dependencies:
+    unist-util-remove "^1.0.0"
+
+mdast-util-definitions@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-1.2.4.tgz#2b54ad4eecaff9d9fcb6bf6f9f6b68b232d77ca7"
+  integrity sha512-HfUArPog1j4Z78Xlzy9Q4aHLnrF/7fb57cooTHypyGoe2XFNbcx/kWZDoOz+ra8CkUzvg3+VHV434yqEd1DRmA==
+  dependencies:
+    unist-util-visit "^1.0.0"
+
+mdast-util-to-hast@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-3.0.4.tgz#132001b266031192348d3366a6b011f28e54dc40"
+  integrity sha512-/eIbly2YmyVgpJNo+bFLLMCI1XgolO/Ffowhf+pHDq3X4/V6FntC9sGQCDLM147eTS+uSXv5dRzJyFn+o0tazA==
+  dependencies:
+    collapse-white-space "^1.0.0"
+    detab "^2.0.0"
+    mdast-util-definitions "^1.2.0"
+    mdurl "^1.0.1"
+    trim "0.0.1"
+    trim-lines "^1.0.0"
+    unist-builder "^1.0.1"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.1.0"
+    xtend "^4.0.1"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
   version "0.4.1"
@@ -3008,6 +3166,13 @@ next@^9.0.2:
     webpack-hot-middleware "2.25.0"
     webpack-sources "1.3.0"
     worker-farm "1.7.0"
+
+node-emoji@^1.4.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.10.0.tgz#8886abd25d9c7bb61802a658523d1f8d2a89b2da"
+  integrity sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==
+  dependencies:
+    lodash.toarray "^4.4.0"
 
 node-fetch@2.6.0:
   version "2.6.0"
@@ -3280,6 +3445,18 @@ parse-asn1@^5.0.0:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
+parse-entities@^1.1.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
+  integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
@@ -3444,7 +3621,7 @@ prop-types-exact@1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.7.2:
+prop-types@15.7.2, prop-types@^15.6.1:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -3672,6 +3849,50 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
+remark-emoji@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/remark-emoji/-/remark-emoji-2.0.1.tgz#6de4be7acb05b8534b6bad679d56eab24fba5e06"
+  integrity sha512-bcJbn5KObMXDs3U00SZZTOiqygDgP3ls6S5zw4ONFWcwQcOqJNpO0YnCaqted9DJLtgJjBZcuqK4eKuyPDJTQw==
+  dependencies:
+    node-emoji "^1.4.1"
+    unist-util-visit "^1.1.0"
+
+remark-images@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/remark-images/-/remark-images-0.8.1.tgz#9c5ebd2f5973c95d21ee342f078e68876cbab580"
+  integrity sha512-1NpiFnIQ7WQIeL+1ofFdrP7NYW+jOShXbjqwertfZMDzFrTrWqY6PmMSWl3imGqPF2AWyMOPkxObe6botEb5Cg==
+  dependencies:
+    is-url "^1.2.2"
+    unist-util-visit "^1.3.0"
+
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
+remark-squeeze-paragraphs@^3.0.1:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-3.0.4.tgz#9fe50c3bf3b572dd88754cd426ada007c0b8dc5f"
+  integrity sha512-Wmz5Yj9q+W1oryo8BV17JrOXZgUKVcpJ2ApE2pwnoHwhFKSk4Wp2PmFNbmJMgYSqAdFwfkoe+TSYop5Fy8wMgA==
+  dependencies:
+    mdast-squeeze-paragraphs "^3.0.0"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -3682,10 +3903,15 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.6.1:
+repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
+  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -3963,6 +4189,11 @@ ssri@^6.0.1:
   dependencies:
     figgy-pudding "^3.5.1"
 
+state-toggle@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.2.tgz#75e93a61944116b4959d665c8db2d243631d6ddc"
+  integrity sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -4228,10 +4459,30 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
+trim-lines@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-1.1.2.tgz#c8adbdbdae21bb5c2766240a661f693afe23e59b"
+  integrity sha512-3GOuyNeTqk3FAqc3jOJtw7FTjYl94XBR5aD9QnDbK/T4CA9sW/J0l9RoaRPE9wyPP7NF331qnHnvJFBJ+IDkmQ==
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+trim-trailing-lines@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz#d2f1e153161152e9f02fabc670fb40bec2ea2e3a"
+  integrity sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
+
+trough@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.4.tgz#3b52b1f13924f460c3fbfd0df69b587dbcbc762e"
+  integrity sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==
 
 tslib@^1.9.0:
   version "1.10.0"
@@ -4260,6 +4511,14 @@ unfetch@4.1.0:
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"
   integrity sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==
 
+unherit@^1.0.4:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.2.tgz#14f1f397253ee4ec95cec167762e77df83678449"
+  integrity sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==
+  dependencies:
+    inherits "^2.0.1"
+    xtend "^4.0.1"
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -4282,6 +4541,18 @@ unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz#a9cc6cc7ce63a0a3023fc99e341b94431d405a57"
   integrity sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==
+
+unified@^6.1.6:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  integrity sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -4306,6 +4577,61 @@ unique-slug@^2.0.0:
   integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
   dependencies:
     imurmurhash "^0.1.4"
+
+unist-builder@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-1.0.4.tgz#e1808aed30bd72adc3607f25afecebef4dd59e17"
+  integrity sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==
+  dependencies:
+    object-assign "^4.1.0"
+
+unist-util-generated@^1.1.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.4.tgz#2261c033d9fc23fae41872cdb7663746e972c1a7"
+  integrity sha512-SA7Sys3h3X4AlVnxHdvN/qYdr4R38HzihoEVY2Q2BZu8NHWDnw5OGcC/tXWjQfd4iG+M6qRFNIRGqJmp2ez4Ww==
+
+unist-util-is@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
+  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
+
+unist-util-position@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.0.3.tgz#fff942b879538b242096c148153826664b1ca373"
+  integrity sha512-28EpCBYFvnMeq9y/4w6pbnFmCUfzlsc41NJui5c51hOFjBA1fejcwc+5W4z2+0ECVbScG3dURS3JTVqwenzqZw==
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz#d91aa8b89b30cb38bad2924da11072faa64fd972"
+  integrity sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-remove@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-remove/-/unist-util-remove-1.0.3.tgz#58ec193dfa84b52d5a055ffbc58e5444eb8031a3"
+  integrity sha512-mB6nCHCQK0pQffUAcCVmKgIWzG/AXs/V8qpS8K72tMPtOSCMSjDeMc5yN+Ye8rB0FhcE+JvW++o1xRNc0R+++g==
+  dependencies:
+    unist-util-is "^3.0.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+  integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
+
+unist-util-visit-parents@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
+  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
+  dependencies:
+    unist-util-is "^3.0.0"
+
+unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
+  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 unpipe@1.0.0:
   version "1.0.0"
@@ -4381,6 +4707,28 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+vfile-location@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.5.tgz#c83eb02f8040228a8d2b3f10e485be3e3433e0a2"
+  integrity sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ==
+
+vfile-message@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
+  integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  integrity sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 vm-browserify@^1.0.1:
   version "1.1.0"
@@ -4503,7 +4851,12 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-xtend@^4.0.0, xtend@~4.0.1:
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+  integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
+
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "dev": "npm run watch",
     "test": "jest",
     "test-coverage": "jest --coverage --runInBand --bail",
-    "build": "rimraf ./dist && webpack && bundlesize && yarn docs",
+    "build": "rimraf ./dist && webpack && yarn docs&& bundlesize",
     "lint-fix": "npm run lint -- --fix",
     "lint": "tslint --project tsconfig.json -c tslint.json ./src/**/*.{ts,tsx}",
     "watch": "start-storybook -p 9001 -s .storybook/public",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "dev": "npm run watch",
     "test": "jest",
     "test-coverage": "jest --coverage --runInBand --bail",
-    "build": "rimraf ./dist && webpack && bundlesize",
+    "build": "rimraf ./dist && webpack && bundlesize && yarn docs",
     "lint-fix": "npm run lint -- --fix",
     "lint": "tslint --project tsconfig.json -c tslint.json ./src/**/*.{ts,tsx}",
     "watch": "start-storybook -p 9001 -s .storybook/public",
@@ -116,7 +116,8 @@
     "build-storybook": "build-storybook -o public -s .storybook/public",
     "cs-fix": "prettier --write ./src/**/*.{ts,tsx}",
     "cs": "prettier --list-different ./src/**/*.{ts,tsx}",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "docs": "node scripts/copy-readme.js"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "dev": "npm run watch",
     "test": "jest",
     "test-coverage": "jest --coverage --runInBand --bail",
-    "build": "rimraf ./dist && webpack && yarn docs&& bundlesize",
+    "build": "rimraf ./dist && webpack && yarn docs && bundlesize",
     "lint-fix": "npm run lint -- --fix",
     "lint": "tslint --project tsconfig.json -c tslint.json ./src/**/*.{ts,tsx}",
     "watch": "start-storybook -p 9001 -s .storybook/public",

--- a/scripts/copy-readme.js
+++ b/scripts/copy-readme.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+const found = [];
+
+const copyReadme = (dir, filter) => {
+    if (!fs.existsSync(dir)) {
+        throw new Error(`No directory found at ${dir}`);
+    }
+
+    const files = fs.readdirSync(dir);
+
+    for (let i = 0; i < files.length; i++) {
+        const filename = path.join(dir, files[i]);
+        const stat = fs.lstatSync(filename);
+
+        if (stat.isDirectory()) {
+            copyReadme(filename, filter);
+        } else if (filename.indexOf(filter) >= 0) {
+            found.push(filename);
+        }
+    }
+
+    for (let i = 0; i < found.length; i++) {
+        const newPath = found[i].replace('src', 'dist');
+
+        fs.writeFileSync(newPath, fs.readFileSync(found[i]));
+    }
+};
+
+copyReadme('src', '.mdx');

--- a/src/components/Badge/readme.mdx
+++ b/src/components/Badge/readme.mdx
@@ -1,0 +1,9 @@
+import { Badge } from '@myonlinestore/bricks';
+
+# Badge
+
+"Introduction to the badge component."
+
+## Examples
+
+<Badge>Badge</Badge>


### PR DESCRIPTION
### This PR:

This PR sets up content management for the docs website by pulling from readme files. We could use github as a "versioned CMS" since you can edit a file without knowing anything about git through the github web app.


**Bugfixes/Changed internals** 🎈
- The docs-site can now take content from readme.mdx files colocated in component folders.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
