### PR TITLE
Textfield is now testable with a data-testid

### DIFF
--- a/src/components/TextField/formatters/withCurrencyFormatting/test.tsx
+++ b/src/components/TextField/formatters/withCurrencyFormatting/test.tsx
@@ -294,4 +294,19 @@ describe('withCurrencyFormatting', () => {
         expect(component.find('input').prop('value')).toEqual('1908');
         expect(changeMock).toHaveBeenCalledWith(190800);
     });
+
+    it('should be testable with a test-id', () => {
+        const component = mountWithTheme(
+            <TextField.Currency
+                data-testid="foo"
+                locale="nl-NL"
+                currency="EUR"
+                value={0}
+                name="foo"
+                onChange={jest.fn()}
+            />,
+        );
+
+        expect(component.find('[data-testid="foo"]').hostNodes().length).toBe(1);
+    });
 });

--- a/src/components/TextField/formatters/withNumberFormatting/test.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/test.tsx
@@ -36,4 +36,12 @@ describe('withNumberFormatting', () => {
 
         expect(changeMock).toHaveBeenCalledWith(0);
     });
+
+    it('should be testable with a test-id', () => {
+        const component = mountWithTheme(
+            <TextField.Number data-testid="foo" value={0} name="foo" onChange={jest.fn()} />,
+        );
+
+        expect(component.find('[data-testid="foo"]').hostNodes().length).toBe(1);
+    });
 });

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -1,6 +1,5 @@
 import React, { ChangeEvent, Component } from 'react';
 import SeverityType from '../../types/SeverityType';
-import trbl from '../../utility/trbl';
 import InlineNotification from '../InlineNotification';
 import Box from '../Box';
 import { StyledInput, StyledWrapper, StyledAffix, StyledAffixWrapper } from './style';

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -24,6 +24,7 @@ type PropsType = {
     suffix?: string;
     disabled?: boolean;
     placeholder?: string;
+    'data-testid'?: string;
     extractRef?(ref: HTMLInputElement): void;
     onChange(value: string, event: ChangeEvent<HTMLInputElement>): void;
     onBlur?(): void;
@@ -81,6 +82,7 @@ class TextField extends Component<PropsType, StateType> {
                     )}
                     <Box position="relative" width="100%">
                         <StyledInput
+                            data-testid={this.props['data-testid']}
                             type={this.props.type ? this.props.type : 'text'}
                             placeholder={this.props.placeholder}
                             name={this.props.name}
@@ -106,7 +108,7 @@ class TextField extends Component<PropsType, StateType> {
                     )}
                 </StyledWrapper>
                 {this.props.feedback && this.props.feedback.message !== '' && (
-                    <Box margin={trbl(6, 0, 0, 12)}>
+                    <Box margin={[6, 0, 0, 12]}>
                         <InlineNotification
                             icon={this.props.feedback.severity === 'info' ? questionCircle : dangerCircle}
                             message={this.props.feedback.message}

--- a/src/components/TextField/test.tsx
+++ b/src/components/TextField/test.tsx
@@ -60,4 +60,10 @@ describe('TextField', () => {
         );
         expect(component.find(StyledInput).prop('placeholder')).toEqual('foo');
     });
+
+    it('should be testable with a test-id', () => {
+        const component = mountWithTheme(<TextField data-testid="foo" value="" name="foo" onChange={jest.fn()} />);
+
+        expect(component.find('[data-testid="foo"]').hostNodes().length).toBe(1);
+    });
 });


### PR DESCRIPTION
### This PR:

**Backwards compatible additions** ✨
- Textfield is now testable with a data-testid


**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
