### PR TITLE
Correctly render Skeletons in a FormRow

### DIFF
--- a/src/components/FormRow/index.tsx
+++ b/src/components/FormRow/index.tsx
@@ -13,8 +13,8 @@ const FormRow: FunctionComponent<PropsType> = (props): JSX.Element => {
     return (
         <StyledFormRow>
             <Box basis={'180px'} direction="row" grow={1} maxWidth="241px" margin={trbl(18, 9, 0, 0)} wrap>
-                <Box wrap={false}>
-                    <Box>{props.label}</Box>
+                <Box grow={1} wrap={false}>
+                    <Box grow={props.badge ? 0 : 1}>{props.label}</Box>
                     <Box margin={[-9, 3]}>{props.badge !== undefined && props.badge}</Box>
                 </Box>
             </Box>

--- a/src/components/FormRow/story.tsx
+++ b/src/components/FormRow/story.tsx
@@ -1,4 +1,3 @@
-// tslint:disable:max-file-line-count
 import { storiesOf } from '@storybook/react';
 import React, { Component } from 'react';
 import Checkbox from '../Checkbox';

--- a/src/components/FormRow/story.tsx
+++ b/src/components/FormRow/story.tsx
@@ -10,6 +10,7 @@ import Toggle from '../Toggle';
 import trbl from '../../utility/trbl';
 import Separated from '../Separated';
 import { text } from '@storybook/addon-knobs';
+import { Skeleton } from '../..';
 
 type PropsType = {
     descriptions: boolean;
@@ -344,5 +345,12 @@ storiesOf('FormRow', module)
                     <Toggle checked={true} name="storyToggle" value={'true'} onChange={(): string => 'void'} />
                 </Box>
             }
+        />
+    ))
+    .add('With Skeletons', () => (
+        <FormRow
+            label={<Skeleton.Text lines={1} baseWidth={180} />}
+            // 38px is the height of an TextField field
+            field={<Skeleton.Rect width="100%" height="38px" />}
         />
     ));

--- a/src/components/FormRow/story.tsx
+++ b/src/components/FormRow/story.tsx
@@ -1,3 +1,4 @@
+// tslint:disable:max-file-line-count
 import { storiesOf } from '@storybook/react';
 import React, { Component } from 'react';
 import Checkbox from '../Checkbox';


### PR DESCRIPTION
### This PR:

resolves #382 

This renders Skeletons in the `FormRow` the same as before the introduction of the `badge` prop.

**Bugfixes/Changed internals** 🎈
- Skeleton now renders properly in the label field of a `FormRow` again.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
