### PR TITLE
Disable 'max-file-line-count' in tslint and remove all references

### DIFF
--- a/src/components/Select/test.tsx
+++ b/src/components/Select/test.tsx
@@ -48,8 +48,6 @@ const options = [
     },
 ];
 
-/* tslint:disable:max-file-line-count */
-
 describe('Select', () => {
     it('should open when the spacebar is pressed', () => {
         const component = mountWithTheme(

--- a/src/components/Table/test.tsx
+++ b/src/components/Table/test.tsx
@@ -1,5 +1,4 @@
 /// <reference path="../../_declarations/global.d.ts" />
-/* tslint:disable:max-file-line-count */
 import React from 'react';
 import { DragDropContext } from 'react-beautiful-dnd';
 import Table from '.';

--- a/src/themes/MosCorporateTheme/theme.ts
+++ b/src/themes/MosCorporateTheme/theme.ts
@@ -3,8 +3,6 @@ import rgba from '../../utility/rgba';
 import RecursivePartialType from '../../types/RecursivePartialType';
 import { bodyFont, fontSize, green, silver, grey, red, yellow } from '../MosTheme/MosTheme.theme';
 
-/* tslint:disable:max-file-line-count */
-
 const roundness = {
     base: '19px',
 };

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -1,8 +1,6 @@
 import ThemeType from '../../types/ThemeType';
 import rgba from '../../utility/rgba';
 
-/* tslint:disable:max-file-line-count */
-
 const bodyFont = 'Source Sans Pro,sans-serif';
 const headingFont = 'Melbourne,sans-serif';
 

--- a/tslint.json
+++ b/tslint.json
@@ -40,7 +40,6 @@
   
       "max-line-length": [ true, 200 ],
       "max-classes-per-file": [true, 1],
-      "max-file-line-count": [true, 350],
       "member-access": true,
       "member-ordering": [true, {
           "order": [


### PR DESCRIPTION
### This PR:

Removes TSLint rule `max-file-line-count` as we disable it when necessary making it only a nuisance and not a help.

**Bugfixes/Changed internals** 🎈
- Disable `max-file-line-count` rule in TSLint

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
