### PR TITLE
Add optional secondary button and persistent option to Toast

### DIFF
--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -65,7 +65,11 @@ class Toast extends Component<PropsType> {
             <TransitionAnimation show={this.props.show} animation="zoom" onExited={this.handleExit}>
                 <Measure client>
                     {({ measureRef, contentRect }) => {
-                        const isSmall = contentRect.client && contentRect.client.width < 375;
+                        const isSmall =
+                            (!this.props.secondaryButtonTitle &&
+                                contentRect.client &&
+                                contentRect.client.width < 375) ||
+                            (this.props.secondaryButtonTitle && contentRect.client && contentRect.client.width < 550);
 
                         return (
                             <StyledToastWrapper ref={measureRef} role="alertdialog" aria-label={this.props.title}>

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -17,12 +17,15 @@ type PropsType = {
     show: boolean;
     message?: string;
     buttonTitle?: string;
+    secondaryButtonTitle?: string;
     buttonSeverity?: ButtonVariant;
     severity: SeverityType;
     autoDismiss?: boolean;
+    persistent?: boolean;
     onExited?(): void;
     onClose?(): void;
     onClick?(): void;
+    onClickSecondary?(): void;
 };
 
 type ButtonVariant = 'primary' | 'destructive' | 'warning' | 'secondary' | 'plain';
@@ -49,7 +52,7 @@ class Toast extends Component<PropsType> {
     };
 
     public componentDidMount = (): void => {
-        if (this.props.autoDismiss) setTimeout((): void => this.closeAction(), 6000);
+        if (this.props.autoDismiss && !this.props.persistent) setTimeout((): void => this.closeAction(), 6000);
     };
 
     public render(): JSX.Element {
@@ -96,6 +99,20 @@ class Toast extends Component<PropsType> {
                                                     </Text>
                                                 )}
                                             </Box>
+                                            {this.props.secondaryButtonTitle && (
+                                                <Box
+                                                    direction="column"
+                                                    justifyContent="center"
+                                                    margin={isSmall ? trbl(0, 12, 12, 12) : trbl(0, 6, 0, 12)}
+                                                    alignItems="flex-start"
+                                                >
+                                                    <Button
+                                                        title={this.props.secondaryButtonTitle}
+                                                        onClick={this.props.onClickSecondary}
+                                                        variant={'secondary'}
+                                                    />
+                                                </Box>
+                                            )}
                                             {this.props.buttonTitle && (
                                                 <Box
                                                     direction="column"
@@ -112,13 +129,15 @@ class Toast extends Component<PropsType> {
                                             )}
                                         </Box>
                                         <Box direction="column" margin={[0, 12, 0, 0]}>
-                                            <IconButton
-                                                variant="primary"
-                                                icon={close}
-                                                iconSize="small"
-                                                title="close"
-                                                onClick={this.closeAction}
-                                            />
+                                            {!this.props.persistent && (
+                                                <IconButton
+                                                    variant="primary"
+                                                    icon={close}
+                                                    iconSize="small"
+                                                    title="close"
+                                                    onClick={this.closeAction}
+                                                />
+                                            )}
                                         </Box>
                                     </StyledToast>
                                 </Box>

--- a/src/components/Toast/story.tsx
+++ b/src/components/Toast/story.tsx
@@ -4,6 +4,7 @@ import React, { Component } from 'react';
 import Toast, { PropsType } from '.';
 import Toaster from '../Toaster';
 import cash from '../../assets/icons/cash.svg';
+import infoCircle from '../../assets/icons/info-circle.svg';
 
 class Demo extends Component<{}, { isOpen: boolean }> {
     public constructor(props: PropsType) {
@@ -66,4 +67,19 @@ storiesOf('Toast', module)
         });
 
         return <Toaster />;
-    });
+    })
+    .add('Persistent with secondary button', () => (
+        <Toast
+            icon={infoCircle}
+            onClick={(): boolean => confirm('Primary action')}
+            show={boolean('show', true)}
+            severity={select('severity', ['success', 'warning', 'error', 'info'], 'info') as PropsType['severity']}
+            onClose={(): boolean => confirm('Do you want to close the Toast? \nYou must choose, but choose wisely')}
+            buttonTitle={text('Button title', 'Accept')}
+            secondaryButtonTitle={text('Secondary title', 'More information')}
+            onClickSecondary={(): boolean => confirm('Secondary action')}
+            persistent={boolean('persistent', true)}
+            title={text('title', 'Overcome injustice.')}
+            message={text('description', 'Please agree or decline this proposition.')}
+        />
+    ));

--- a/src/components/Toast/test.tsx
+++ b/src/components/Toast/test.tsx
@@ -85,9 +85,9 @@ describe('Toast', () => {
             />,
         );
 
-        const closeButton = component.find(Button);
+        const buttons = component.find(Button);
 
-        closeButton.forEach(button => {
+        buttons.forEach(button => {
             button.simulate('click');
         });
 

--- a/src/components/Toast/test.tsx
+++ b/src/components/Toast/test.tsx
@@ -52,7 +52,8 @@ describe('Toast', () => {
                 show
                 severity={'warning'}
                 buttonSeverity={'destructive'}
-                buttonTitle="Bar?"
+                buttonTitle="Bar"
+                secondaryButtonTitle="Baz"
                 onClose={undefined}
                 title="Foo"
             />,
@@ -69,15 +70,60 @@ describe('Toast', () => {
 
     it('should be possible to trigger the button', () => {
         const clickMock = jest.fn();
+        const clickMockSecondary = jest.fn();
 
         const component = mountWithTheme(
-            <Toast show severity="warning" title="Foo" buttonTitle="Bar?" onClose={undefined} onClick={clickMock} />,
+            <Toast
+                show
+                severity="warning"
+                title="Foo"
+                buttonTitle="Bar"
+                secondaryButtonTitle="Baz"
+                onClose={undefined}
+                onClick={clickMock}
+                onClickSecondary={clickMockSecondary}
+            />,
         );
 
         const closeButton = component.find(Button);
 
-        closeButton.simulate('click');
+        closeButton.forEach(button => {
+            button.simulate('click');
+        });
 
         expect(clickMock).toHaveBeenCalled();
+        expect(clickMockSecondary).toHaveBeenCalled();
+    });
+
+    it('should not have a closebutton when persistent is true', () => {
+        const clickMock = jest.fn();
+
+        const component = mountWithTheme(
+            <Toast show persistent severity="success" buttonTitle="Bar" title="Foo" onClose={clickMock} />,
+        );
+
+        const closeButton = component.find(IconButton);
+
+        expect(closeButton).toHaveLength(0);
+    });
+
+    it('should render two buttons if a second button title is provided', () => {
+        const clickMock = jest.fn();
+
+        const component = mountWithTheme(
+            <Toast
+                show
+                persistent
+                severity="success"
+                buttonTitle="Bar"
+                secondaryButtonTitle="Baz"
+                title="Foo"
+                onClose={clickMock}
+            />,
+        );
+
+        const buttons = component.find(Button);
+
+        expect(buttons).toHaveLength(2);
     });
 });


### PR DESCRIPTION
### This PR:

Adds the possibility to add a secondary button to a toast as well as the option to make a toast persistent, meaning that it has no close button and cannot autodismiss.

**Backwards compatible additions** ✨
- `secondaryButtonTitle`, `onClickSecondary` and `persistent` props to `Toast`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
