### PR TITLE
Radio testid

### DIFF
--- a/src/components/RadioButton/index.tsx
+++ b/src/components/RadioButton/index.tsx
@@ -1,10 +1,10 @@
-import React, {Component} from 'react';
+import React, { FC, useState } from 'react';
 import trbl from '../../utility/trbl';
 import Box from '../Box';
 import Text from '../Text';
 import Icon from '../Icon';
 import lockedIcon from '../../assets/icons/locked.svg';
-import StyledRadioButton, {StyledRadioButtonSkin, StyledRadioWrapper} from './style';
+import StyledRadioButton, { StyledRadioButtonSkin, StyledRadioWrapper } from './style';
 
 type StateType = {
     focus: boolean;
@@ -19,69 +19,61 @@ type PropsType = {
     id?: string;
     label: string;
     'data-testid'?: string;
-    onChange(change: {checked: boolean; value: string}): void;
+    onChange(change: { checked: boolean; value: string }): void;
 };
 
-class RadioButton extends Component<PropsType, StateType> {
-    public constructor(props: PropsType) {
-        super(props);
+const RadioButton: FC<PropsType> = props => {
+    const [isFocussed, setFocus] = useState(false);
 
-        this.state = {
-            focus: false,
-        };
-    }
-
-    public toggleFocus = (): void => {
-        this.setState({focus: !this.state.focus});
+    const toggleFocus = (): void => {
+        setFocus(!isFocussed);
     };
 
-    public handleChange = (): void => {
-        this.props.onChange({
-            checked: !this.props.checked,
-            value: this.props.value,
+    const handleChange = (): void => {
+        props.onChange({
+            checked: !props.checked,
+            value: props.value,
         });
     };
 
-    public render(): JSX.Element {
-        return (
-            <StyledRadioWrapper onClick={this.handleChange}>
-                <Box margin={this.props.disabled ? trbl(0, 6, 0, 0) : trbl(0, 12, 0, 0)}>
-                    <StyledRadioButtonSkin
-                        elementFocus={this.state.focus}
-                        checked={this.props.checked}
-                        disabled={this.props.disabled}
-                        error={this.props.error}
-                    >
-                        <StyledRadioButton
-                            onFocus={this.toggleFocus}
-                            onBlur={this.toggleFocus}
-                            onChange={this.handleChange}
-                            checked={this.props.checked}
-                            type="radio"
-                            name={this.props.name}
-                            value={this.props.value}
-                            id={this.props.id}
-                            aria-labelledby={this.props.name}
-                            data-testid={this.props['data-testid']}
-                        />
-                    </StyledRadioButtonSkin>
+    return (
+        <StyledRadioWrapper onClick={handleChange}>
+            <Box margin={props.disabled ? trbl(0, 6, 0, 0) : trbl(0, 12, 0, 0)}>
+                <StyledRadioButtonSkin
+                    elementFocus={isFocussed}
+                    checked={props.checked}
+                    disabled={props.disabled}
+                    error={props.error}
+                >
+                    <StyledRadioButton
+                        onFocus={toggleFocus}
+                        onBlur={toggleFocus}
+                        onChange={handleChange}
+                        checked={props.checked}
+                        type="radio"
+                        name={props.name}
+                        value={props.value}
+                        id={props.id}
+                        aria-labelledby={props.name}
+                        data-testid={props['data-testid']}
+                    />
+                </StyledRadioButtonSkin>
+            </Box>
+            <Text severity={props.disabled ? 'info' : undefined}>
+                <Box inline direction="row" align-items="center">
+                    {props.disabled && (
+                        <Box inline margin={trbl(0, 12, 0, 0)}>
+                            <Icon size="medium" icon={lockedIcon} />{' '}
+                        </Box>
+                    )}
+                    <label id={props.name} htmlFor={props.name}>
+                        {props.label}
+                    </label>
                 </Box>
-                <Text severity={this.props.disabled ? 'info' : undefined}>
-                    <Box inline direction="row" align-items="center">
-                        {this.props.disabled && (
-                            <Box inline margin={trbl(0, 12, 0, 0)}>
-                                <Icon size="medium" icon={lockedIcon} />{' '}
-                            </Box>
-                        )}
-                        <label id={this.props.name} htmlFor={this.props.name}>
-                            {this.props.label}
-                        </label>
-                    </Box>
-                </Text>
-            </StyledRadioWrapper>
-        );
-    }
-}
+            </Text>
+        </StyledRadioWrapper>
+    );
+};
 
 export default RadioButton;
-export {PropsType, StateType};
+export { PropsType, StateType };

--- a/src/components/RadioButton/index.tsx
+++ b/src/components/RadioButton/index.tsx
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import trbl from '../../utility/trbl';
 import Box from '../Box';
 import Text from '../Text';
 import Icon from '../Icon';
 import lockedIcon from '../../assets/icons/locked.svg';
-import StyledRadioButton, { StyledRadioButtonSkin, StyledRadioWrapper } from './style';
+import StyledRadioButton, {StyledRadioButtonSkin, StyledRadioWrapper} from './style';
 
 type StateType = {
     focus: boolean;
@@ -18,7 +18,8 @@ type PropsType = {
     name: string;
     id?: string;
     label: string;
-    onChange(change: { checked: boolean; value: string }): void;
+    'data-testid'?: string;
+    onChange(change: {checked: boolean; value: string}): void;
 };
 
 class RadioButton extends Component<PropsType, StateType> {
@@ -31,7 +32,7 @@ class RadioButton extends Component<PropsType, StateType> {
     }
 
     public toggleFocus = (): void => {
-        this.setState({ focus: !this.state.focus });
+        this.setState({focus: !this.state.focus});
     };
 
     public handleChange = (): void => {
@@ -61,6 +62,7 @@ class RadioButton extends Component<PropsType, StateType> {
                             value={this.props.value}
                             id={this.props.id}
                             aria-labelledby={this.props.name}
+                            data-testid={this.props['data-testid']}
                         />
                     </StyledRadioButtonSkin>
                 </Box>
@@ -82,4 +84,4 @@ class RadioButton extends Component<PropsType, StateType> {
 }
 
 export default RadioButton;
-export { PropsType, StateType };
+export {PropsType, StateType};

--- a/src/components/RadioButton/test.tsx
+++ b/src/components/RadioButton/test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import RadioButton from '.';
-import { mosTheme } from '../../themes/MosTheme';
-import { mountWithTheme } from '../../utility/styled/testing';
-import StyledRadioButton, { StyledRadioButtonSkin } from './style';
+import {mosTheme} from '../../themes/MosTheme';
+import {mountWithTheme} from '../../utility/styled/testing';
+import StyledRadioButton, {StyledRadioButtonSkin} from './style';
 import 'jest-styled-components';
 
 describe('RadioButton', () => {
@@ -94,5 +94,43 @@ describe('RadioButton', () => {
             'border',
             `1px solid ${mosTheme.RadioButton.error.borderColor}`,
         );
+    });
+
+    it('should be testable with a data-testid', () => {
+        const component = mountWithTheme(
+            <RadioButton checked name="foo" value="foo" label="foo" onChange={jest.fn()} data-testid="foo" />,
+        );
+
+        expect(component.find('[data-testid="foo"]').hostNodes().length).toBe(1);
+    });
+
+    it('should be able to simulate a change', () => {
+        const changeMock = jest.fn();
+
+        const component = mountWithTheme(
+            <RadioButton checked name="foo" value="foo" label="foo" onChange={changeMock} data-testid="foo" />,
+        );
+
+        component
+            .find('[data-testid="foo"]')
+            .hostNodes()
+            .simulate('change');
+
+        expect(changeMock).toHaveBeenCalledWith({checked: false, value: 'foo'});
+    });
+
+    it('should be able to trigger a change by simulating a click', () => {
+        const changeMock = jest.fn();
+
+        const component = mountWithTheme(
+            <RadioButton checked name="foo" value="foo" label="foo" onChange={changeMock} data-testid="foo" />,
+        );
+
+        component
+            .find('[data-testid="foo"]')
+            .hostNodes()
+            .simulate('click');
+
+        expect(changeMock).toHaveBeenCalledWith({checked: false, value: 'foo'});
     });
 });

--- a/src/components/RadioButton/test.tsx
+++ b/src/components/RadioButton/test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import RadioButton from '.';
-import {mosTheme} from '../../themes/MosTheme';
-import {mountWithTheme} from '../../utility/styled/testing';
-import StyledRadioButton, {StyledRadioButtonSkin} from './style';
+import { mosTheme } from '../../themes/MosTheme';
+import { mountWithTheme } from '../../utility/styled/testing';
+import StyledRadioButton, { StyledRadioButtonSkin } from './style';
 import 'jest-styled-components';
 
 describe('RadioButton', () => {
@@ -116,7 +116,7 @@ describe('RadioButton', () => {
             .hostNodes()
             .simulate('change');
 
-        expect(changeMock).toHaveBeenCalledWith({checked: false, value: 'foo'});
+        expect(changeMock).toHaveBeenCalledWith({ checked: false, value: 'foo' });
     });
 
     it('should be able to trigger a change by simulating a click', () => {
@@ -131,6 +131,6 @@ describe('RadioButton', () => {
             .hostNodes()
             .simulate('click');
 
-        expect(changeMock).toHaveBeenCalledWith({checked: false, value: 'foo'});
+        expect(changeMock).toHaveBeenCalledWith({ checked: false, value: 'foo' });
     });
 });

--- a/src/components/Text/test.tsx
+++ b/src/components/Text/test.tsx
@@ -51,4 +51,10 @@ describe('Text', () => {
 
         expect(component).toHaveStyleRule('font-weight', mosTheme.Text.strong.fontWeight);
     });
+
+    it('should be testable with a data-testid', () => {
+        const component = mountWithTheme(<Text data-testid="foo">some text</Text>);
+
+        expect(component.find('[data-testid="foo"]').hostNodes().length).toBe(1);
+    });
 });


### PR DESCRIPTION
### This PR:

Makes the radiobutton testable with a data-testid prop.

**Backwards compatible additions** ✨
- RadioButton is not testable with a data-testid

**Bugfixes/Changed internals** 🎈
- Wrote some test to cover the testid
- Rewrote the Radiobutton to hooks. 
- Added a test for the Text component, since it is already testable with a testid.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
