### PR TITLE
Fix buttongroup focus order

### DIFF
--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -6,26 +6,24 @@ type PropsType = {
     'data-testid'?: string;
 };
 
-const ButtonGroup: FunctionComponent<PropsType> = (props): JSX.Element => {
-    const direction = props.stacked ? 'column' : 'row-reverse';
+const ButtonGroup: FunctionComponent<PropsType> = props => {
+    const direction = props.stacked ? 'column' : 'row';
+    const children = props.stacked ? Children.toArray(props.children) : Children.toArray(props.children).reverse();
 
     return (
         <Box
             direction={direction}
-            justifyContent="flex-start"
+            justifyContent={props.stacked ? 'flex-start' : 'flex-end'}
             alignItems="stretch"
             wrap
             margin={[-6]}
             data-testid={props['data-testid']}
         >
-            {Children.map(
-                props.children,
-                (child): JSX.Element => (
-                    <Box direction={direction === 'row-reverse' ? 'row' : 'column'} alignSelf="stretch" margin={[6]}>
-                        {child}
-                    </Box>
-                ),
-            )}
+            {children.map((child, index) => (
+                <Box key={index} direction={direction} alignSelf="stretch" margin={[6]}>
+                    {child}
+                </Box>
+            ))}
         </Box>
     );
 };

--- a/src/components/ButtonGroup/story.tsx
+++ b/src/components/ButtonGroup/story.tsx
@@ -9,17 +9,32 @@ const Wrap = styled.div`
     border: solid 3px rgba(255, 36, 94, 0.3);
 `;
 
-storiesOf('Buttons/ButtonGroup', module).add('Default', () => {
-    return (
-        <Wrap>
-            <ButtonGroup>
-                <Button variant="primary" title="Primary button">
-                    Primary button
-                </Button>
-                <Button variant="secondary" title="Secondary button">
-                    Secondary button
-                </Button>
-            </ButtonGroup>
-        </Wrap>
-    );
-});
+storiesOf('Buttons/ButtonGroup', module)
+    .add('Default', () => {
+        return (
+            <Wrap>
+                <ButtonGroup>
+                    <Button variant="primary" title="Primary button">
+                        Primary button
+                    </Button>
+                    <Button variant="secondary" title="Secondary button">
+                        Secondary button
+                    </Button>
+                </ButtonGroup>
+            </Wrap>
+        );
+    })
+    .add('Stacked', () => {
+        return (
+            <Wrap>
+                <ButtonGroup stacked>
+                    <Button variant="primary" title="Primary button">
+                        Primary button
+                    </Button>
+                    <Button variant="secondary" title="Secondary button">
+                        Secondary button
+                    </Button>
+                </ButtonGroup>
+            </Wrap>
+        );
+    });

--- a/src/components/ButtonGroup/test.tsx
+++ b/src/components/ButtonGroup/test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ButtonGroup from '.';
 import Button from '../Button';
-import {mountWithTheme} from '../../utility/styled/testing';
+import { mountWithTheme } from '../../utility/styled/testing';
 
 describe('ButtonGroup', () => {
     it('renders the correct amount of Buttons', () => {

--- a/src/components/ButtonGroup/test.tsx
+++ b/src/components/ButtonGroup/test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ButtonGroup from '.';
 import Button from '../Button';
-import { mountWithTheme } from '../../utility/styled/testing';
+import {mountWithTheme} from '../../utility/styled/testing';
 
 describe('ButtonGroup', () => {
     it('renders the correct amount of Buttons', () => {
@@ -29,5 +29,51 @@ describe('ButtonGroup', () => {
         const component = mountWithTheme(<ButtonGroup data-testid="buttongroup" />);
 
         expect(component.find('[data-testid="buttongroup"]').hostNodes()).toHaveLength(1);
+    });
+
+    it('should render the buttons in the correct order', () => {
+        const component = mountWithTheme(
+            <ButtonGroup>
+                <Button title="foo" variant="primary" />
+                <Button title="bar" variant="secondary" />
+            </ButtonGroup>,
+        );
+
+        expect(
+            component
+                .find(Button)
+                .last()
+                .prop('variant'),
+        ).toEqual('primary');
+
+        expect(
+            component
+                .find(Button)
+                .first()
+                .prop('variant'),
+        ).toEqual('secondary');
+    });
+
+    it('should render the buttons in the correct order when stacked', () => {
+        const component = mountWithTheme(
+            <ButtonGroup stacked>
+                <Button title="foo" variant="primary" />
+                <Button title="bar" variant="secondary" />
+            </ButtonGroup>,
+        );
+
+        expect(
+            component
+                .find(Button)
+                .first()
+                .prop('variant'),
+        ).toEqual('primary');
+
+        expect(
+            component
+                .find(Button)
+                .last()
+                .prop('variant'),
+        ).toEqual('secondary');
     });
 });


### PR DESCRIPTION
### This PR:
 
resolves #424 

**Bugfixes/Changed internals** 🎈
- switched the button order from flexbox reverse-row to an array reverse. This way the order isn't just perceived.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
