### PR TITLE
fix: Raised styling no longer has padding and width

### DIFF
--- a/src/components/Raised/index.tsx
+++ b/src/components/Raised/index.tsx
@@ -21,8 +21,6 @@ const Raised = styled.div<PropsType>`
     box-shadow: ${({ level, theme }): string => (level ? theme.Raised[`level${level}`].boxShadow : 'none')};
     transition: box-shadow 300ms;
     border-radius: 3px 3px 3px 3px;
-    padding: 36px;
-    width: 100%;
 `;
 
 const composeRaisedTheme = (themeTools: ThemeTools): RaisedThemeType => {

--- a/src/components/_MerchantTheme/sampleContent.tsx
+++ b/src/components/_MerchantTheme/sampleContent.tsx
@@ -87,68 +87,70 @@ const SampleContent: FunctionComponent<PropsType> = (props): JSX.Element => {
                 rel="stylesheet"
             />
             <Box direction="column" width="100%" padding={[0, 0, 24, 0]}>
-                <Raised level={2} style={{ boxSizing: 'border-box', backgroundColor: '#FFF' }}>
-                    <Box direction="row" style={{ marginBottom: '20px' }}>
-                        {mapColors(props.themeSettings.colors.primary, 'Primary Color')}
-                        {mapColors(props.themeSettings.colors.secondary, 'Secondary Color')}
-                        {mapColors(props.themeSettings.colors.tertiary, 'Tertiary Color')}
-                        {mapColors(props.themeSettings.colors.silver, 'Light')}
-                        {mapColors(props.themeSettings.colors.grey, 'Dark')}
-                    </Box>
-                    <Box direction="column">
-                        <Box
-                            style={{
-                                backgroundColor: props.themeSettings.colors.background,
-                                color: props.themeSettings.text.colors.textOnBackground,
-                                height: '30px',
-                                fontSize: '12px',
-                                fontFamily: 'monospace',
-                            }}
-                            justifyContent="center"
-                            alignItems="center"
-                        >
-                            text on background : {props.themeSettings.wcagContrastRatios.backgroundToText}
-                            {props.themeSettings.wcagContrastRatios.backgroundToText < 4.5 && <> 👎</>}
+                <Raised level={2}>
+                    <div style={{ backgroundColor: '#FFF', padding: '36px' }}>
+                        <Box direction="row" style={{ marginBottom: '20px' }}>
+                            {mapColors(props.themeSettings.colors.primary, 'Primary Color')}
+                            {mapColors(props.themeSettings.colors.secondary, 'Secondary Color')}
+                            {mapColors(props.themeSettings.colors.tertiary, 'Tertiary Color')}
+                            {mapColors(props.themeSettings.colors.silver, 'Light')}
+                            {mapColors(props.themeSettings.colors.grey, 'Dark')}
                         </Box>
-                        <Box
-                            style={{
-                                backgroundColor: props.themeSettings.colors.contrastBackground,
-                                color: props.themeSettings.text.colors.textOnBackground,
-                                height: '30px',
-                                fontSize: '12px',
-                                fontFamily: 'monospace',
-                            }}
-                            justifyContent="center"
-                            alignItems="center"
-                        >
-                            text on contrasting background :{' '}
-                            {props.themeSettings.wcagContrastRatios.contrastBackgroundToText}
-                            {props.themeSettings.wcagContrastRatios.contrastBackgroundToText < 4.5 && <> 👎</>}
+                        <Box direction="column">
+                            <Box
+                                style={{
+                                    backgroundColor: props.themeSettings.colors.background,
+                                    color: props.themeSettings.text.colors.textOnBackground,
+                                    height: '30px',
+                                    fontSize: '12px',
+                                    fontFamily: 'monospace',
+                                }}
+                                justifyContent="center"
+                                alignItems="center"
+                            >
+                                text on background : {props.themeSettings.wcagContrastRatios.backgroundToText}
+                                {props.themeSettings.wcagContrastRatios.backgroundToText < 4.5 && <> 👎</>}
+                            </Box>
+                            <Box
+                                style={{
+                                    backgroundColor: props.themeSettings.colors.contrastBackground,
+                                    color: props.themeSettings.text.colors.textOnBackground,
+                                    height: '30px',
+                                    fontSize: '12px',
+                                    fontFamily: 'monospace',
+                                }}
+                                justifyContent="center"
+                                alignItems="center"
+                            >
+                                text on contrasting background :{' '}
+                                {props.themeSettings.wcagContrastRatios.contrastBackgroundToText}
+                                {props.themeSettings.wcagContrastRatios.contrastBackgroundToText < 4.5 && <> 👎</>}
+                            </Box>
+                            <Box
+                                style={{
+                                    backgroundColor: props.themeSettings.colors.background,
+                                    color: props.themeSettings.colors.primary.base,
+                                    height: '30px',
+                                    fontSize: '12px',
+                                    fontFamily: 'monospace',
+                                }}
+                                justifyContent="center"
+                                alignItems="center"
+                            >
+                                primary on background : {props.themeSettings.wcagContrastRatios.backgroundToPrimary}
+                                {props.themeSettings.wcagContrastRatios.backgroundToPrimary < 4.5 && <> 👎</>}
+                            </Box>
+                            {props.themeSettings.wcagContrastRatios.backgroundToText >= 4.5 &&
+                                props.themeSettings.wcagContrastRatios.contrastBackgroundToText >= 4.5 &&
+                                props.themeSettings.wcagContrastRatios.backgroundToPrimary >= 4.5 && (
+                                    <Box justifyContent="center" alignItems="center" padding={[12]}>
+                                        <Text style={{ color: '#000' }}>
+                                            The contrasts in this theme are WCAG approved 👍
+                                        </Text>
+                                    </Box>
+                                )}
                         </Box>
-                        <Box
-                            style={{
-                                backgroundColor: props.themeSettings.colors.background,
-                                color: props.themeSettings.colors.primary.base,
-                                height: '30px',
-                                fontSize: '12px',
-                                fontFamily: 'monospace',
-                            }}
-                            justifyContent="center"
-                            alignItems="center"
-                        >
-                            primary on background : {props.themeSettings.wcagContrastRatios.backgroundToPrimary}
-                            {props.themeSettings.wcagContrastRatios.backgroundToPrimary < 4.5 && <> 👎</>}
-                        </Box>
-                        {props.themeSettings.wcagContrastRatios.backgroundToText >= 4.5 &&
-                            props.themeSettings.wcagContrastRatios.contrastBackgroundToText >= 4.5 &&
-                            props.themeSettings.wcagContrastRatios.backgroundToPrimary >= 4.5 && (
-                                <Box justifyContent="center" alignItems="center" padding={[12]}>
-                                    <Text style={{ color: '#000' }}>
-                                        The contrasts in this theme are WCAG approved 👍
-                                    </Text>
-                                </Box>
-                            )}
-                    </Box>
+                    </div>
                 </Raised>
             </Box>
             <Box direction="column" padding={[24, 0]}>
@@ -174,133 +176,135 @@ const SampleContent: FunctionComponent<PropsType> = (props): JSX.Element => {
                     <Notification severity="info" message="Hello buddy. I am here for you." />
                 </Separated>
             </Box>
-            <Raised level={1} style={{ boxSizing: 'border-box' }}>
-                <form>
-                    <FormRow
-                        label={
-                            <label>
-                                <Text>What is your name?</Text>
-                            </label>
-                        }
-                        field={
-                            <Box wrap width="100%">
-                                <Box>
-                                    <Box margin={[0, 9, 18, 0]} justifyContent="stretch" grow={1} width="40%">
+            <Raised level={1}>
+                <Box padding={[36]}>
+                    <form>
+                        <FormRow
+                            label={
+                                <label>
+                                    <Text>What is your name?</Text>
+                                </label>
+                            }
+                            field={
+                                <Box wrap width="100%">
+                                    <Box>
+                                        <Box margin={[0, 9, 18, 0]} justifyContent="stretch" grow={1} width="40%">
+                                            <TextField
+                                                prefix="Initials"
+                                                name="Initials"
+                                                value={sampleForm.initials}
+                                                onChange={(initials: string): void =>
+                                                    setSampleForm({ ...sampleForm, initials })
+                                                }
+                                            />
+                                        </Box>
+                                        <Box margin={[0, 9, 18, 0]} justifyContent="stretch" grow={1} width="60%">
+                                            <TextField
+                                                prefix="First name"
+                                                name="First name"
+                                                value={sampleForm.firstname}
+                                                onChange={(firstname: string): void =>
+                                                    setSampleForm({ ...sampleForm, firstname })
+                                                }
+                                            />
+                                        </Box>
+                                    </Box>
+                                    <Box margin={[0, 9, 18, 0]} justifyContent="stretch" grow={1}>
                                         <TextField
-                                            prefix="Initials"
-                                            name="Initials"
-                                            value={sampleForm.initials}
-                                            onChange={(initials: string): void =>
-                                                setSampleForm({ ...sampleForm, initials })
+                                            prefix="Surname"
+                                            name="Lastname"
+                                            value={sampleForm.lastname}
+                                            onChange={(lastname: string): void =>
+                                                setSampleForm({ ...sampleForm, lastname })
                                             }
                                         />
                                     </Box>
-                                    <Box margin={[0, 9, 18, 0]} justifyContent="stretch" grow={1} width="60%">
-                                        <TextField
-                                            prefix="First name"
-                                            name="First name"
-                                            value={sampleForm.firstname}
-                                            onChange={(firstname: string): void =>
-                                                setSampleForm({ ...sampleForm, firstname })
-                                            }
+                                </Box>
+                            }
+                        />
+                        <FormRow
+                            label={
+                                <label>
+                                    <Box>
+                                        <Text>Can a boolean only be either true or false?</Text>
+                                    </Box>
+                                    <Text severity="info">In my opinion a boolean should also be "maybe".</Text>
+                                </label>
+                            }
+                            field={
+                                <Box direction="row" wrap={true} margin={[9, 0]}>
+                                    <Box padding={[0, 24, 0, 0]}>
+                                        <RadioButton
+                                            name="bool"
+                                            label="True"
+                                            value="1"
+                                            checked={sampleForm.selected === 1}
+                                            onChange={({ value }): void => {
+                                                setSampleForm({ ...sampleForm, selected: parseInt(value, 10) });
+                                            }}
+                                        />
+                                    </Box>
+                                    <Box padding={[0, 24, 0, 0]}>
+                                        <RadioButton
+                                            name="bool"
+                                            label="False"
+                                            value="2"
+                                            checked={sampleForm.selected === 2}
+                                            onChange={({ value }): void => {
+                                                setSampleForm({ ...sampleForm, selected: parseInt(value, 10) });
+                                            }}
+                                        />
+                                    </Box>
+                                    <Box padding={[0, 24, 0, 0]}>
+                                        <RadioButton
+                                            name="bool"
+                                            label="Sometimes"
+                                            value="3"
+                                            checked={sampleForm.selected === 3}
+                                            onChange={({ value }): void => {
+                                                setSampleForm({ ...sampleForm, selected: parseInt(value, 10) });
+                                            }}
                                         />
                                     </Box>
                                 </Box>
-                                <Box margin={[0, 9, 18, 0]} justifyContent="stretch" grow={1}>
-                                    <TextField
-                                        prefix="Surname"
-                                        name="Lastname"
-                                        value={sampleForm.lastname}
-                                        onChange={(lastname: string): void =>
-                                            setSampleForm({ ...sampleForm, lastname })
-                                        }
-                                    />
-                                </Box>
-                            </Box>
-                        }
-                    />
-                    <FormRow
-                        label={
-                            <label>
-                                <Box>
-                                    <Text>Can a boolean only be either true or false?</Text>
-                                </Box>
-                                <Text severity="info">In my opinion a boolean should also be "maybe".</Text>
-                            </label>
-                        }
-                        field={
-                            <Box direction="row" wrap={true} margin={[9, 0]}>
-                                <Box padding={[0, 24, 0, 0]}>
-                                    <RadioButton
-                                        name="bool"
-                                        label="True"
-                                        value="1"
-                                        checked={sampleForm.selected === 1}
-                                        onChange={({ value }): void => {
-                                            setSampleForm({ ...sampleForm, selected: parseInt(value, 10) });
-                                        }}
-                                    />
-                                </Box>
-                                <Box padding={[0, 24, 0, 0]}>
-                                    <RadioButton
-                                        name="bool"
-                                        label="False"
-                                        value="2"
-                                        checked={sampleForm.selected === 2}
-                                        onChange={({ value }): void => {
-                                            setSampleForm({ ...sampleForm, selected: parseInt(value, 10) });
-                                        }}
-                                    />
-                                </Box>
-                                <Box padding={[0, 24, 0, 0]}>
-                                    <RadioButton
-                                        name="bool"
-                                        label="Sometimes"
-                                        value="3"
-                                        checked={sampleForm.selected === 3}
-                                        onChange={({ value }): void => {
-                                            setSampleForm({ ...sampleForm, selected: parseInt(value, 10) });
-                                        }}
-                                    />
-                                </Box>
-                            </Box>
-                        }
-                    />
-                    <FormRow
-                        label={
-                            <>
-                                <Text>Comments</Text>
-                            </>
-                        }
-                        field={
-                            <TextArea
-                                value={sampleForm.comments}
-                                name="comments"
-                                onChange={(value: string): void => {
-                                    setSampleForm({ ...sampleForm, comments: value });
-                                }}
-                            />
-                        }
-                    />
-                    <FormRow
-                        label={
-                            <>
-                                <Text>Newsletter</Text>
-                            </>
-                        }
-                        field={
-                            <Toggle
-                                onChange={({ checked }): void => {
-                                    setSampleForm({ ...sampleForm, newsletter: checked });
-                                }}
-                                name="newsletter"
-                                value="newsletter"
-                                checked={sampleForm.newsletter}
-                                label={'subscribe to newsletter yes?'}
-                            />
-                        }
-                    />
-                </form>
+                            }
+                        />
+                        <FormRow
+                            label={
+                                <>
+                                    <Text>Comments</Text>
+                                </>
+                            }
+                            field={
+                                <TextArea
+                                    value={sampleForm.comments}
+                                    name="comments"
+                                    onChange={(value: string): void => {
+                                        setSampleForm({ ...sampleForm, comments: value });
+                                    }}
+                                />
+                            }
+                        />
+                        <FormRow
+                            label={
+                                <>
+                                    <Text>Newsletter</Text>
+                                </>
+                            }
+                            field={
+                                <Toggle
+                                    onChange={({ checked }): void => {
+                                        setSampleForm({ ...sampleForm, newsletter: checked });
+                                    }}
+                                    name="newsletter"
+                                    value="newsletter"
+                                    checked={sampleForm.newsletter}
+                                    label={'subscribe to newsletter yes?'}
+                                />
+                            }
+                        />
+                    </form>
+                </Box>
             </Raised>
             <Box direction="row" justifyContent="space-between" wrap={true} padding={[24, 0]}>
                 <Button title="Primary" variant="primary" />


### PR DESCRIPTION
### This PR:

resolves #438 

**Bugfixes/Changed internals** 🎈
- Removes `padding` and `width` from `Raised`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
