### PR TITLE
Added as prop to Box

### DIFF
--- a/src/components/Box/index.tsx
+++ b/src/components/Box/index.tsx
@@ -1,9 +1,10 @@
 import React, { FunctionComponent } from 'react';
 import trbl, { TrblType } from '../../utility/trbl';
-import { StyledDiv, StyledSpan } from './style';
+import { StyledBox } from './style';
 import { OffsetShorthandType } from '../../types/OffsetType';
 
 type PropsType = JSX.IntrinsicElements['div'] & {
+    as?: keyof JSX.IntrinsicElements;
     justifyContent?:
         | 'flex-start'
         | 'flex-end'
@@ -38,7 +39,7 @@ type PropsType = JSX.IntrinsicElements['div'] & {
     zIndex?: number;
 };
 
-const Box: FunctionComponent<PropsType> = (props): JSX.Element => {
+const Box: FunctionComponent<PropsType> = props => {
     const {
         order,
         direction,
@@ -73,10 +74,10 @@ const Box: FunctionComponent<PropsType> = (props): JSX.Element => {
         padding: shorthandPadding,
     };
 
-    return props.inline ? (
-        <StyledSpan {...newProps}>{props.children}</StyledSpan>
-    ) : (
-        <StyledDiv {...newProps}>{props.children}</StyledDiv>
+    return (
+        <StyledBox as={props.inline ? ('span' as 'span') : ('div' as 'div')} {...newProps}>
+            {props.children}
+        </StyledBox>
     );
 };
 

--- a/src/components/Box/style.tsx
+++ b/src/components/Box/style.tsx
@@ -16,7 +16,7 @@ type BoxPropsType = PropsType & {
     padding?: TrblType;
 };
 
-const StyledDiv = styled.div<BoxPropsType>`
+const StyledBox = styled.div<BoxPropsType>`
     box-sizing: border-box;
     display: ${({ inline }): string => (inline ? 'inline-flex' : 'flex')};
     height: ${({ elementHeight }): string => (elementHeight !== undefined ? elementHeight : '')};
@@ -63,6 +63,4 @@ const StyledDiv = styled.div<BoxPropsType>`
     ${({ zIndex }): string => (zIndex ? `z-index: ${zIndex};` : '')}
 `;
 
-const StyledSpan = StyledDiv.withComponent('span');
-
-export { StyledDiv, StyledSpan, BoxPropsType };
+export { StyledBox, BoxPropsType };

--- a/src/components/Box/test.tsx
+++ b/src/components/Box/test.tsx
@@ -154,4 +154,18 @@ describe('Box', () => {
 
         expect(component).toHaveStyleRule('z-index', '10');
     });
+
+    it('should be able to render an inline variant', () => {
+        const component = mount(<Box inline />);
+
+        expect(component.find('span').length).toBe(1);
+    });
+
+    it('should be able to overwrite the rendered html element', () => {
+        const component = mount(<Box as="dt" />);
+        const inlineComponent = mount(<Box inline as="dt" />);
+
+        expect(component.find('dt').length).toBe(1);
+        expect(inlineComponent.find('dt').length).toBe(1);
+    });
 });


### PR DESCRIPTION
### This PR:

The box missed to `as` prop that can be passed to the styled-component this PR fixes that.

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- None

**Bugfixes/Changed internals** 🎈
- Correctly typed the as prop on the Box
- Also used the as prop internally.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
