### PR TITLE
Close persistent toast on primary action

### DIFF
--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -32,7 +32,14 @@ type ButtonVariant = 'primary' | 'destructive' | 'warning' | 'secondary' | 'plai
 
 class Toast extends Component<PropsType> {
     private action = (): void => {
-        if (this.props.onClick !== undefined) this.props.onClick();
+        if (this.props.onClick !== undefined) {
+            this.props.onClick();
+
+            // When a toast is persistent, executing the primary action closes it instead of one of the other closing behaviors
+            if (this.props.persistent) {
+                this.closeAction();
+            }
+        }
     };
 
     private closeAction = (): void => {

--- a/src/components/Toast/story.tsx
+++ b/src/components/Toast/story.tsx
@@ -82,4 +82,21 @@ storiesOf('Toast', module)
             title={text('title', 'Overcome injustice.')}
             message={text('description', 'Please agree or decline this proposition.')}
         />
-    ));
+    ))
+    .add('Persistent and triggered remotely', () => {
+        button('Trigger a toast', () => {
+            window.toaster.notify({
+                icon: infoCircle,
+                onClick: () => confirm('Primary action'),
+                severity: 'info',
+                buttonTitle: 'Accept',
+                secondaryButtonTitle: 'More information',
+                onClickSecondary: () => confirm('Secondary action'),
+                persistent: true,
+                title: 'Overcome injustice',
+                message: 'Please agree or decline this proposition',
+            });
+        });
+
+        return <Toaster />;
+    });


### PR DESCRIPTION
### This PR:

The persistent prop was added to `Toast` to be able to use the toast in scenarios where they are forced to interact with it. In the way it was added it was not possible to close a remotely triggered persistent toast. This PR executes the close action on the primary button action to close the toast after a "successful" interaction has taken place. This is in line with our currently (single) usecase for the persistent `Toast`.

**Backwards compatible additions** ✨
- Persistent `Toast` closes on primary button action

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [ ] Appropriate tests have been added for my functionality (check if not applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
