### PR TITLE
Popover : added arrowStyle prop

### DIFF
--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect, useRef } from 'react';
+import React, { FC, useState, useEffect, useRef, CSSProperties } from 'react';
 import { Manager, Popper, PopperChildrenProps, Reference, ReferenceChildrenProps } from 'react-popper';
 import TransitionAnimation from '../TransitionAnimation';
 import { PopoverAnchor, PopoverArrow, PopoverBackground, PopoverContent, PopoverWindow } from './style';
@@ -14,6 +14,7 @@ type PropsType = {
     stretch?: boolean;
     preventOverflow?: boolean;
     triggerOn?: 'click' | 'hover';
+    arrowStyle?: CSSProperties;
     onClickOutside?(): void;
     renderContent(): JSX.Element | string;
 };
@@ -40,6 +41,8 @@ type PropsType = {
  * @param preventOverflow
  * This is used to prevent the tooltip from being positioned outside the boundary
  * [reference](https://popper.js.org/popper-documentation.html#modifiers..preventOverflow)
+ * @param arrowStyle
+ * These styles (react css properties) are applied on the arrow of the popover
  * @param triggerOn
  * Used to set they way the tooltip is triggered. Can't be used together with show prop.
  * @param onClickOutside
@@ -165,7 +168,11 @@ const Popover: FC<PropsType> = props => {
                             <PopoverWindow ref={ref} style={style}>
                                 <PopoverContent>{props.renderContent()}</PopoverContent>
                                 <PopoverBackground />
-                                <PopoverArrow ref={arrowProps.ref} style={arrowProps.style} placement={placement} />
+                                <PopoverArrow
+                                    ref={arrowProps.ref}
+                                    style={{ ...arrowProps.style, ...props.arrowStyle }}
+                                    placement={placement}
+                                />
                                 <PopoverArrow shadow style={arrowProps.style} placement={placement} />
                             </PopoverWindow>
                         )}


### PR DESCRIPTION
### This PR:

Adds a prop arrowStyle to the popover component that passes an object with css properties to the arrow rendered in react-popper.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
