### PR TITLE
FoldOut: Set overflow to visible when opening foldout and animate transition

### DIFF
--- a/src/components/FoldOut/style.tsx
+++ b/src/components/FoldOut/style.tsx
@@ -1,9 +1,13 @@
-import styled from 'styled-components';
+import styled, { keyframes, css } from 'styled-components';
 import { ContentProps } from '.';
+
+const animateOverflow = keyframes`
+    from { overflow: hidden; }
+    to { overflow: visible; }
+`;
 
 const StyledFoldOut = styled.div`
     transition: height 300ms cubic-bezier(0.5, 0, 0.1, 1);
-    overflow: hidden;
     height: ${(props: ContentProps): string => {
         if (!props.isOpen) {
             return '0';
@@ -15,6 +19,17 @@ const StyledFoldOut = styled.div`
 
         return 'auto';
     }};
+
+    ${(props: ContentProps) => {
+        if (props.isOpen) {
+            return css`
+                overflow: visible;
+                animation: 500ms ${animateOverflow};
+            `;
+        }
+
+        return 'overflow: hidden';
+    }}
 `;
 
 export default StyledFoldOut;


### PR DESCRIPTION
### This PR:

resolves #442 

**Bugfixes/Changed internals** 🎈
- Overflow is now visible when `FoldOut` is open

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
