### PR TITLE
Added onNotify callback to toaster

### DIFF
--- a/src/components/Toaster/index.tsx
+++ b/src/components/Toaster/index.tsx
@@ -11,7 +11,7 @@ type PropsType = {
     portalId?: string;
     /**
      * This callback can be used to respond to calls of toaster.notify, An example
-     * for this would to log an error every time a toast is shown with severity "error"
+     *  would be to log an error every time a toast is shown with severity "error"
      *
      * @example
      * ```

--- a/src/components/Toaster/index.tsx
+++ b/src/components/Toaster/index.tsx
@@ -4,8 +4,12 @@ import { createPortal } from 'react-dom';
 
 type ToastType = Pick<ToastPropsType, Exclude<keyof ToastPropsType, 'show'>>;
 
+// tslint:disable-next-line:no-any
+type MetaType = any;
+
 type PropsType = {
     portalId?: string;
+    onNotify?(toast: ToastType, meta?: MetaType): void;
 };
 
 type StateType = {
@@ -15,7 +19,7 @@ type StateType = {
 declare global {
     interface Window {
         toaster: {
-            notify(toast: ToastType): void;
+            notify(toast: ToastType, meta?: MetaType): void;
         };
     }
 }
@@ -65,7 +69,7 @@ class Toaster extends Component<PropsType, StateType> {
         };
     }
 
-    public notify = (toast: ToastType): void => {
+    public notify = (toast: ToastType, meta?: MetaType): void => {
         this.setState({
             toasts: [
                 ...this.state.toasts,
@@ -76,6 +80,10 @@ class Toaster extends Component<PropsType, StateType> {
                 },
             ],
         });
+
+        if (this.props.onNotify) {
+            this.props.onNotify(toast, meta);
+        }
     };
 
     public render(): JSX.Element {

--- a/src/components/Toaster/index.tsx
+++ b/src/components/Toaster/index.tsx
@@ -5,7 +5,7 @@ import { createPortal } from 'react-dom';
 type ToastType = Pick<ToastPropsType, Exclude<keyof ToastPropsType, 'show'>>;
 
 // tslint:disable-next-line:no-any
-type MetaType = any;
+type MetaDataType = any;
 
 type PropsType = {
     portalId?: string;
@@ -29,7 +29,7 @@ type PropsType = {
      * }, 'Some error');
      * ```
      */
-    onNotify?(toast: ToastType, meta?: MetaType): void;
+    onNotify?(toast: ToastType, meta?: MetaDataType): void;
 };
 
 type StateType = {
@@ -39,7 +39,7 @@ type StateType = {
 declare global {
     interface Window {
         toaster: {
-            notify(toast: ToastType, meta?: MetaType): void;
+            notify(toast: ToastType, meta?: MetaDataType): void;
         };
     }
 }
@@ -89,7 +89,7 @@ class Toaster extends Component<PropsType, StateType> {
         };
     }
 
-    public notify = (toast: ToastType, meta?: MetaType): void => {
+    public notify = (toast: ToastType, meta?: MetaDataType): void => {
         this.setState({
             toasts: [
                 ...this.state.toasts,

--- a/src/components/Toaster/index.tsx
+++ b/src/components/Toaster/index.tsx
@@ -9,6 +9,26 @@ type MetaType = any;
 
 type PropsType = {
     portalId?: string;
+    /**
+     * This callback can be used to respond to calls of toaster.notify, An example
+     * for this would to log an error every time a toast is shown with severity "error"
+     *
+     * @example
+     * ```
+     * <Toaster
+     *     onNotify={(toaster, meta) => {
+     *         if (toaster.severity === 'error') {
+     *             log(meta);
+     *         }
+     *     }}
+     * />
+     *
+     * window.toaster.notify({
+     *     severity: 'error',
+     *     title: 'Something went wrong',
+     * }, 'Some error');
+     * ```
+     */
     onNotify?(toast: ToastType, meta?: MetaType): void;
 };
 

--- a/src/components/Toaster/test.tsx
+++ b/src/components/Toaster/test.tsx
@@ -42,4 +42,20 @@ describe('Toaster', () => {
 
         expect(component.find(Toast).prop('isOpen')).toBe(false);
     });
+
+    it('should fire the onNotify callback when window.notify gets called', () => {
+        const notifyMock = jest.fn();
+        const meta = 'some type of meta-data';
+
+        const toast = {
+            title: 'foo',
+            severity: 'error' as 'error',
+        };
+
+        mountWithTheme(<Toaster onNotify={notifyMock} />);
+
+        window.toaster.notify(toast, meta);
+
+        expect(notifyMock).toHaveBeenCalledWith(toast, meta);
+    });
 });


### PR DESCRIPTION
### This PR:

**Backwards compatible additions** ✨
- Adds a callback that gets fired on a toaster.notify to the Toaster. 

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
