### PR TITLE
Refactored textfield story + added component support to affix props

### DIFF
--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, Component } from 'react';
+import React, { ChangeEvent, Component, ReactNode } from 'react';
 import SeverityType from '../../types/SeverityType';
 import InlineNotification from '../InlineNotification';
 import Box from '../Box';
@@ -19,8 +19,8 @@ type PropsType = {
         severity: SeverityType;
         message: string;
     };
-    prefix?: string;
-    suffix?: string;
+    prefix?: string | ReactNode;
+    suffix?: string | ReactNode;
     disabled?: boolean;
     placeholder?: string;
     'data-testid'?: string;
@@ -75,7 +75,11 @@ class TextField extends Component<PropsType, StateType> {
                     severity={this.props.feedback ? this.props.feedback.severity : undefined}
                 >
                     {this.props.prefix && (
-                        <StyledAffixWrapper onClick={this.forceFocus} disabled={this.props.disabled}>
+                        <StyledAffixWrapper
+                            onClick={typeof this.props.prefix === 'string' ? this.forceFocus : undefined}
+                            disabled={this.props.disabled}
+                            isString={typeof this.props.prefix === 'string' ? true : false}
+                        >
                             <StyledAffix>{this.props.prefix}</StyledAffix>
                         </StyledAffixWrapper>
                     )}
@@ -101,7 +105,11 @@ class TextField extends Component<PropsType, StateType> {
                         </Box>
                     </Box>
                     {this.props.suffix && (
-                        <StyledAffixWrapper onClick={this.forceFocus} disabled={this.props.disabled}>
+                        <StyledAffixWrapper
+                            onClick={typeof this.props.suffix === 'string' ? this.forceFocus : undefined}
+                            disabled={this.props.disabled}
+                            isString={typeof this.props.prefix === 'string' ? true : false}
+                        >
                             <StyledAffix>{this.props.suffix}</StyledAffix>
                         </StyledAffixWrapper>
                     )}

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -1,98 +1,104 @@
+import React, { useState, FC } from 'react';
 import { select, text, boolean } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
-import React, { Component } from 'react';
 import TextField from '.';
 import SeverityType from '../../types/SeverityType';
+import { Checkbox, IconButton, Box } from '../..';
+import { SearchIcon } from '../../assets';
 
-type DemoPropsType = {
-    withFeedback: boolean;
-    formatter?: string;
-    currency?: string;
-    locale?: string;
-};
-type DemoStateType = {
-    numberValue: number;
-    stringValue: string;
+type PropsType = {
+    withFeedback?: boolean;
+    isNumber?: boolean;
+    isCurrency?: boolean;
+    hasComponentPrefix?: boolean;
 };
 
-class Demo extends Component<DemoPropsType, DemoStateType> {
-    public ref: HTMLInputElement;
+const Demo: FC<PropsType> = (props): JSX.Element => {
+    const [stringValue, setStringValue] = useState('');
+    const [numberValue, setNumberValue] = useState(10);
+    const [isChecked, setChecked] = useState(true);
 
-    public constructor(props: DemoPropsType) {
-        super(props);
-
-        this.state = { numberValue: 10.0, stringValue: '' };
-    }
-
-    public render(): JSX.Element {
-        if (this.props.formatter === 'withCurrency') {
-            return (
-                <TextField.Currency
-                    name="first name"
-                    disabled={boolean('disabled', false)}
-                    disableNegative={boolean('disableNegative', false)}
-                    currency={this.props.currency ? this.props.currency : 'USD'}
-                    feedback={{
-                        severity: 'info',
-                        message: `The reported value of this field is: ${this.state.numberValue}`,
+    const sharedProps = {
+        prefix: props.hasComponentPrefix ? (
+            <Box padding={[0, 12]}>
+                <Checkbox
+                    checked={isChecked}
+                    value={'1'}
+                    name="TextfieldCheckbox"
+                    onChange={() => {
+                        setChecked(!isChecked);
                     }}
-                    locale={this.props.locale ? this.props.locale : 'en-US'}
-                    value={this.state.numberValue}
-                    onChange={(value: number): void => this.setState({ numberValue: value })}
-                    minor={boolean('minor', false)}
                 />
-            );
-        } else if (this.props.formatter === 'withNumber') {
-            return (
-                <TextField.Number
-                    name="min value"
-                    disableNegative={boolean('disable negative numbers', false)}
-                    disabled={boolean('disabled', false)}
-                    value={this.state.numberValue}
-                    onChange={(value: number): void => this.setState({ numberValue: value })}
-                />
-            );
-        }
-
-        return (
-            <TextField
-                prefix={text('Prefix', 'Username')}
-                suffix={text('Suffix', '$')}
-                placeholder={text('Placeholder', 'This is a placeholder')}
-                value={this.state.stringValue}
-                disabled={boolean('disabled', false)}
-                name="firstname"
-                onChange={(value: string): void => this.setState({ stringValue: value })}
-                extractRef={(ref: HTMLInputElement): void => {
-                    this.ref = ref;
+            </Box>
+        ) : (
+            text('Prefix', 'Username')
+        ),
+        suffix: props.hasComponentPrefix ? (
+            <IconButton
+                title="search"
+                icon={SearchIcon}
+                onClick={() => {
+                    alert(`Search for "${stringValue}"`);
                 }}
-                feedback={
-                    this.props.withFeedback
-                        ? {
-                              message: text('feedback message', 'This is a feedback message'),
-                              severity: select(
-                                  'feedback type',
-                                  ['success', 'warning', 'error', 'info'],
-                                  'error',
-                              ) as SeverityType,
-                          }
-                        : undefined
-                }
+            />
+        ) : (
+            text('Suffix', '$')
+        ),
+        palceholder: text('Placeholder', 'This is a placeholder'),
+        name: 'fieldname',
+        disabled: boolean('disabled', false),
+        feedback: props.withFeedback
+            ? {
+                  message: text('feedback message', 'This is a feedback message'),
+                  severity: select('feedback type', ['success', 'warning', 'error', 'info'], 'error') as SeverityType,
+              }
+            : undefined,
+    };
+
+    const numberProps = {
+        value: numberValue,
+        onChange: setNumberValue,
+        disableNegative: boolean('disable negative numbers', false),
+    };
+
+    const textProps = {
+        value: stringValue,
+        onChange: setStringValue,
+    };
+
+    if (props.isCurrency) {
+        return (
+            <TextField.Currency
+                {...sharedProps}
+                {...numberProps}
+                currency={select('currency', ['USD', 'EUR', 'JPY', 'GBP', 'AUD'], 'USD')}
+                feedback={{
+                    severity: 'info',
+                    message: `The reported value of this field is: ${numberValue}`,
+                }}
+                locale={select(
+                    'locale',
+                    ['en-US', 'nl-NL', 'de-DE', 'jp-JP', 'en_US', 'nl_NL', 'de_DE', 'jp_JP'],
+                    'en-US',
+                )}
+                minor={boolean('minor', false)}
             />
         );
     }
-}
 
-storiesOf('TextField', module).add('Default', () => <Demo withFeedback={false} />);
+    if (props.isNumber) {
+        return <TextField.Number {...sharedProps} {...numberProps} />;
+    }
+
+    return <TextField {...sharedProps} {...textProps} />;
+};
+
+storiesOf('TextField', module).add('Default', () => <Demo />);
+
 storiesOf('TextField', module).add('With Feedback', () => <Demo withFeedback />);
-storiesOf('TextField', module).add('With Number formatting', () => (
-    <Demo withFeedback={false} formatter="withNumber" />
-));
-storiesOf('TextField', module).add('With Currency formatting', () => (
-    <Demo
-        formatter="withCurrency"
-        withFeedback={false}
-        currency={select('currency', ['USD', 'EUR', 'JPY', 'GBP', 'AUD'], 'USD')}
-        locale={select('locale', ['en-US', 'nl-NL', 'de-DE', 'jp-JP', 'en_US', 'nl_NL', 'de_DE', 'jp_JP'], 'en-US')}
-    />
-));
+
+storiesOf('TextField', module).add('With Number formatting', () => <Demo isNumber />);
+
+storiesOf('TextField', module).add('With Currency formatting', () => <Demo isCurrency />);
+
+storiesOf('TextField', module).add('With checkbox prefix', () => <Demo hasComponentPrefix />);

--- a/src/components/TextField/style.tsx
+++ b/src/components/TextField/style.tsx
@@ -51,6 +51,7 @@ type TextFieldThemeType = {
 
 type AffixPropsType = {
     disabled?: boolean;
+    isString?: boolean;
 };
 
 type WrapperPropsType = {
@@ -97,7 +98,7 @@ const StyledInput = styled.input<InputPropsType>`
 
 const StyledAffixWrapper = styled.div<AffixPropsType>`
     display: flex;
-    padding: 0 12px;
+    padding: ${({ isString }): string => (isString ? '0 12px' : '0')};
     user-select: none;
     background-color: ${({ theme }): string => theme.TextField.idle.affix.background};
     align-items: center;
@@ -128,7 +129,6 @@ const StyledWrapper = styled.div<WrapperPropsType>`
     font-family: ${({ theme }): string => theme.TextField.idle.common.fontFamily};
     border-radius: ${({ theme }): string => theme.TextField.idle.common.borderRadius};
     display: flex;
-    cursor: text;
     overflow: hidden;
     width: 100%;
     box-sizing: border-box;
@@ -142,11 +142,6 @@ const StyledWrapper = styled.div<WrapperPropsType>`
             box-shadow: ${severity ? theme.TextField.severity[severity].boxShadow : theme.TextField.focus.boxShadow};
             `
             : `border: solid 1px ${theme.TextField.idle.common.borderColor}`};
-
-    * {
-        cursor: text;
-    }
-
 }
 `;
 

--- a/src/components/TextField/test.tsx
+++ b/src/components/TextField/test.tsx
@@ -72,14 +72,15 @@ describe('TextField', () => {
         const component = mountWithTheme(
             <TextField
                 data-testid="foo"
-                prefix={<Box>Foo</Box>}
-                suffix={<Box>Bar</Box>}
+                prefix={<Box data-testid="prefix">Foo</Box>}
+                suffix={<Box data-testid="suffix">Bar</Box>}
                 value=""
                 name="foo"
                 onChange={jest.fn()}
             />,
         );
 
-        expect(component.find('[data-testid="foo"]').hostNodes().length).toBe(1);
+        expect(component.find('[data-testid="prefix"]').hostNodes().length).toBe(1);
+        expect(component.find('[data-testid="suffix"]').hostNodes().length).toBe(1);
     });
 });

--- a/src/components/TextField/test.tsx
+++ b/src/components/TextField/test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import TextField from '.';
 import { mountWithTheme } from '../../utility/styled/testing';
 import { StyledInput, StyledWrapper, StyledAffixWrapper } from './style';
+import { Box } from '../..';
 
 describe('TextField', () => {
     it('should not change value when disabled', () => {
@@ -63,6 +64,21 @@ describe('TextField', () => {
 
     it('should be testable with a test-id', () => {
         const component = mountWithTheme(<TextField data-testid="foo" value="" name="foo" onChange={jest.fn()} />);
+
+        expect(component.find('[data-testid="foo"]').hostNodes().length).toBe(1);
+    });
+
+    it('should accept a React Node as pre- and suffix', () => {
+        const component = mountWithTheme(
+            <TextField
+                data-testid="foo"
+                prefix={<Box>Foo</Box>}
+                suffix={<Box>Bar</Box>}
+                value=""
+                name="foo"
+                onChange={jest.fn()}
+            />,
+        );
 
         expect(component.find('[data-testid="foo"]').hostNodes().length).toBe(1);
     });


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- None

**Bugfixes/Changed internals** 🎈
- The `prefix` and `suffix` props on `TextField` now also take ReactNodes instead of only strings
- The TextField component story refactored from class to FC and cleaner code with less duplication

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

Result:
![image](https://user-images.githubusercontent.com/2428204/66746513-4a3a3a80-ee82-11e9-8d85-3c4528d85131.png)

Left is a Checkbox, right a clickable IconButton.