### PR TITLE
Add clear TextField button

### DIFF
--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -110,6 +110,7 @@ class TextField extends Component<PropsType, StateType> {
                                         this.forceFocus();
                                     }}
                                     style={{ cursor: 'pointer' }}
+                                    data-testid={`${this.props['data-testid']}-clear-button`}
                                 >
                                     <Icon icon={CloseSmallIcon} color="#A6AAB3" size="small" />
                                 </div>

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -9,6 +9,7 @@ import Icon from '../Icon';
 import lockedIcon from '../../assets/icons/locked.svg';
 import questionCircle from '../../assets/icons/question-circle.svg';
 import dangerCircle from '../../assets/icons/danger-circle.svg';
+import { CloseSmallIcon } from '../../assets';
 
 type PropsType = {
     value: string;
@@ -23,9 +24,10 @@ type PropsType = {
     suffix?: string | ReactNode;
     disabled?: boolean;
     placeholder?: string;
+    showClearButton?: boolean;
     'data-testid'?: string;
     extractRef?(ref: HTMLInputElement): void;
-    onChange(value: string, event: ChangeEvent<HTMLInputElement>): void;
+    onChange(value: string, event?: ChangeEvent<HTMLInputElement>): void;
     onBlur?(): void;
     onFocus?(): void;
 };
@@ -100,7 +102,18 @@ class TextField extends Component<PropsType, StateType> {
                                 if (ref !== null && this.props.extractRef !== undefined) this.props.extractRef(ref);
                             }}
                         />
-                        <Box position="absolute" right="8px" top="8px">
+                        <Box position="absolute" height="100%" right="8px" top="0" alignItems="center">
+                            {this.props.showClearButton && !this.props.disabled && this.props.value !== '' && (
+                                <div
+                                    onClick={() => {
+                                        this.props.onChange('');
+                                        this.forceFocus();
+                                    }}
+                                    style={{ cursor: 'pointer' }}
+                                >
+                                    <Icon icon={CloseSmallIcon} color="#A6AAB3" size="small" />
+                                </div>
+                            )}
                             {this.props.disabled && <Icon icon={lockedIcon} color="#A6AAB3" size="medium" />}
                         </Box>
                     </Box>

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -24,15 +24,16 @@ type PropsType = {
     suffix?: string | ReactNode;
     disabled?: boolean;
     placeholder?: string;
-    showClearButton?: boolean;
     'data-testid'?: string;
     extractRef?(ref: HTMLInputElement): void;
-    onChange(value: string, event?: ChangeEvent<HTMLInputElement>): void;
+    onClear?(): void;
+    onChange(value: string, event: ChangeEvent<HTMLInputElement>): void;
     onBlur?(): void;
     onFocus?(): void;
 };
 
 type StateType = { focus: boolean };
+const ICON_COLOR = '#A6AAB3';
 
 class TextField extends Component<PropsType, StateType> {
     public static Currency: WithCurrencyFormattingType = withCurrencyFormatting(TextField);
@@ -103,19 +104,21 @@ class TextField extends Component<PropsType, StateType> {
                             }}
                         />
                         <Box position="absolute" height="100%" right="8px" top="0" alignItems="center">
-                            {this.props.showClearButton && !this.props.disabled && this.props.value !== '' && (
+                            {this.props.onClear && !this.props.disabled && this.props.value !== '' && (
                                 <div
                                     onClick={() => {
-                                        this.props.onChange('');
-                                        this.forceFocus();
+                                        if (this.props.onClear) {
+                                            this.props.onClear();
+                                            this.forceFocus();
+                                        }
                                     }}
                                     style={{ cursor: 'pointer' }}
                                     data-testid={`${this.props['data-testid']}-clear-button`}
                                 >
-                                    <Icon icon={CloseSmallIcon} color="#A6AAB3" size="small" />
+                                    <Icon icon={CloseSmallIcon} color={ICON_COLOR} size="small" />
                                 </div>
                             )}
-                            {this.props.disabled && <Icon icon={lockedIcon} color="#A6AAB3" size="medium" />}
+                            {this.props.disabled && <Icon icon={lockedIcon} color={ICON_COLOR} size="medium" />}
                         </Box>
                     </Box>
                     {this.props.suffix && (

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -7,6 +7,7 @@ import { Checkbox, IconButton, Box } from '../..';
 import { SearchIcon } from '../../assets';
 
 type PropsType = {
+    withClearButton?: boolean;
     withFeedback?: boolean;
     isNumber?: boolean;
     isCurrency?: boolean;
@@ -47,6 +48,7 @@ const Demo: FC<PropsType> = (props): JSX.Element => {
         palceholder: text('Placeholder', 'This is a placeholder'),
         name: 'fieldname',
         disabled: boolean('disabled', false),
+        showClearButton: props.withClearButton,
         feedback: props.withFeedback
             ? {
                   message: text('feedback message', 'This is a feedback message'),
@@ -94,6 +96,8 @@ const Demo: FC<PropsType> = (props): JSX.Element => {
 };
 
 storiesOf('TextField', module).add('Default', () => <Demo />);
+
+storiesOf('TextField', module).add('With clear button', () => <Demo withClearButton />);
 
 storiesOf('TextField', module).add('With Feedback', () => <Demo withFeedback />);
 

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -48,7 +48,11 @@ const Demo: FC<PropsType> = (props): JSX.Element => {
         palceholder: text('Placeholder', 'This is a placeholder'),
         name: 'fieldname',
         disabled: boolean('disabled', false),
-        showClearButton: props.withClearButton,
+        onClear: props.withClearButton
+            ? () => {
+                  setStringValue('');
+              }
+            : undefined,
         feedback: props.withFeedback
             ? {
                   message: text('feedback message', 'This is a feedback message'),

--- a/src/components/TextField/test.tsx
+++ b/src/components/TextField/test.tsx
@@ -82,4 +82,19 @@ describe('TextField', () => {
 
         expect(component.find('[data-testid="foo"]').hostNodes().length).toBe(1);
     });
+
+    it('should return an empty string in the onChange callback when the clear button is clicked', () => {
+        const changeMock = jest.fn();
+
+        const component = mountWithTheme(
+            <TextField data-testid="foo" value="not-empty-value" name="foo" onChange={changeMock} showClearButton />,
+        );
+
+        component
+            .find('[data-testid="foo-clear-button"]')
+            .hostNodes()
+            .simulate('click');
+
+        expect(changeMock).toHaveBeenCalledWith('');
+    });
 });

--- a/src/components/TextField/test.tsx
+++ b/src/components/TextField/test.tsx
@@ -85,9 +85,16 @@ describe('TextField', () => {
 
     it('should return an empty string in the onChange callback when the clear button is clicked', () => {
         const changeMock = jest.fn();
+        const clearMock = jest.fn();
 
         const component = mountWithTheme(
-            <TextField data-testid="foo" value="not-empty-value" name="foo" onChange={changeMock} showClearButton />,
+            <TextField
+                data-testid="foo"
+                value="not-empty-value"
+                name="foo"
+                onChange={changeMock}
+                onClear={clearMock}
+            />,
         );
 
         component
@@ -95,6 +102,6 @@ describe('TextField', () => {
             .hostNodes()
             .simulate('click');
 
-        expect(changeMock).toHaveBeenCalledWith('');
+        expect(clearMock).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
### This PR:

resolves #BIER-1250

**Backwards compatible additions** ✨
- Added an optional `showClearButton` prop
- This prop shows a button that returns an empty string in the onChange callback when clicked

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [ ] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

**WARNING: this PR is based on SCS-1065.**