### PR TITLE
refactored textfield to use IconButton to clear the field

### DIFF
--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -10,6 +10,7 @@ import lockedIcon from '../../assets/icons/locked.svg';
 import questionCircle from '../../assets/icons/question-circle.svg';
 import dangerCircle from '../../assets/icons/danger-circle.svg';
 import { CloseSmallIcon } from '../../assets';
+import { IconButton } from '../..';
 
 type PropsType = {
     value: string;
@@ -103,23 +104,27 @@ class TextField extends Component<PropsType, StateType> {
                                 if (ref !== null && this.props.extractRef !== undefined) this.props.extractRef(ref);
                             }}
                         />
-                        <Box position="absolute" height="100%" right="8px" top="0" alignItems="center">
-                            {this.props.onClear && !this.props.disabled && this.props.value !== '' && (
-                                <div
+                        {this.props.onClear && !this.props.disabled && this.props.value !== '' && (
+                            <Box position="absolute" height="100%" right="0" top="0" alignItems="center">
+                                <IconButton
+                                    data-testid={`${this.props['data-testid']}-clear-button`}
+                                    icon={CloseSmallIcon}
+                                    iconSize="small"
+                                    title="Clear field"
                                     onClick={() => {
                                         if (this.props.onClear) {
                                             this.props.onClear();
                                             this.forceFocus();
                                         }
                                     }}
-                                    style={{ cursor: 'pointer' }}
-                                    data-testid={`${this.props['data-testid']}-clear-button`}
-                                >
-                                    <Icon icon={CloseSmallIcon} color={ICON_COLOR} size="small" />
-                                </div>
-                            )}
-                            {this.props.disabled && <Icon icon={lockedIcon} color={ICON_COLOR} size="medium" />}
-                        </Box>
+                                />
+                            </Box>
+                        )}
+                        {this.props.disabled && (
+                            <Box position="absolute" height="100%" right="8px" top="0" alignItems="center">
+                                <Icon icon={lockedIcon} color={ICON_COLOR} size="medium" />
+                            </Box>
+                        )}
                     </Box>
                     {this.props.suffix && (
                         <StyledAffixWrapper

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -34,16 +34,20 @@ const Demo: FC<PropsType> = (props): JSX.Element => {
         ) : (
             text('Prefix', 'Username')
         ),
-        suffix: props.hasComponentPrefix ? (
-            <IconButton
-                title="search"
-                icon={SearchIcon}
-                onClick={() => {
-                    alert(`Search for "${stringValue}"`);
-                }}
-            />
+        suffix: !props.withClearButton ? (
+            props.hasComponentPrefix ? (
+                <IconButton
+                    title="search"
+                    icon={SearchIcon}
+                    onClick={() => {
+                        alert(`Search for "${stringValue}"`);
+                    }}
+                />
+            ) : (
+                text('Suffix', '$')
+            )
         ) : (
-            text('Suffix', '$')
+            undefined
         ),
         palceholder: text('Placeholder', 'This is a placeholder'),
         name: 'fieldname',


### PR DESCRIPTION
### This PR:

The clear-button in TextField used a plain icon. This is now replaced with an IconButton, to make sure the interaction (hover) is the same as other buttons, for example the action buttons used in tables.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
