### PR TITLE
Modal centered

### DIFF
--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -8,7 +8,7 @@ type PropsType = {
      * the next major version. Please use direction="stacked" going forward.
      */
     stacked?: boolean;
-    direction?: 'rtl' | 'ltr' | 'stacked';
+    direction?: 'centered' | 'rtl' | 'ltr' | 'stacked';
     'data-testid'?: string;
 };
 
@@ -30,10 +30,20 @@ const ButtonGroup: FunctionComponent<PropsType> = props => {
             ? Children.toArray(props.children)
             : Children.toArray(props.children).reverse();
 
+    let justifyContent: 'flex-end' | 'flex-start' | 'center' = 'flex-end';
+
+    if (isStacked || props.direction === 'ltr') {
+        justifyContent = 'flex-start';
+    }
+
+    if (props.direction === 'centered') {
+        justifyContent = 'center';
+    }
+
     return (
         <Box
             direction={direction}
-            justifyContent={isStacked || props.direction === 'ltr' ? 'flex-start' : 'flex-end'}
+            justifyContent={justifyContent}
             alignItems="stretch"
             wrap
             margin={[-6]}

--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -8,7 +8,7 @@ type PropsType = {
      * the next major version. Please use direction="stacked" going forward.
      */
     stacked?: boolean;
-    direction?: 'centered' | 'rtl' | 'ltr' | 'stacked';
+    direction?: 'rtl' | 'ltr' | 'stacked';
     'data-testid'?: string;
 };
 
@@ -30,20 +30,10 @@ const ButtonGroup: FunctionComponent<PropsType> = props => {
             ? Children.toArray(props.children)
             : Children.toArray(props.children).reverse();
 
-    let justifyContent: 'flex-end' | 'flex-start' | 'center' = 'flex-end';
-
-    if (isStacked || props.direction === 'ltr') {
-        justifyContent = 'flex-start';
-    }
-
-    if (props.direction === 'centered') {
-        justifyContent = 'center';
-    }
-
     return (
         <Box
             direction={direction}
-            justifyContent={justifyContent}
+            justifyContent={isStacked || props.direction === 'ltr' ? 'flex-start' : 'flex-end'}
             alignItems="stretch"
             wrap
             margin={[-6]}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -17,6 +17,7 @@ type PropsType = {
     size?: 'small' | 'medium' | 'large';
     buttons?: Array<ReactNode>;
     media?: ReactNode;
+    centered?: boolean;
     onClose?(): void;
     renderFixed?(): JSX.Element;
 };
@@ -121,8 +122,10 @@ const Modal: FC<PropsType> = props => {
                                             {!isSplit && props.media && (
                                                 <MediaWrapper fullWidth>{props.media}</MediaWrapper>
                                             )}
-                                            <Box margin={[0, 0, 12, 0]}>
-                                                <Heading hierarchy={2}>{props.title}</Heading>
+                                            <Box margin={[0, 0, 12, 0]} direction="column">
+                                                <Heading textAlign={props.centered ? 'center' : 'left'} hierarchy={2}>
+                                                    {props.title}
+                                                </Heading>
                                             </Box>
                                             {props.children}
                                         </Box>
@@ -133,7 +136,7 @@ const Modal: FC<PropsType> = props => {
                                         <Contrast>
                                             <Box
                                                 direction="column"
-                                                alignItems="stretch"
+                                                alignItems={props.centered ? 'center' : 'stretch'}
                                                 shrink={0}
                                                 padding={isSmall ? [24] : [24, 36]}
                                             >

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -135,6 +135,7 @@ const Modal: FC<PropsType> = props => {
                                     <Box shrink={0} width="100%" direction="column">
                                         <Contrast>
                                             <Box
+                                                data-testid="modal-buttons-container"
                                                 direction="column"
                                                 alignItems={props.centered ? 'center' : 'stretch'}
                                                 shrink={0}

--- a/src/components/Modal/story.tsx
+++ b/src/components/Modal/story.tsx
@@ -41,6 +41,20 @@ storiesOf('Modal', module)
             </Modal>
         );
     })
+    .add('Centered', () => {
+        return (
+            <Modal
+                centered
+                show={boolean('show', true)}
+                size={select('size', ['small', 'medium', 'large'], 'large')}
+                title={text('title', 'Would you like me to be your role modal?')}
+                onClose={(): boolean => confirm('You are now closing this modal, do you wish to continue?')}
+                buttons={[<Button key="activate" variant="primary" title="Activate" />]}
+            >
+                <Text textAlign="center">{text('contents', demoContent)}</Text>
+            </Modal>
+        );
+    })
     .add('Without onClose', () => {
         return (
             <Modal

--- a/src/components/Modal/test.tsx
+++ b/src/components/Modal/test.tsx
@@ -7,9 +7,10 @@ import IconButton from '../IconButton';
 import Measure from 'react-measure';
 import ButtonGroup from '../ButtonGroup';
 import Button from '../Button';
+import Heading from '../Heading';
+import ScrollBox from '../ScrollBox';
 
-jest.mock('../ScrollBox', () => jest.fn().mockImplementation((): string => 'div'));
-
+jest.mock('../ScrollBox', () => jest.fn().mockImplementation(() => 'div'));
 jest.mock('react-measure');
 
 describe('Modal', () => {
@@ -171,5 +172,30 @@ describe('Modal', () => {
 
         const component = mountWithTheme(<Modal show title="Foo" media={<div data-testid="modal-media">media</div>} />);
         expect(component.find('[data-testid="modal-media"]').length).toBe(1);
+    });
+
+    it('should the heading and the buttons when the centered prop is set', () => {
+        (ScrollBox as jest.Mock).mockImplementationOnce(props => <div>{props.children}</div>);
+        const component = mountWithTheme(
+            <Modal
+                show
+                title="Foo"
+                centered
+                buttons={[
+                    <Button key="foo" variant="primary" title="foo" />,
+                    <Button key="bar" variant="primary" title="bar" />,
+                ]}
+            />,
+        );
+
+        expect(component.find(Heading).prop('textAlign')).toBe('center');
+
+        expect(
+            component
+                .find('[data-testid="modal-buttons-container"]')
+                // We use .first() here instead of .hostNodes because we want to assert a react prop instead of an html attribute
+                .first()
+                .prop('alignItems'),
+        ).toBe('center');
     });
 });


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- A centered prop to the Modal that centers the heading and buttons.

**Bugfixes/Changed internals** 🎈
- None

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [ ] Appropriate tests have been added for my functionality (check if not applicable).
- [ ] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
