### PR TITLE
Added character limit to TextArea

### DIFF
--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -4,6 +4,7 @@ import InlineNotification from '../InlineNotification';
 import SeverityType from '../../types/SeverityType';
 import trbl from '../../utility/trbl';
 import Box from '../Box';
+import Text from '../Text';
 import questionCircle from '../../assets/icons/question-circle.svg';
 import dangerCircle from '../../assets/icons/danger-circle.svg';
 
@@ -18,12 +19,18 @@ type PropsType = {
         severity: SeverityType;
         message: string;
     };
+    characterLimit?: number;
     onChange(value: string, event: ChangeEvent<HTMLTextAreaElement>): void;
 };
 
 class TextArea extends Component<PropsType> {
     public onChange = (event: ChangeEvent<HTMLTextAreaElement>): void => {
-        if (!this.props.disabled) this.props.onChange(event.target.value, event);
+        if (!this.props.disabled)
+            if (this.props.characterLimit) {
+                this.props.onChange(event.target.value.substring(0, this.props.characterLimit), event);
+            } else {
+                this.props.onChange(event.target.value, event);
+            }
     };
 
     public render(): JSX.Element {
@@ -42,6 +49,11 @@ class TextArea extends Component<PropsType> {
                         resizeable={this.props.resizeable}
                         onChange={this.onChange}
                     />
+                    {this.props.characterLimit && (
+                        <Box justifyContent="flex-end">
+                            <Text severity="info">{`${this.props.value.length} / ${this.props.characterLimit}`}</Text>
+                        </Box>
+                    )}
                 </StyledTextAreaWrapper>
                 {this.props.feedback && (
                     <Box margin={trbl(6, 0, 0, 12)}>

--- a/src/components/TextArea/story.tsx
+++ b/src/components/TextArea/story.tsx
@@ -5,7 +5,8 @@ import { storiesOf } from '@storybook/react';
 import TextArea from '.';
 
 type DemoPropsType = {
-    withFeedback: boolean;
+    withFeedback?: boolean;
+    withCharacterLimit?: boolean;
 };
 
 class Demo extends Component<DemoPropsType, { value: string }> {
@@ -38,10 +39,12 @@ class Demo extends Component<DemoPropsType, { value: string }> {
                           }
                         : undefined
                 }
+                characterLimit={this.props.withCharacterLimit ? number('Character Limit', 140) : undefined}
             />
         );
     }
 }
 
-storiesOf('TextArea', module).add('Default', () => <Demo withFeedback={false} />);
+storiesOf('TextArea', module).add('Default', () => <Demo />);
 storiesOf('TextArea', module).add('With Feedback', () => <Demo withFeedback />);
+storiesOf('TextArea', module).add('With Character Limit', () => <Demo withCharacterLimit />);

--- a/src/components/TextArea/test.tsx
+++ b/src/components/TextArea/test.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react';
+import React from 'react';
 import TextArea from '.';
 import { mountWithTheme } from '../../utility/styled/testing';
 import { StyledTextArea } from './style';

--- a/src/components/TextArea/test.tsx
+++ b/src/components/TextArea/test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 import TextArea from '.';
 import { mountWithTheme } from '../../utility/styled/testing';
 import { StyledTextArea } from './style';
@@ -31,5 +31,34 @@ describe('TextArea', () => {
         component.find(StyledTextArea).simulate('change');
 
         expect(changeMock).toHaveBeenCalled();
+    });
+
+    it('should be able to enforce a character limit', () => {
+        const changeMock = jest.fn();
+        const changeString =
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam a sem sollicitudin, sodales felis vel, porta est. Donec quam nulla, egestas vitae feugiat amet. ';
+
+        const expectedString =
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam a sem sollicitudin, sodales felis vel, porta est. Donec quam nulla, egestas';
+
+        const component = mountWithTheme(
+            <TextArea
+                value=""
+                resizeable
+                feedback={{ severity: 'info', message: 'hi' }}
+                name="firstName"
+                onChange={changeMock}
+                characterLimit={140}
+            />,
+        );
+
+        component.find(StyledTextArea).simulate('focus');
+        component.find(StyledTextArea).simulate('change', {
+            target: {
+                value: changeString,
+            },
+        });
+
+        expect(changeMock).toHaveBeenCalledWith(expectedString, expect.any(Object));
     });
 });


### PR DESCRIPTION
### This PR:

Adds an optional character limit to `TextArea`

**Backwards compatible additions** ✨
- Component `TextArea` also supports optional `characterLimit` prop

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
