### PR TITLE
Added onMouseEnter and onMouseLeave to ButtonBase

### DIFF
--- a/src/components/Button/base/index.tsx
+++ b/src/components/Button/base/index.tsx
@@ -49,6 +49,8 @@ const ButtonBase: FunctionComponent<PropsType> = (props): JSX.Element => {
             id={props.id}
             isLoading={props.loading}
             data-testid={props['data-testid']}
+            onMouseEnter={props.onMouseEnter}
+            onMouseLeave={props.onMouseLeave}
         >
             {props.children}
         </StyledButton>


### PR DESCRIPTION
### This PR:
`onMouseEnter` and `onMouseLeave` on ButtonBase were only passed on the anchor. With this PR they're passed on the button element as well.

**Bugfixes/Changed internals** 🎈
- passes `onMouseEnter` and `onMouseLeave` on ButtonBase as `button` as well

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
