### PR TITLE
Added TooltipWindow z-index

### DIFF
--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState, useEffect, useRef } from 'react';
 import { Manager, Popper, PopperChildrenProps, Reference, ReferenceChildrenProps } from 'react-popper';
 import TransitionAnimation from '../TransitionAnimation';
 import Text from '../Text';
-import { TooltipAnchor, TooltipArrow, TooltipBackground, TooltipContent } from './style';
+import { TooltipAnchor, TooltipArrow, TooltipBackground, TooltipContent, TooltipWindow } from './style';
 
 type PlacementType = PopperChildrenProps['placement'];
 
@@ -133,8 +133,8 @@ const Tooltip: FC<PropsType> = props => {
                     </span>
                 )}
             </Reference>
-            <TransitionAnimation show={props.show !== undefined ? props.show : isOpen} animation="fade">
-                <div ref={tooltipRef}>
+            <TooltipWindow ref={tooltipRef}>
+                <TransitionAnimation show={props.show !== undefined ? props.show : isOpen} animation="fade">
                     <Popper
                         positionFixed={true}
                         placement="bottom"
@@ -157,8 +157,8 @@ const Tooltip: FC<PropsType> = props => {
                             </div>
                         )}
                     </Popper>
-                </div>
-            </TransitionAnimation>
+                </TransitionAnimation>
+            </TooltipWindow>
         </Manager>
     );
 };

--- a/src/components/Tooltip/style.tsx
+++ b/src/components/Tooltip/style.tsx
@@ -13,6 +13,11 @@ const TooltipAnchor = styled.div`
     cursor: pointer;
 `;
 
+const TooltipWindow = styled.div`
+    postion: relative;
+    z-index: 9999;
+`;
+
 const TooltipBackground = styled.div`
     position: absolute;
     left: 0;
@@ -103,4 +108,12 @@ const composeTooltipTheme = (themeTools: ThemeTools): TooltipThemeType => {
     };
 };
 
-export { TooltipAnchor, TooltipArrow, TooltipBackground, TooltipContent, TooltipThemeType, composeTooltipTheme };
+export {
+    TooltipAnchor,
+    TooltipArrow,
+    TooltipWindow,
+    TooltipBackground,
+    TooltipContent,
+    TooltipThemeType,
+    composeTooltipTheme,
+};


### PR DESCRIPTION
### This PR:
Adjusts the z-index of the Tooltip window so it lays on top of appending nodes

**Bugfixes/Changed internals** 🎈
- Rearranged TooltipWindow

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
