### PR TITLE
Added testid to TextArea and adjusted padding and color

### DIFF
--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ChangeEvent } from 'react';
+import React, { ChangeEvent, FC, useRef } from 'react';
 import StyledTextArea, { StyledTextAreaWrapper } from './style';
 import InlineNotification from '../InlineNotification';
 import SeverityType from '../../types/SeverityType';
@@ -24,53 +24,57 @@ type PropsType = {
     onChange(value: string, event: ChangeEvent<HTMLTextAreaElement>): void;
 };
 
-class TextArea extends Component<PropsType> {
-    public onChange = (event: ChangeEvent<HTMLTextAreaElement>): void => {
-        if (!this.props.disabled)
-            if (this.props.characterLimit) {
-                this.props.onChange(event.target.value.substring(0, this.props.characterLimit), event);
+const TextArea: FC<PropsType> = props => {
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    const onChange = (event: ChangeEvent<HTMLTextAreaElement>): void => {
+        if (!props.disabled)
+            if (props.characterLimit) {
+                props.onChange(event.target.value.substring(0, props.characterLimit), event);
             } else {
-                this.props.onChange(event.target.value, event);
+                props.onChange(event.target.value, event);
             }
     };
 
-    public render(): JSX.Element {
-        return (
-            <>
-                <StyledTextAreaWrapper
-                    disabled={this.props.disabled}
-                    severity={this.props.feedback ? this.props.feedback.severity : undefined}
-                >
-                    <StyledTextArea
-                        data-testid={this.props['data-testid']}
-                        value={this.props.value}
-                        name={this.props.name}
-                        id={this.props.id}
-                        rows={this.props.rows ? this.props.rows : 3}
-                        disabled={this.props.disabled}
-                        resizeable={this.props.resizeable}
-                        onChange={this.onChange}
-                        characterLimit={this.props.characterLimit}
-                    />
-                    {this.props.characterLimit && (
-                        <Box justifyContent="flex-end" position="absolute" right="12px" bottom="6px">
-                            <Text severity="info">{`${this.props.value.length} / ${this.props.characterLimit}`}</Text>
-                        </Box>
-                    )}
-                </StyledTextAreaWrapper>
-                {this.props.feedback && (
-                    <Box margin={trbl(6, 0, 0, 12)}>
-                        <InlineNotification
-                            icon={this.props.feedback.severity === 'info' ? questionCircle : dangerCircle}
-                            message={this.props.feedback.message}
-                            severity={this.props.feedback.severity}
-                        />
+    const focusField = () => {
+        if (textareaRef.current) textareaRef.current.focus();
+    };
+
+    return (
+        <>
+            <StyledTextAreaWrapper
+                disabled={props.disabled}
+                severity={props.feedback ? props.feedback.severity : undefined}
+            >
+                <StyledTextArea
+                    ref={textareaRef}
+                    data-testid={props['data-testid']}
+                    value={props.value}
+                    name={props.name}
+                    id={props.id}
+                    rows={props.rows ? props.rows : 3}
+                    disabled={props.disabled}
+                    resizeable={props.resizeable}
+                    onChange={onChange}
+                />
+                {props.characterLimit && (
+                    <Box justifyContent="flex-end" padding={[0, 12, 6]} onClick={focusField}>
+                        <Text severity="info">{`${props.value.length} / ${props.characterLimit}`}</Text>
                     </Box>
                 )}
-            </>
-        );
-    }
-}
+            </StyledTextAreaWrapper>
+            {props.feedback && (
+                <Box margin={trbl(6, 0, 0, 12)}>
+                    <InlineNotification
+                        icon={props.feedback.severity === 'info' ? questionCircle : dangerCircle}
+                        message={props.feedback.message}
+                        severity={props.feedback.severity}
+                    />
+                </Box>
+            )}
+        </>
+    );
+};
 
 export default TextArea;
 export { PropsType, StyledTextArea };

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -58,7 +58,7 @@ const TextArea: FC<PropsType> = props => {
                     onChange={onChange}
                 />
                 {props.characterLimit && (
-                    <Box justifyContent="flex-end" padding={[0, 12, 6]} onClick={focusField}>
+                    <Box justifyContent="flex-end" padding={[0, 12, 6]} onClick={focusField} style={{ cursor: 'text' }}>
                         <Text severity="info">{`${props.value.length} / ${props.characterLimit}`}</Text>
                     </Box>
                 )}

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -20,6 +20,7 @@ type PropsType = {
         message: string;
     };
     characterLimit?: number;
+    'data-testid'?: string;
     onChange(value: string, event: ChangeEvent<HTMLTextAreaElement>): void;
 };
 
@@ -41,6 +42,7 @@ class TextArea extends Component<PropsType> {
                     severity={this.props.feedback ? this.props.feedback.severity : undefined}
                 >
                     <StyledTextArea
+                        data-testid={this.props['data-testid']}
                         value={this.props.value}
                         name={this.props.name}
                         id={this.props.id}
@@ -48,9 +50,10 @@ class TextArea extends Component<PropsType> {
                         disabled={this.props.disabled}
                         resizeable={this.props.resizeable}
                         onChange={this.onChange}
+                        characterLimit={this.props.characterLimit}
                     />
                     {this.props.characterLimit && (
-                        <Box justifyContent="flex-end">
+                        <Box justifyContent="flex-end" position="absolute" right="12px" bottom="6px">
                             <Text severity="info">{`${this.props.value.length} / ${this.props.characterLimit}`}</Text>
                         </Box>
                     )}

--- a/src/components/TextArea/style.tsx
+++ b/src/components/TextArea/style.tsx
@@ -11,6 +11,7 @@ type TextAreaWrapperPropsType = {
 type TextAreaPropsType = {
     resizeable?: boolean;
     disabled?: boolean;
+    characterLimit?: number;
 };
 
 type TextAreaThemeType = {
@@ -53,9 +54,10 @@ type TextAreaThemeType = {
 };
 
 const StyledTextAreaWrapper = styled.div<TextAreaWrapperPropsType>`
+    position: relative;
     width: 100%;
-    padding: 6px 12px;
-    box-sizing: border-box;
+    padding: 0;
+    overflow: hidden;
     border: solid 1px ${({ theme }): string => theme.TextArea.idle.common.borderColor};
     border-radius: ${({ theme }): string => theme.TextArea.idle.common.borderRadius};
     background: ${({ theme, disabled }): string =>
@@ -76,7 +78,8 @@ const StyledTextAreaWrapper = styled.div<TextAreaWrapperPropsType>`
 `;
 
 const StyledTextArea = styled.textarea<TextAreaPropsType>`
-    padding: 0;
+    padding: ${({ characterLimit }): string => (characterLimit ? '6px 12px 24px' : '6px 12px')};
+    box-sizing: border-box;
     width: 100%;
     border: none;
     outline: none;

--- a/src/components/TextArea/style.tsx
+++ b/src/components/TextArea/style.tsx
@@ -11,7 +11,6 @@ type TextAreaWrapperPropsType = {
 type TextAreaPropsType = {
     resizeable?: boolean;
     disabled?: boolean;
-    characterLimit?: number;
 };
 
 type TextAreaThemeType = {
@@ -54,7 +53,6 @@ type TextAreaThemeType = {
 };
 
 const StyledTextAreaWrapper = styled.div<TextAreaWrapperPropsType>`
-    position: relative;
     width: 100%;
     padding: 0;
     overflow: hidden;
@@ -78,7 +76,7 @@ const StyledTextAreaWrapper = styled.div<TextAreaWrapperPropsType>`
 `;
 
 const StyledTextArea = styled.textarea<TextAreaPropsType>`
-    padding: ${({ characterLimit }): string => (characterLimit ? '6px 12px 24px' : '6px 12px')};
+    padding: 6px 12px;
     box-sizing: border-box;
     width: 100%;
     border: none;

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -731,7 +731,7 @@ const theme: ThemeType = {
                 borderColor: silver.darker4,
                 fontSize: fontSize.base,
                 fontFamily: bodyFont,
-                color: grey.lighter3,
+                color: grey.base,
                 background: silver.lighter1,
             },
         },
@@ -739,7 +739,6 @@ const theme: ThemeType = {
             borderColor: green.darker2,
             boxShadow: `0 0 0 4px ${rgba(green.base, 0.4)}`,
         },
-
         severity: {
             error: {
                 borderColor: severity.error,


### PR DESCRIPTION
### This PR:
**Bugfixes/Changed internals** 🎈
- Adds `data-testid` to TextArea element
- Changes padding so native ui elements don't float (scrollbar and resize icon)
- Added onClick to characterLimit box to focus the textarea
- Refactored to Functional Component
- Fixed text color

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
