### PR TITLE
Added minor prop to PriceTag to handle minor units

### DIFF
--- a/src/components/PriceTag/index.tsx
+++ b/src/components/PriceTag/index.tsx
@@ -4,6 +4,7 @@ import StyledPriceTag from './style';
 import formatFraction from './formatters/formatFraction';
 import formatCurrency from './formatters/formatCurrency';
 import formatDecimalSeperator from './formatters/formatDecimalSeperator';
+import { Decimal } from 'decimal.js';
 
 type PropsType = {
     hideCurrency?: boolean;
@@ -14,6 +15,7 @@ type PropsType = {
     fractionFormat?: 'none' | 'dash';
     locale: string;
     currency: string;
+    minor?: boolean;
 };
 
 type StatsType = {
@@ -44,7 +46,11 @@ const PriceTag: FunctionComponent<PropsType> = (props): JSX.Element => {
         currency: props.currency,
     });
 
-    const parts = formatter.formatToParts(props.value);
+    const amount = props.minor
+        ? new Decimal(props.value).dividedBy(Math.pow(10, formatter.resolvedOptions().maximumFractionDigits)).toNumber()
+        : props.value;
+
+    const parts = formatter.formatToParts(amount);
 
     const stats = parts.reduce(deriveStatsFromPart, {
         isRound: false,

--- a/src/components/PriceTag/story.tsx
+++ b/src/components/PriceTag/story.tsx
@@ -15,6 +15,7 @@ storiesOf('PriceTag', module).add('Default', () => (
             hideCurrency={boolean('hideCurrency', false)}
             superScriptFraction={boolean('superScriptFraction', false)}
             strikethrough={boolean('strikethrough', false)}
+            minor={boolean('minor', false)}
         />
     </Text>
 ));

--- a/src/components/PriceTag/test.tsx
+++ b/src/components/PriceTag/test.tsx
@@ -113,4 +113,10 @@ describe('PriceTag', () => {
 
         expect(component.text()).toContain('free');
     });
+
+    it('should handle minor values', () => {
+        const component = mountWithTheme(<PriceTag locale="nl-NL" currency="EUR" value={1020} minor />).find(PriceTag);
+
+        expect(component.text()).toContain('€ 10,20');
+    });
 });


### PR DESCRIPTION
### This PR:

Adds the ability to use minor units in the PriceTag

**Backwards compatible additions** ✨
- `minor` prop on `PriceTag`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
