### PR TITLE
Add actual ci user to GitHub action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v2-beta
     - name: Configuring GitHub user
       run: |
-        git config --global user.email no-reply@myonlinestore.com
+        git config --global user.email team-tech+myonlinestore-ci-eu@myonlinestore.com
         git config --global user.name myonlinestore-ci-eu
     - name: Setting up Node environment
       uses: actions/setup-node@v1


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥

**Backwards compatible additions** ✨

**Bugfixes/Changed internals** 🎈
- This makes sure GitHub recognizes the actual CI account as a user. Could be useful for stats in the future

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
