### PR TITLE
Added float support to TextField.Number

### DIFF
--- a/src/components/TextField/formatters/withNumberFormatting/index.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/index.tsx
@@ -31,7 +31,7 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
             this.state = {
                 value: this.formatter.format(props.value),
                 savedValue: this.props.value,
-                decimalSeperator: '.',
+                decimalSeperator: this.getSeperator(props.value),
             };
         }
 
@@ -56,12 +56,10 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
             });
         }
 
-        private setSeperator(value: number): void {
-            this.formatter.formatToParts(value).map(part => {
-                if (part.type === 'decimal') {
-                    this.setState({ decimalSeperator: part.value });
-                }
-            });
+        private getSeperator(value: number): string {
+            const seperator = this.formatter.formatToParts(value).find(part => part.type === 'decimal');
+
+            return seperator ? seperator.value : '.';
         }
 
         private parse(value: string): number {
@@ -91,14 +89,6 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
                 this.props.onBlur();
             }
         };
-
-        public componentDidMount() {
-            this.setSeperator(this.props.value);
-
-            this.setState({
-                value: this.formatter.format(this.state.savedValue),
-            });
-        }
 
         public componentDidUpdate(prevProps: PropsType) {
             if (

--- a/src/components/TextField/formatters/withNumberFormatting/index.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/index.tsx
@@ -6,7 +6,7 @@ type OmittedKeys = 'onChange' | 'value' | 'type';
 type PropsType = Pick<TextFieldPropsType, Exclude<keyof TextFieldPropsType, OmittedKeys>> & {
     value: number;
     disableNegative?: boolean;
-    allowFloats?: boolean;
+    allowDecimals?: boolean;
     minimumFractionDigits?: number;
     maximumFractionDigits?: number;
     locale?: string;
@@ -37,15 +37,15 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
 
         private setFormatter(): void {
             const locale = this.props.locale ? this.props.locale.replace('_', '-') : 'nl-NL';
-            const defaultMaximumFractionDigits = this.props.allowFloats ? 2 : 0;
+            const defaultMaximumFractionDigits = this.props.allowDecimals ? 2 : 0;
 
             const minimumFractionDigits =
-                this.props.minimumFractionDigits && this.props.allowFloats && this.props.minimumFractionDigits > 0
+                this.props.minimumFractionDigits && this.props.allowDecimals && this.props.minimumFractionDigits > 0
                     ? this.props.minimumFractionDigits
                     : 0;
 
             let maximumFractionDigits =
-                this.props.maximumFractionDigits && this.props.allowFloats && this.props.maximumFractionDigits >= 0
+                this.props.maximumFractionDigits && this.props.allowDecimals && this.props.maximumFractionDigits >= 0
                     ? this.props.maximumFractionDigits
                     : defaultMaximumFractionDigits;
 
@@ -68,16 +68,14 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
         }
 
         private parse(value: string): number {
-            if (this.props.allowFloats) {
+            if (this.props.allowDecimals) {
                 const stripped = value.replace(new RegExp(`[^\-0-9${this.state.decimalSeperator}]`, 'g'), '');
-                const toFixed = parseFloat(stripped.replace(this.state.decimalSeperator, '.')).toFixed(
-                    this.formatter.resolvedOptions().maximumFractionDigits,
-                );
+                const parsedValue = parseFloat(stripped.replace(this.state.decimalSeperator, '.'));
 
-                return parseFloat(toFixed);
+                return parseFloat(parsedValue.toFixed(this.formatter.resolvedOptions().maximumFractionDigits));
             }
 
-            return parseFloat(value);
+            return parseInt(value, 10);
         }
 
         private handleChange = (value: string): void => {
@@ -105,7 +103,7 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
 
         public componentDidUpdate(prevProps: PropsType) {
             if (
-                this.props.allowFloats !== prevProps.allowFloats ||
+                this.props.allowDecimals !== prevProps.allowDecimals ||
                 this.props.locale !== prevProps.locale ||
                 this.props.minimumFractionDigits !== prevProps.minimumFractionDigits ||
                 this.props.maximumFractionDigits !== prevProps.maximumFractionDigits
@@ -126,7 +124,7 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
         public render(): JSX.Element {
             const wrappedProps = {
                 ...this.props,
-                type: this.props.allowFloats ? 'text' : 'number',
+                type: this.props.allowDecimals ? 'text' : 'number',
                 value: this.state.value,
                 onChange: this.handleChange,
                 onBlur: this.handleBlur,

--- a/src/components/TextField/formatters/withNumberFormatting/index.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/index.tsx
@@ -6,40 +6,102 @@ type OmittedKeys = 'onChange' | 'value' | 'type';
 type PropsType = Pick<TextFieldPropsType, Exclude<keyof TextFieldPropsType, OmittedKeys>> & {
     value: number;
     disableNegative?: boolean;
+    minimumFractionDigits?: number;
+    maximumFractionDigits?: number;
+    locale?: string;
     onChange(value: number): void;
 };
 
 type StateType = {
     value: string;
     savedValue: number;
+    decimalSeperator: string;
 };
 
 type WithNumberFormattingType = ComponentClass<PropsType>;
 
 const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): ComponentClass<PropsType> => {
     class WithNumberFormatting extends Component<PropsType, StateType> {
+        private formatter: Intl.NumberFormat;
         public constructor(props: PropsType) {
             super(props);
+            this.setFormatter(
+                props.locale ? props.locale : 'en_GB',
+                props.minimumFractionDigits ? props.minimumFractionDigits : 0,
+                props.maximumFractionDigits ? props.maximumFractionDigits : 2,
+            );
 
             this.state = {
                 value: `${this.props.value}`,
                 savedValue: this.props.value,
+                decimalSeperator: '.',
             };
         }
 
-        public static getDerivedStateFromProps(nextProps: PropsType, prevState: StateType): StateType {
-            if (nextProps.value === prevState.savedValue) {
-                return { ...prevState, value: prevState.value === '' ? '' : prevState.savedValue.toString() };
+        private setFormatter(locale: string, minimumFractionDigits: number, maximumFractionDigits: number): void {
+            this.formatter = new Intl.NumberFormat(locale.replace('_', '-'), {
+                style: 'decimal',
+                minimumFractionDigits,
+                maximumFractionDigits,
+            });
+        }
+
+        private parse(direction: 'in', value: string): string;
+        private parse(direction: 'out', value: string): number;
+        private parse(direction: 'in' | 'out', value: string): string | number {
+            const negatedValues = this.props.disableNegative
+                ? `[^0-9${this.state.decimalSeperator}]`
+                : `[^\-0-9${this.state.decimalSeperator}]`;
+
+            const stripped = value.replace(new RegExp(negatedValues, 'g'), '');
+
+            if (direction === 'out') {
+                const parsed = parseFloat(stripped.replace(this.state.decimalSeperator, '.'));
+
+                return !isNaN(parsed) ? parseFloat(parsed.toFixed(2)) : this.props.value;
             }
 
-            return {
-                ...prevState,
-                value: `${nextProps.value}`,
-            };
+            return stripped;
         }
 
+        private format(value: string): string {
+            try {
+                return this.formatter
+                    .formatToParts(this.parse('out', value))
+                    .filter(part => {
+                        switch (part.type) {
+                            case 'decimal': {
+                                this.setState({ decimalSeperator: part.value });
+
+                                return true;
+                            }
+                            case 'literal':
+                                return false;
+                            default:
+                                return true;
+                        }
+                    })
+                    .reduce((combined: string, { value }: Intl.PartType): string => `${combined}${value}`, '');
+            } catch (error) {
+                return value;
+            }
+        }
+
+        // public static getDerivedStateFromProps(nextProps: PropsType, prevState: StateType): StateType {
+        //     if (nextProps.value === prevState.savedValue) {
+        //         return { ...prevState, value: prevState.value === '' ? '' : prevState.savedValue.toString() };
+        //     }
+
+        //     return {
+        //         ...prevState,
+        //         value: `${nextProps.value}`,
+        //     };
+        // }
+
         private handleChange = (value: string): void => {
-            const parsedValue = parseInt(value, 10);
+            const parsedValue = this.parse('out', value);
+            console.debug('PARSED', parsedValue);
+
             if (isNaN(parsedValue)) {
                 this.setState({ value: '' });
                 this.props.onChange(this.state.savedValue);
@@ -47,9 +109,12 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
                 this.setState({ savedValue: 0 });
                 this.props.onChange(0);
             } else {
-                if (parsedValue !== this.state.savedValue || this.state.value.length === 0) {
-                    this.setState({ value: '0', savedValue: parsedValue });
-                }
+                // if (parsedValue !== this.state.savedValue || this.state.value.length === 0) {
+                //     this.setState({ value: '0', savedValue: parsedValue });
+                // } else {
+                this.setState({ value: this.format(value), savedValue: parsedValue });
+                // }
+
                 this.props.onChange(parsedValue);
             }
         };
@@ -57,7 +122,10 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
         private handleBlur = (): void => {
             if (this.state.value.length === 0) {
                 this.setState({ value: '0' });
+            } else {
+                this.setState({ value: this.format(this.state.value) });
             }
+
             if (this.props.onBlur !== undefined) {
                 this.props.onBlur();
             }
@@ -66,7 +134,7 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
         public render(): JSX.Element {
             const wrappedProps = {
                 ...this.props,
-                type: 'number' as 'number',
+                type: this.props.minimumFractionDigits || this.props.maximumFractionDigits ? 'text' : 'number',
                 value: this.state.value,
                 onChange: this.handleChange,
                 onBlur: this.handleBlur,

--- a/src/components/TextField/formatters/withNumberFormatting/index.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/index.tsx
@@ -68,9 +68,13 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
         }
 
         private parse(value: string): number {
-            const stripped = value.replace(new RegExp(`[^\-0-9${this.state.decimalSeperator}]`, 'g'), '');
+            if (this.props.allowFloats) {
+                const stripped = value.replace(new RegExp(`[^\-0-9${this.state.decimalSeperator}]`, 'g'), '');
 
-            return parseFloat(stripped.replace(this.state.decimalSeperator, '.'));
+                return parseFloat(stripped.replace(this.state.decimalSeperator, '.'));
+            }
+
+            return parseFloat(value);
         }
 
         private handleChange = (value: string): void => {

--- a/src/components/TextField/formatters/withNumberFormatting/index.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/index.tsx
@@ -43,6 +43,7 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
                 style: 'decimal',
                 minimumFractionDigits,
                 maximumFractionDigits,
+                useGrouping: false,
             });
         }
 
@@ -100,6 +101,7 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
 
         private handleChange = (value: string): void => {
             const parsedValue = this.parse('out', value);
+            console.debug('STRING', value);
             console.debug('PARSED', parsedValue);
 
             if (isNaN(parsedValue)) {
@@ -112,7 +114,7 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
                 // if (parsedValue !== this.state.savedValue || this.state.value.length === 0) {
                 //     this.setState({ value: '0', savedValue: parsedValue });
                 // } else {
-                this.setState({ value: this.format(value), savedValue: parsedValue });
+                this.setState({ savedValue: parsedValue });
                 // }
 
                 this.props.onChange(parsedValue);
@@ -120,11 +122,11 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
         };
 
         private handleBlur = (): void => {
-            if (this.state.value.length === 0) {
-                this.setState({ value: '0' });
-            } else {
-                this.setState({ value: this.format(this.state.value) });
-            }
+            // if (this.state.value.length === 0) {
+            //     this.setState({ value: '0' });
+            // } else {
+            this.setState({ value: this.format(this.state.value) });
+            // }
 
             if (this.props.onBlur !== undefined) {
                 this.props.onBlur();
@@ -134,7 +136,11 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
         public render(): JSX.Element {
             const wrappedProps = {
                 ...this.props,
-                type: this.props.minimumFractionDigits || this.props.maximumFractionDigits ? 'text' : 'number',
+                type:
+                    this.props.minimumFractionDigits ||
+                    (this.props.maximumFractionDigits && this.props.maximumFractionDigits > 0)
+                        ? 'text'
+                        : 'number',
                 value: this.state.value,
                 onChange: this.handleChange,
                 onBlur: this.handleBlur,

--- a/src/components/TextField/formatters/withNumberFormatting/index.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/index.tsx
@@ -31,19 +31,22 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
             this.state = {
                 value: this.formatter.format(props.value),
                 savedValue: this.props.value,
-                decimalSeperator: this.getSeperator(props.value),
+                decimalSeperator: this.getSeperator(),
             };
         }
 
         private setFormatter(): void {
             const locale = this.props.locale ? this.props.locale.replace('_', '-') : 'nl-NL';
             const defaultMaximumFractionDigits = this.props.allowFloats ? 2 : 0;
+
             const minimumFractionDigits =
-                this.props.minimumFractionDigits && this.props.allowFloats ? this.props.minimumFractionDigits : 0;
+                this.props.minimumFractionDigits && this.props.allowFloats
+                    ? Math.abs(this.props.minimumFractionDigits)
+                    : 0;
 
             let maximumFractionDigits =
                 this.props.maximumFractionDigits && this.props.allowFloats
-                    ? this.props.maximumFractionDigits
+                    ? Math.abs(this.props.maximumFractionDigits)
                     : defaultMaximumFractionDigits;
 
             if (minimumFractionDigits > maximumFractionDigits) maximumFractionDigits = minimumFractionDigits;
@@ -56,8 +59,10 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
             });
         }
 
-        private getSeperator(value: number): string {
-            const seperator = this.formatter.formatToParts(value).find(part => part.type === 'decimal');
+        private getSeperator(): string {
+            const seperator = this.formatter.formatToParts(1.1).find(part => {
+                return part.type === 'decimal';
+            });
 
             return seperator ? seperator.value : '.';
         }
@@ -92,13 +97,17 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
 
         public componentDidUpdate(prevProps: PropsType) {
             if (
+                this.props.allowFloats !== prevProps.allowFloats ||
                 this.props.locale !== prevProps.locale ||
                 this.props.minimumFractionDigits !== prevProps.minimumFractionDigits ||
                 this.props.maximumFractionDigits !== prevProps.maximumFractionDigits
             ) {
                 this.setFormatter();
 
-                this.setState({ value: this.formatter.format(this.state.savedValue) });
+                this.setState({
+                    value: this.formatter.format(this.state.savedValue),
+                    decimalSeperator: this.getSeperator(),
+                });
             }
 
             if (this.props.value !== prevProps.value && this.props.value !== this.state.savedValue) {

--- a/src/components/TextField/formatters/withNumberFormatting/index.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/index.tsx
@@ -70,8 +70,11 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
         private parse(value: string): number {
             if (this.props.allowFloats) {
                 const stripped = value.replace(new RegExp(`[^\-0-9${this.state.decimalSeperator}]`, 'g'), '');
+                const toFixed = parseFloat(stripped.replace(this.state.decimalSeperator, '.')).toFixed(
+                    this.formatter.resolvedOptions().maximumFractionDigits,
+                );
 
-                return parseFloat(stripped.replace(this.state.decimalSeperator, '.'));
+                return parseFloat(toFixed);
             }
 
             return parseFloat(value);

--- a/src/components/TextField/formatters/withNumberFormatting/index.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/index.tsx
@@ -40,13 +40,13 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
             const defaultMaximumFractionDigits = this.props.allowFloats ? 2 : 0;
 
             const minimumFractionDigits =
-                this.props.minimumFractionDigits && this.props.allowFloats
-                    ? Math.abs(this.props.minimumFractionDigits)
+                this.props.minimumFractionDigits && this.props.allowFloats && this.props.minimumFractionDigits > 0
+                    ? this.props.minimumFractionDigits
                     : 0;
 
             let maximumFractionDigits =
-                this.props.maximumFractionDigits && this.props.allowFloats
-                    ? Math.abs(this.props.maximumFractionDigits)
+                this.props.maximumFractionDigits && this.props.allowFloats && this.props.maximumFractionDigits >= 0
+                    ? this.props.maximumFractionDigits
                     : defaultMaximumFractionDigits;
 
             if (minimumFractionDigits > maximumFractionDigits) maximumFractionDigits = minimumFractionDigits;
@@ -77,6 +77,7 @@ const withNumberFormatting = (Wrapped: ComponentType<TextFieldPropsType>): Compo
             const parsedValue = this.parse(value);
 
             if (isNaN(parsedValue)) {
+                this.setState({ value: '' });
                 this.props.onChange(this.state.savedValue);
             } else if (parsedValue < 0 && this.props.disableNegative) {
                 this.setState({ savedValue: 0, value: '0' });

--- a/src/components/TextField/formatters/withNumberFormatting/test.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/test.tsx
@@ -9,7 +9,7 @@ describe('withNumberFormatting', () => {
         const NumberField = withNumberFormatting(TextField);
         const component = mountWithTheme(<NumberField name="" value={19} onChange={changeMock} />);
 
-        component.find('input').simulate('change', { target: { value: 20 } });
+        component.find('input').simulate('change', { target: { value: '20' } });
 
         expect(changeMock).toHaveBeenCalledWith(20);
     });
@@ -31,7 +31,7 @@ describe('withNumberFormatting', () => {
         const NumberField = withNumberFormatting(TextField);
         const component = mountWithTheme(<NumberField name="" value={19} disableNegative onChange={changeMock} />);
 
-        component.find('input').simulate('change', { target: { value: -5 } });
+        component.find('input').simulate('change', { target: { value: '-5' } });
         component.find('input').simulate('blur');
 
         expect(changeMock).toHaveBeenCalledWith(0);

--- a/src/components/TextField/formatters/withNumberFormatting/test.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/test.tsx
@@ -42,7 +42,7 @@ describe('withNumberFormatting', () => {
         const NumberField = withNumberFormatting(TextField);
 
         const component = mountWithTheme(
-            <NumberField name="" value={10} allowFloats locale="nl_NL" onChange={changeMock} />,
+            <NumberField name="" value={10} allowDecimals locale="nl_NL" onChange={changeMock} />,
         );
 
         component.update();
@@ -54,10 +54,12 @@ describe('withNumberFormatting', () => {
         expect(component.find('input').prop('value')).toBe('12,34');
     });
 
-    it('should not allow float values when allowFloats is false', () => {
+    it('should not allow float values when allowDecimals is false', () => {
         const changeMock = jest.fn();
         const NumberField = withNumberFormatting(TextField);
-        const component = mountWithTheme(<NumberField name="" value={10} allowFloats={false} onChange={changeMock} />);
+        const component = mountWithTheme(
+            <NumberField name="" value={10} allowDecimals={false} onChange={changeMock} />,
+        );
 
         component.find('input').simulate('change', { target: { value: '12,34' } });
         component.find('input').simulate('blur');
@@ -74,7 +76,7 @@ describe('withNumberFormatting', () => {
             <NumberField
                 name=""
                 value={10}
-                allowFloats
+                allowDecimals
                 minimumFractionDigits={2}
                 locale="nl_NL"
                 onChange={changeMock}
@@ -98,7 +100,7 @@ describe('withNumberFormatting', () => {
             <NumberField
                 name=""
                 value={10}
-                allowFloats
+                allowDecimals
                 maximumFractionDigits={2}
                 locale="nl_NL"
                 onChange={changeMock}

--- a/src/components/TextField/formatters/withNumberFormatting/test.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/test.tsx
@@ -42,16 +42,16 @@ describe('withNumberFormatting', () => {
         const NumberField = withNumberFormatting(TextField);
 
         const component = mountWithTheme(
-            <NumberField name="" value={12.34} allowFloats locale="nl_NL" onChange={changeMock} />,
+            <NumberField name="" value={10} allowFloats locale="nl_NL" onChange={changeMock} />,
         );
 
         component.update();
 
-        component.find('input').simulate('change', { target: { value: '56,78' } });
+        component.find('input').simulate('change', { target: { value: '12,34' } });
         component.find('input').simulate('blur');
 
-        expect(changeMock).toHaveBeenCalledWith(56.78);
-        expect(component.find('input').prop('value')).toBe('56,78');
+        expect(changeMock).toHaveBeenCalledWith(12.34);
+        expect(component.find('input').prop('value')).toBe('12,34');
     });
 
     it('should render the value with a minimum amount of decimals', () => {
@@ -70,6 +70,12 @@ describe('withNumberFormatting', () => {
         );
 
         expect(component.find('input').prop('value')).toBe('10,00');
+
+        component.find('input').simulate('change', { target: { value: '11' } });
+        component.find('input').simulate('blur');
+
+        expect(changeMock).toHaveBeenCalledWith(11);
+        expect(component.find('input').prop('value')).toBe('11,00');
     });
 
     it('should be testable with a test-id', () => {

--- a/src/components/TextField/formatters/withNumberFormatting/test.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/test.tsx
@@ -90,6 +90,28 @@ describe('withNumberFormatting', () => {
         expect(component.find('input').prop('value')).toBe('11,00');
     });
 
+    it('should render the value with a maximum amount of decimals', () => {
+        const changeMock = jest.fn();
+        const NumberField = withNumberFormatting(TextField);
+
+        const component = mountWithTheme(
+            <NumberField
+                name=""
+                value={10}
+                allowFloats
+                maximumFractionDigits={2}
+                locale="nl_NL"
+                onChange={changeMock}
+            />,
+        );
+
+        component.find('input').simulate('change', { target: { value: '12,34567' } });
+        component.find('input').simulate('blur');
+
+        expect(changeMock).toHaveBeenCalledWith(12.35);
+        expect(component.find('input').prop('value')).toBe('12,35');
+    });
+
     it('should be testable with a test-id', () => {
         const component = mountWithTheme(
             <TextField.Number data-testid="foo" value={0} name="foo" onChange={jest.fn()} />,

--- a/src/components/TextField/formatters/withNumberFormatting/test.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/test.tsx
@@ -54,6 +54,18 @@ describe('withNumberFormatting', () => {
         expect(component.find('input').prop('value')).toBe('12,34');
     });
 
+    it('should not allow float values when allowFloats is false', () => {
+        const changeMock = jest.fn();
+        const NumberField = withNumberFormatting(TextField);
+        const component = mountWithTheme(<NumberField name="" value={10} allowFloats={false} onChange={changeMock} />);
+
+        component.find('input').simulate('change', { target: { value: '12,34' } });
+        component.find('input').simulate('blur');
+
+        expect(changeMock).toHaveBeenCalledWith(12);
+        expect(component.find('input').prop('value')).toBe('12');
+    });
+
     it('should render the value with a minimum amount of decimals', () => {
         const changeMock = jest.fn();
         const NumberField = withNumberFormatting(TextField);

--- a/src/components/TextField/formatters/withNumberFormatting/test.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/test.tsx
@@ -37,6 +37,41 @@ describe('withNumberFormatting', () => {
         expect(changeMock).toHaveBeenCalledWith(0);
     });
 
+    it('should be able to handle localized float values', () => {
+        const changeMock = jest.fn();
+        const NumberField = withNumberFormatting(TextField);
+
+        const component = mountWithTheme(
+            <NumberField name="" value={12.34} allowFloats locale="nl_NL" onChange={changeMock} />,
+        );
+
+        component.update();
+
+        component.find('input').simulate('change', { target: { value: '56,78' } });
+        component.find('input').simulate('blur');
+
+        expect(changeMock).toHaveBeenCalledWith(56.78);
+        expect(component.find('input').prop('value')).toBe('56,78');
+    });
+
+    it('should render the value with a minimum amount of decimals', () => {
+        const changeMock = jest.fn();
+        const NumberField = withNumberFormatting(TextField);
+
+        const component = mountWithTheme(
+            <NumberField
+                name=""
+                value={10}
+                allowFloats
+                minimumFractionDigits={2}
+                locale="nl_NL"
+                onChange={changeMock}
+            />,
+        );
+
+        expect(component.find('input').prop('value')).toBe('10,00');
+    });
+
     it('should be testable with a test-id', () => {
         const component = mountWithTheme(
             <TextField.Number data-testid="foo" value={0} name="foo" onChange={jest.fn()} />,

--- a/src/components/TextField/formatters/withNumberFormatting/test.tsx
+++ b/src/components/TextField/formatters/withNumberFormatting/test.tsx
@@ -45,8 +45,6 @@ describe('withNumberFormatting', () => {
             <NumberField name="" value={10} allowDecimals locale="nl_NL" onChange={changeMock} />,
         );
 
-        component.update();
-
         component.find('input').simulate('change', { target: { value: '12,34' } });
         component.find('input').simulate('blur');
 

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -130,7 +130,7 @@ class TextField extends Component<PropsType, StateType> {
                         <StyledAffixWrapper
                             onClick={typeof this.props.suffix === 'string' ? this.forceFocus : undefined}
                             disabled={this.props.disabled}
-                            isString={typeof this.props.prefix === 'string' ? true : false}
+                            isString={typeof this.props.suffix === 'string' ? true : false}
                         >
                             <StyledAffix>{this.props.suffix}</StyledAffix>
                         </StyledAffixWrapper>

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -69,7 +69,7 @@ const Demo: FC<PropsType> = (props): JSX.Element => {
         value: numberValue,
         onChange: setNumberValue,
         disableNegative: boolean('disable negative numbers', false),
-        allowFloats: boolean('allowFloats', false),
+        allowDecimals: boolean('allowDecimals', false),
         minimumFractionDigits: number('minimumFractionDigits', 0),
         maximumFractionDigits: number('maximumFractionDigits', 2),
         locale: select('locale', ['nl_NL', 'en_GB'], 'nl_NL'),

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -5,6 +5,7 @@ import TextField from '.';
 import SeverityType from '../../types/SeverityType';
 import { Checkbox, IconButton, Box } from '../..';
 import { SearchIcon } from '../../assets';
+import { number } from '@storybook/addon-knobs';
 
 type PropsType = {
     withClearButton?: boolean;
@@ -69,6 +70,8 @@ const Demo: FC<PropsType> = (props): JSX.Element => {
         value: numberValue,
         onChange: setNumberValue,
         disableNegative: boolean('disable negative numbers', false),
+        minimumFractionDigits: number('minimumFractionDigits', 0),
+        maximumFractionDigits: number('maximumFractionDigits', 2),
     };
 
     const textProps = {

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -1,11 +1,10 @@
 import React, { useState, FC } from 'react';
-import { select, text, boolean } from '@storybook/addon-knobs';
+import { select, text, boolean, number } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import TextField from '.';
 import SeverityType from '../../types/SeverityType';
 import { Checkbox, IconButton, Box } from '../..';
 import { SearchIcon } from '../../assets';
-import { number } from '@storybook/addon-knobs';
 
 type PropsType = {
     withClearButton?: boolean;
@@ -72,6 +71,7 @@ const Demo: FC<PropsType> = (props): JSX.Element => {
         disableNegative: boolean('disable negative numbers', false),
         minimumFractionDigits: number('minimumFractionDigits', 0),
         maximumFractionDigits: number('maximumFractionDigits', 2),
+        locale: select('locale', ['nl_NL', 'en_GB'], 'nl_NL'),
     };
 
     const textProps = {

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -16,7 +16,7 @@ type PropsType = {
 
 const Demo: FC<PropsType> = (props): JSX.Element => {
     const [stringValue, setStringValue] = useState('');
-    const [numberValue, setNumberValue] = useState(10.12);
+    const [numberValue, setNumberValue] = useState(10);
     const [isChecked, setChecked] = useState(true);
 
     const sharedProps = {

--- a/src/components/TextField/story.tsx
+++ b/src/components/TextField/story.tsx
@@ -16,7 +16,7 @@ type PropsType = {
 
 const Demo: FC<PropsType> = (props): JSX.Element => {
     const [stringValue, setStringValue] = useState('');
-    const [numberValue, setNumberValue] = useState(10);
+    const [numberValue, setNumberValue] = useState(10.12);
     const [isChecked, setChecked] = useState(true);
 
     const sharedProps = {
@@ -69,6 +69,7 @@ const Demo: FC<PropsType> = (props): JSX.Element => {
         value: numberValue,
         onChange: setNumberValue,
         disableNegative: boolean('disable negative numbers', false),
+        allowFloats: boolean('allowFloats', false),
         minimumFractionDigits: number('minimumFractionDigits', 0),
         maximumFractionDigits: number('maximumFractionDigits', 2),
         locale: select('locale', ['nl_NL', 'en_GB'], 'nl_NL'),


### PR DESCRIPTION
### This PR:

Resolves #483

**Backwards compatible additions** ✨
- Added optional `allowDecimals`, `locale`, `minimumFractionDigits` and `maximumFractionDigits` to `TextField.Number`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
