### PR TITLE
Prevented firing of onChange when checkbox is disabled

### DIFF
--- a/src/components/Checkbox/index.tsx
+++ b/src/components/Checkbox/index.tsx
@@ -31,10 +31,12 @@ class Checkbox extends Component<PropsType, StateType> {
     }
 
     private changeHandler = (event: MouseEvent<HTMLDivElement>): void => {
-        this.props.onChange({
-            checked: !(this.props.checked === true),
-            event,
-        });
+        if (!this.props.disabled) {
+            this.props.onChange({
+                checked: !(this.props.checked === true),
+                event,
+            });
+        }
     };
 
     public toggleFocus = (): void => {

--- a/src/components/Checkbox/test.tsx
+++ b/src/components/Checkbox/test.tsx
@@ -66,6 +66,18 @@ describe('Checkbox', () => {
         );
     });
 
+    it('should not handle the change when disabled', () => {
+        const mockChangeHandler = jest.fn();
+
+        const checkbox = mountWithTheme(
+            <Checkbox onChange={mockChangeHandler} name="demo" disabled={true} checked={false} value="bar" />,
+        );
+
+        checkbox.simulate('click');
+
+        expect(mockChangeHandler).not.toHaveBeenCalled();
+    });
+
     it('should show an error state', () => {
         const checkbox = mountWithTheme(
             <Checkbox onChange={(): void => undefined} name="demo" error={true} checked={false} value="bar" />,


### PR DESCRIPTION
### This PR:

I discovered the `Checkbox` still handled it's `onChange` when disabled. This PR prevents `props.onChange` from being called and adds a test to ensure it.

**Bugfixes/Changed internals** 🎈
- `onChange` no longer fires when disabled is true.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
