### PR TITLE
Use styled-components instead of style prop, replace hardcoded colors

### DIFF
--- a/docs/components/ContentPane.tsx
+++ b/docs/components/ContentPane.tsx
@@ -1,20 +1,18 @@
 import React, { FC } from 'react';
-import { Box } from '@myonlinestore/bricks';
+import { Box, colors, rgba } from '@myonlinestore/bricks';
+import styled from 'styled-components';
+
+const StyledContentPane = styled(Box)`
+    background: ${colors.white};
+    border-radius: 9px 9px 0 0;
+    box-shadow: 0 1px 4px 0 ${rgba(colors.grey900, 0.25)};
+`;
 
 const ContentPane: FC = props => (
-    <Box
-        grow={1}
-        padding={[48, 120 as 0]}
-        maxWidth="960px"
-        minWidth="960px"
-        style={{
-            background: '#fff',
-            borderRadius: '9px 9px 0 0',
-            boxShadow: '0 1px 4px 0 rgba(0,0,0,0.25)',
-        }}
-    >
+    <StyledContentPane grow={1} padding={[48, 120 as 0]} maxWidth="960px" minWidth="960px">
         {props.children}
-    </Box>
+    </StyledContentPane>
 );
 
 export default ContentPane;
+export { StyledContentPane };

--- a/docs/components/Page.tsx
+++ b/docs/components/Page.tsx
@@ -1,17 +1,22 @@
 import React, { FC } from 'react';
-import { Box } from '@myonlinestore/bricks';
+import { Box, colors } from '@myonlinestore/bricks';
 import Header from '../containers/Header';
+import styled from 'styled-components';
+
+const StyledPage = styled.main`
+    background-color: ${colors.grey100};
+`;
 
 const Page: FC = props => {
     return (
-        <main style={{ backgroundColor: '#F8F9FB' }}>
+        <StyledPage>
             <Box minHeight="100vh" direction="column" maxWidth="1200px" margin={['auto']}>
                 <Header />
                 <Box width="100%" minHeight="80vh" alignContent="stretch">
                     {props.children}
                 </Box>
             </Box>
-        </main>
+        </StyledPage>
     );
 };
 

--- a/docs/components/SidebarLink.tsx
+++ b/docs/components/SidebarLink.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { Heading, Text, Box, Link } from '@myonlinestore/bricks';
 import StyledLink from './StyledLink';
+import styled from 'styled-components';
 
 type PropsType = {
     depth?: number;
@@ -8,16 +9,17 @@ type PropsType = {
     title: string;
 };
 
+const StyledText = styled(Text)`
+    font-size: inherit;
+    font-family: inherit;
+`;
+
 const SidebarLink: FC<PropsType> = props => (
     <Box padding={[12, 0]}>
         <Heading as="h3" hierarchy={3}>
-            <Text
-                severity={props.depth === 2 ? 'info' : undefined}
-                as="span"
-                style={{ fontSize: 'inherit', fontFamily: 'inherit' }}
-            >
+            <StyledText severity={props.depth === 2 ? 'info' : undefined} as="span">
                 <StyledLink href={props.href} title={props.title} />
-            </Text>
+            </StyledText>
         </Heading>
     </Box>
 );

--- a/docs/containers/Header.tsx
+++ b/docs/containers/Header.tsx
@@ -31,6 +31,10 @@ const StyledHeader = styled.div`
     }
 `;
 
+const HeadingLinkContainer = styled(Box)`
+    margin-left: 120px;
+`;
+
 const Header: FC = props => {
     return (
         <StyledHeader>
@@ -41,7 +45,7 @@ const Header: FC = props => {
                     </Link>
                 </Box>
 
-                <Box style={{ marginLeft: '120px' }}>
+                <HeadingLinkContainer>
                     {articleData.srcDirs.map((category, index) => (
                         <HeadingLink key={index}>
                             <StyledLink
@@ -50,7 +54,7 @@ const Header: FC = props => {
                             />
                         </HeadingLink>
                     ))}
-                </Box>
+                </HeadingLinkContainer>
             </Box>
         </StyledHeader>
     );

--- a/docs/lib/componentMap.tsx
+++ b/docs/lib/componentMap.tsx
@@ -1,5 +1,12 @@
 import React, { FC } from 'react';
-import { Heading, Text, Box } from '@myonlinestore/bricks';
+import { Heading, Text, Box, colors } from '@myonlinestore/bricks';
+import styled from 'styled-components';
+
+const StyledHr = styled.hr`
+    width: 100%;
+    color: transparent;
+    border-top: 1px solid ${colors.grey300};
+`;
 
 const componentMap: { [key: string]: FC } = {
     h1: props => (
@@ -34,7 +41,7 @@ const componentMap: { [key: string]: FC } = {
     ),
     hr: props => (
         <Box margin={[24, 0]} width="100%">
-            <hr style={{ width: '100%', color: 'transparent', borderTop: '1px solid #D2D7E0' }} />
+            <StyledHr />
         </Box>
     ),
     p: props => <Text severity="info">{props.children}</Text>,

--- a/docs/pages/_error.tsx
+++ b/docs/pages/_error.tsx
@@ -3,7 +3,7 @@ import { Box, Heading } from '@myonlinestore/bricks';
 
 const ErrorPage: FC = props => (
     <Box width="100%" height="100%" margin={['auto']} justifyContent="center" alignItems="center">
-        <Heading style={{ color: 'red' }}>404: Page not found</Heading>
+        <Heading>404: Page not found</Heading>
     </Box>
 );
 

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -1,25 +1,13 @@
-import React, { FC } from 'react';
-import { Box, Text, Heading } from '@myonlinestore/bricks';
-import Sidebar from '../components/Sidebar';
-import ContentPane from '../components/ContentPane';
-import componentMap from '../lib/componentMap';
+import React from 'react';
+import { Box, Text, Heading, colors } from '@myonlinestore/bricks';
+import { StyledContentPane } from '../components/ContentPane';
 import headerBackground from '../assets/homepage-header-background.svg';
 import homepageIllustration from '../assets/undraw_fitting_piece_iilo.svg';
 
 const Index = () => {
     return (
         <Box>
-            <Box
-                grow={1}
-                maxWidth="1240px"
-                minWidth="1240px"
-                style={{
-                    background: '#fff',
-                    borderRadius: '9px 9px 0 0',
-                    boxShadow: '0 1px 4px 0 rgba(0,0,0,0.25)',
-                }}
-                direction="column"
-            >
+            <StyledContentPane grow={1} maxWidth="1240px" minWidth="1240px" direction="column">
                 <Box
                     width="100%"
                     height="241px"
@@ -31,12 +19,12 @@ const Index = () => {
                 >
                     <Box
                         direction="column"
-                        style={{ color: '#fff', marginLeft: '84px', marginTop: 'auto', marginBottom: 'auto' }}
+                        style={{ color: colors.white, marginLeft: '84px', marginTop: 'auto', marginBottom: 'auto' }}
                     >
-                        <Heading as="h1" hierarchy={1} style={{ color: '#fff' }}>
+                        <Heading as="h1" hierarchy={1} style={{ color: colors.white }}>
                             Bricks
                         </Heading>
-                        <Heading as="h6" hierarchy={6} style={{ color: '#fff' }}>
+                        <Heading as="h6" hierarchy={6} style={{ color: colors.white }}>
                             A Design system by My Online Store
                         </Heading>
                     </Box>
@@ -45,7 +33,7 @@ const Index = () => {
                     width="100%"
                     height="244px"
                     style={{
-                        background: '#F8F9FB',
+                        background: colors.grey100,
                         marginTop: '-24px',
                     }}
                 >
@@ -53,7 +41,7 @@ const Index = () => {
                         <Box
                             direction="column"
                             width="450px"
-                            style={{ color: '#fff', marginLeft: '84px', marginTop: 'auto', marginBottom: 'auto' }}
+                            style={{ color: colors.white, marginLeft: '84px', marginTop: 'auto', marginBottom: 'auto' }}
                         >
                             <Heading as="h3" hierarchy={3}>
                                 What is Bricks?
@@ -79,7 +67,7 @@ const Index = () => {
                         </Text>
                     </Box>
                 </Box>
-            </Box>
+            </StyledContentPane>
         </Box>
     );
 };


### PR DESCRIPTION
### This PR:

Replaces hardcoded `style` prop styling and colors with styled components and colors from bricks in the design system site.
