### PR TITLE
#455 - Remove deprecated stacked prop on ButtonGroup

### DIFF
--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -7,7 +7,6 @@ type PropsType = {
 };
 
 const ButtonGroup: FunctionComponent<PropsType> = props => {
-    // tslint:disable-next-line:deprecation
     const isStacked = props.direction === 'stacked';
     const direction = isStacked ? 'column' : 'row';
 

--- a/src/components/ButtonGroup/index.tsx
+++ b/src/components/ButtonGroup/index.tsx
@@ -1,28 +1,14 @@
 import React, { Children, FunctionComponent } from 'react';
 import Box from '../Box';
-import deprecationWarning from '../../utility/deprecationWarning';
 
 type PropsType = {
-    /**
-     * @deprecated The stacked prop has been deprecated and will be removed in
-     * the next major version. Please use direction="stacked" going forward.
-     */
-    stacked?: boolean;
     direction?: 'rtl' | 'ltr' | 'stacked';
     'data-testid'?: string;
 };
 
 const ButtonGroup: FunctionComponent<PropsType> = props => {
     // tslint:disable-next-line:deprecation
-    if (props.stacked !== undefined) {
-        deprecationWarning(
-            'The stacked prop has been deprecated and will be removed in the next major version. please use direction="stacked" going forward.',
-            'https://github.com/MyOnlineStore/bricks/issues/455',
-        );
-    }
-
-    // tslint:disable-next-line:deprecation
-    const isStacked = props.stacked || props.direction === 'stacked';
+    const isStacked = props.direction === 'stacked';
     const direction = isStacked ? 'column' : 'row';
 
     const children =

--- a/src/components/ButtonGroup/test.tsx
+++ b/src/components/ButtonGroup/test.tsx
@@ -32,14 +32,6 @@ describe('ButtonGroup', () => {
         expect(component.find('[data-testid="buttongroup"]').hostNodes()).toHaveLength(1);
     });
 
-    it('should show a deprecation warning when the stacked prop is used', () => {
-        (console as any).warn.mockImplementationOnce(() => undefined);
-
-        mountWithTheme(<ButtonGroup stacked />);
-
-        expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('deprecated'));
-    });
-
     const buttonSet = ['primary', 'secondary'];
 
     describe.each<['stacked' | 'rtl' | 'ltr', Array<string>]>([


### PR DESCRIPTION
### This PR:

resolves #455 

**Breaking changes** 🔥
- Removes (deprecated) `stacked` prop on `ButtonGroup`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
