### PR TITLE
#433 - Use font colour for strikethrough PriceTag

### DIFF
--- a/src/components/PriceTag/style.tsx
+++ b/src/components/PriceTag/style.tsx
@@ -5,7 +5,7 @@ type PropsType = {
 };
 
 const StyledPriceTag = styled.span<PropsType>`
-    ${({ theme, strikethrough }): string => {
+    ${({ strikethrough }): string => {
         return `
             position: relative;
 
@@ -13,21 +13,7 @@ const StyledPriceTag = styled.span<PropsType>`
                 font-size: .7em;
             }
 
-            ${
-                strikethrough === true
-                    ? `&::after {
-                    content: '';
-                    width: 100%;
-                    height: 2px;
-                    left: 0;
-                    top: 50%;
-                    margin-top: -1px;
-                    position: absolute;
-                    background: ${theme.Text.default.color};
-                    opacity: 0.7;
-                }`
-                    : ''
-            }
+            ${strikethrough === true ? 'text-decoration: line-through' : ''}
         `;
     }};
 `;

--- a/src/components/PriceTag/style.tsx
+++ b/src/components/PriceTag/style.tsx
@@ -1,10 +1,4 @@
 import styled from '../../utility/styled';
-import ThemeTools from '../../themes/ExperimentalCustomTheme/ThemeTools';
-
-type PriceTagThemeType = {
-    strikethroughColor: string;
-    strikethroughOpacity: string;
-};
 
 type PropsType = {
     strikethrough?: boolean;
@@ -29,8 +23,8 @@ const StyledPriceTag = styled.span<PropsType>`
                     top: 50%;
                     margin-top: -1px;
                     position: absolute;
-                    background: ${theme.PriceTag.strikethroughColor};
-                    opacity: ${theme.PriceTag.strikethroughOpacity};
+                    background: ${theme.Text.default.color};
+                    opacity: 0.7;
                 }`
                     : ''
             }
@@ -38,14 +32,4 @@ const StyledPriceTag = styled.span<PropsType>`
     }};
 `;
 
-const composePriceTagTheme = (themeTools: ThemeTools): PriceTagThemeType => {
-    const { colors } = themeTools.themeSettings;
-
-    return {
-        strikethroughColor: colors.grey.lighter2,
-        strikethroughOpacity: '.7',
-    };
-};
-
 export default StyledPriceTag;
-export { PriceTagThemeType, composePriceTagTheme };

--- a/src/components/PriceTag/test.tsx
+++ b/src/components/PriceTag/test.tsx
@@ -67,7 +67,7 @@ describe('PriceTag', () => {
                     <PriceTag locale={locale} currency={currency} value={10.2} strikethrough />,
                 );
 
-                expect(priceTag).toHaveStyleRule('background', mosTheme.PriceTag.strikethroughColor, {
+                expect(priceTag).toHaveStyleRule('background', mosTheme.Text.default.color, {
                     modifier: '::after',
                 });
             });

--- a/src/components/PriceTag/test.tsx
+++ b/src/components/PriceTag/test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PriceTag from '.';
 import { mountWithTheme } from '../../utility/styled/testing';
-import { mosTheme } from '../../themes/MosTheme';
 import 'jest-styled-components';
 
 const currencysymbols = {

--- a/src/components/PriceTag/test.tsx
+++ b/src/components/PriceTag/test.tsx
@@ -67,9 +67,7 @@ describe('PriceTag', () => {
                     <PriceTag locale={locale} currency={currency} value={10.2} strikethrough />,
                 );
 
-                expect(priceTag).toHaveStyleRule('background', mosTheme.Text.default.color, {
-                    modifier: '::after',
-                });
+                expect(priceTag).toHaveStyleRule('text-decoration', 'line-through');
             });
         },
     );

--- a/src/themes/ExperimentalCustomTheme/genTheme.ts
+++ b/src/themes/ExperimentalCustomTheme/genTheme.ts
@@ -32,7 +32,6 @@ import { composeTileTheme } from '../../components/Tile';
 import { composePopoverTheme } from '../../components/Popover/style';
 import { composeTooltipTheme } from '../../components/Tooltip/style';
 import { composeScrollBoxTheme } from '../../components/ScrollBox/style';
-import { composePriceTagTheme } from '../../components/PriceTag/style';
 import { composeIllustrationTheme } from '../../components/Illustration/style';
 import { composeTextualButton } from '../../components/TextualButton';
 import { composeProgressTheme } from '../../components/Progress/style';
@@ -88,7 +87,6 @@ const generateThemeObject = (
         NativeSelect: composeNativeSelectTheme(themeTools),
         Notification: composeNotificationTheme(themeTools),
         Popover: composePopoverTheme(themeTools),
-        PriceTag: composePriceTagTheme(themeTools),
         Progress: composeProgressTheme(themeTools),
         RadioButton: composeRadioButtonTheme(themeTools),
         Raised: composeRaisedTheme(themeTools),

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -513,10 +513,6 @@ const theme: ThemeType = {
         background: colors.white,
         borderRadius: roundness.base,
     },
-    PriceTag: {
-        strikethroughColor: colors.grey500,
-        strikethroughOpacity: '.7',
-    },
     Select: {
         common: {
             backgroundColor: colors.white,

--- a/src/types/ThemeType/index.ts
+++ b/src/types/ThemeType/index.ts
@@ -13,7 +13,6 @@ import { MultiButtonThemeType } from '../../components/MultiButton/style';
 import { NativeSelectThemeType } from '../../components/NativeSelect/style';
 import { NotificationThemeType } from '../../components/Notification/style';
 import { PopoverThemeType } from '../../components/Popover/style';
-import { PriceTagThemeType } from '../../components/PriceTag/style';
 import { ProgressThemeType } from '../../components/Progress/style';
 import { RadioButtonThemeType } from '../../components/RadioButton/style';
 import { RaisedThemeType } from '../../components/Raised';
@@ -48,7 +47,6 @@ type ThemeType = {
     NativeSelect: NativeSelectThemeType;
     Notification: NotificationThemeType;
     Popover: PopoverThemeType;
-    PriceTag: PriceTagThemeType;
     Progress: ProgressThemeType;
     RadioButton: RadioButtonThemeType;
     Raised: RaisedThemeType;


### PR DESCRIPTION
### This PR:

resolves #433 

**Breaking changes** 🔥
- Replace separate strikethrough theme properties for pricetag with font colour.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
