### PR TITLE
431 - Refactor variant -> size, severity -> variant in Text component

### DIFF
--- a/docs/lib/componentMap.tsx
+++ b/docs/lib/componentMap.tsx
@@ -44,9 +44,9 @@ const componentMap: { [key: string]: FC } = {
             <StyledHr />
         </Box>
     ),
-    p: props => <Text severity="info">{props.children}</Text>,
+    p: props => <Text variant="descriptive">{props.children}</Text>,
     li: props => (
-        <Text as="span" severity="info">
+        <Text as="span" variant="descriptive">
             <li>{props.children}</li>
         </Text>
     ),

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -34,7 +34,7 @@ const Breadcrumbs: FunctionComponent<PropsType> = (props): JSX.Element => (
                         </Text>
                         {index < props.breadcrumbs.length - 1 && (
                             <Box margin={[0, 9]}>
-                                <Text severity="info">
+                                <Text variant="descriptive">
                                     <Icon icon={chrevronRight} size="small" />
                                 </Text>
                             </Box>

--- a/src/components/EmptyState/index.tsx
+++ b/src/components/EmptyState/index.tsx
@@ -29,7 +29,7 @@ const EmptyState: FunctionComponent<PropsType> = (props): JSX.Element => {
     ));
 
     const message = branchString(props.message, value => (
-        <Text severity="info" textAlign={textAlign}>
+        <Text variant="info" textAlign={textAlign}>
             {value}
         </Text>
     ));

--- a/src/components/FormRow/story.tsx
+++ b/src/components/FormRow/story.tsx
@@ -57,7 +57,7 @@ class DemoComponent extends Component<PropsType, StateType> {
                                 <Box>
                                     <Text>What is your name?</Text>
                                 </Box>
-                                <Text severity="info">
+                                <Text variant="descriptive">
                                     Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
                                     similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
                                     corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
@@ -101,7 +101,7 @@ class DemoComponent extends Component<PropsType, StateType> {
                                 <Box>
                                     <Text>Where do you live?</Text>
                                 </Box>
-                                <Text severity="info">
+                                <Text variant="descriptive">
                                     Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
                                     similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
                                     corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
@@ -135,7 +135,7 @@ class DemoComponent extends Component<PropsType, StateType> {
                                 <Box>
                                     <Text>Can a boolean only be either true or false?</Text>
                                 </Box>
-                                <Text severity="info">
+                                <Text variant="descriptive">
                                     Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
                                     similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
                                     corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
@@ -178,7 +178,7 @@ class DemoComponent extends Component<PropsType, StateType> {
                         label={
                             <>
                                 <Text>Options</Text>
-                                <Text severity="info">
+                                <Text variant="descriptive">
                                     Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
                                     similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
                                     corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
@@ -336,7 +336,7 @@ storiesOf('FormRow', module)
         <FormRow
             label={<Text>{text('label', 'Label text')}</Text>}
             badge={
-                <Text variant="small" severity="success">
+                <Text size="small" variant="success">
                     {text('badge', 'PRO')}
                 </Text>
             }

--- a/src/components/InlineNotification/index.tsx
+++ b/src/components/InlineNotification/index.tsx
@@ -15,7 +15,7 @@ const InlineNotification: FunctionComponent<PropsType> = (props): JSX.Element =>
     const icon = props.icon !== undefined ? props.icon : SeverityIcons[props.severity];
 
     return (
-        <Text variant="small" severity={props.severity}>
+        <Text size="small" variant={props.severity}>
             <Box inline>
                 <Box inline margin={trbl(0, 6, 0, 0)}>
                     <Icon size="medium" icon={icon as string} />

--- a/src/components/MessageStream/index.tsx
+++ b/src/components/MessageStream/index.tsx
@@ -46,7 +46,7 @@ const Message: FunctionComponent<MessagePropsType> = (props): JSX.Element => {
                         <Text>
                             <span dangerouslySetInnerHTML={{ __html: props.message }} />
                         </Text>
-                        <Text severity="info">{props.date}</Text>
+                        <Text variant="descriptive">{props.date}</Text>
                     </Box>
                     {props.onClick !== undefined && props.buttonLabel !== undefined && props.buttonLabel.length > 0 ? (
                         <Box

--- a/src/components/MultiButton/index.tsx
+++ b/src/components/MultiButton/index.tsx
@@ -195,7 +195,7 @@ class MultiButton extends Component<PropsType, StateType> {
                                                         <div>
                                                             <Text
                                                                 as="span"
-                                                                severity="info"
+                                                                variant="descriptive"
                                                                 strong={index === this.state.selectedIndex}
                                                             >
                                                                 <Text strong={index === this.state.selectedIndex}>

--- a/src/components/RadioButton/index.tsx
+++ b/src/components/RadioButton/index.tsx
@@ -59,7 +59,7 @@ const RadioButton: FC<PropsType> = props => {
                     />
                 </StyledRadioButtonSkin>
             </Box>
-            <Text severity={props.disabled ? 'info' : undefined}>
+            <Text variant={props.disabled ? 'info' : undefined}>
                 <Box inline direction="row" align-items="center">
                     {props.disabled && (
                         <Box inline margin={trbl(0, 12, 0, 0)}>

--- a/src/components/Select/Option/index.tsx
+++ b/src/components/Select/Option/index.tsx
@@ -42,12 +42,12 @@ const Option: FunctionComponent<PropsType> = (props): JSX.Element => {
                     <Box padding={trbl(6, 0)} alignItems="center" inline>
                         {props.isSelected && (
                             <Box margin={trbl(0, 6, 0, 0)} inline>
-                                <Text severity={props.isSelected ? 'info' : undefined}>
+                                <Text variant={props.isSelected ? 'descriptive' : undefined}>
                                     <Icon size="medium" icon={checkmark} />
                                 </Text>
                             </Box>
                         )}
-                        <Text severity={props.isSelected ? 'info' : undefined}>{props.label}</Text>
+                        <Text variant={props.isSelected ? 'descriptive' : undefined}>{props.label}</Text>
                     </Box>
                 )}
             </Box>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -246,7 +246,7 @@ class Select<GenericOptionType extends OptionBaseType> extends Component<PropsTy
                             )) || (
                                 <Box alignItems="center" padding={trbl(6, 12)} grow={1}>
                                     {(this.props.value !== '' && <Text>{selectedOption.label}</Text>) || (
-                                        <Text severity="info">
+                                        <Text variant="descriptive">
                                             <StyledPlaceholder
                                                 data-testid={
                                                     this.props['data-testid']

--- a/src/components/Select/story.tsx
+++ b/src/components/Select/story.tsx
@@ -97,14 +97,14 @@ const renderSelected = (option: DemoOptionType): JSX.Element => {
                 </Box>
                 <Box direction="column">
                     <Text>{option.label}</Text>
-                    <Text severity="info">{option.description}</Text>
+                    <Text variant="descriptive">{option.description}</Text>
                 </Box>
             </Box>
         );
     } else {
         return (
             <Box direction="row" alignItems="center">
-                <Text severity="info">{'Make a selection'}</Text>
+                <Text variant="descriptive">{'Make a selection'}</Text>
             </Box>
         );
     }
@@ -117,16 +117,16 @@ const renderOption = (option: DemoOptionType, optionState: OptionStateType): JSX
                 <img src={option.image} />
             </Box>
             <Box direction="column">
-                <Text severity={optionState.isSelected ? 'info' : undefined}>
+                <Text variant={optionState.isSelected ? 'descriptive' : undefined}>
                     {optionState.isSelected && (
-                        <Text as="span" severity="info">
+                        <Text as="span" variant="descriptive">
                             <Icon size="small" icon={checkmarkIcon} />
                             &nbsp;&nbsp;
                         </Text>
                     )}
                     {option.label}
                 </Text>
-                <Text severity="info">{option.description}</Text>
+                <Text variant="descriptive">{option.description}</Text>
             </Box>
         </Box>
     );

--- a/src/components/Table/Card/index.tsx
+++ b/src/components/Table/Card/index.tsx
@@ -118,7 +118,7 @@ class Card extends Component<PropsType, StateType> {
                     )}
                     {this.props.draggable && provided && (
                         <Box padding={[6]} {...provided.dragHandleProps}>
-                            <Text severity={!this.state.hasHover ? 'info' : undefined}>
+                            <Text variant={!this.state.hasHover ? 'descriptive' : undefined}>
                                 <Icon size="medium" icon={bars} />
                             </Text>
                         </Box>

--- a/src/components/Table/Row/index.tsx
+++ b/src/components/Table/Row/index.tsx
@@ -83,7 +83,7 @@ class Row extends Component<PropsType, StateType> {
                                                 onBlur={this.handleBlur}
                                                 onFocus={this.handleFocus}
                                             >
-                                                <Text severity={!this.state.hasHover ? 'info' : undefined}>
+                                                <Text variant={!this.state.hasHover ? 'descriptive' : undefined}>
                                                     <Icon size="medium" icon={bars} />
                                                 </Text>
                                             </Cell>

--- a/src/components/Table/TableHeaders/index.tsx
+++ b/src/components/Table/TableHeaders/index.tsx
@@ -144,7 +144,7 @@ class Headers extends Component<PropsType, StateType> {
                 >
                     {(typeof column.header === 'string' && <Text strong>{column.header}</Text>) || column.header}
                     {this.state.columns[key].sorting !== undefined && (
-                        <Text severity={this.state.columns[key].sorting === 'none' ? 'info' : undefined}>
+                        <Text variant={this.state.columns[key].sorting === 'none' ? 'descriptive' : undefined}>
                             <Icon
                                 title={`sorting: ${
                                     this.state.columns[key].sorting !== undefined

--- a/src/components/Table/story.tsx
+++ b/src/components/Table/story.tsx
@@ -95,7 +95,7 @@ class Demo extends Component<PropsType, StateType> {
     private sortPrice = (a: number, b: number) => a - b;
 
     private renderPrice = (price: number) => {
-        return <Text severity={price > 0 ? 'success' : 'error'}>€ {price.toFixed(2)}</Text>;
+        return <Text variant={price > 0 ? 'success' : 'error'}>€ {price.toFixed(2)}</Text>;
     };
 
     private renderBadge = (badge: string) => {

--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -2,7 +2,7 @@ import styled from '../../utility/styled';
 import SeverityType from '../../types/SeverityType';
 import ThemeTools from '../../themes/CustomTheme/ThemeTools';
 
-type TextVariantStyleType = {
+type TextSizeStyleType = {
     fontFamily: string;
     fontSize: string;
     fontWeight: string;
@@ -16,57 +16,58 @@ type TextThemeType = {
     default: {
         color: string;
     };
-    variant: {
-        small: TextVariantStyleType;
-        regular: TextVariantStyleType;
-        large: TextVariantStyleType;
-        extraLarge: TextVariantStyleType;
-        display: TextVariantStyleType;
+    size: {
+        small: TextSizeStyleType;
+        regular: TextSizeStyleType;
+        large: TextSizeStyleType;
+        extraLarge: TextSizeStyleType;
+        display: TextSizeStyleType;
     };
     strong: {
         fontWeight: string;
     };
-    severity: {
+    variant: {
         error: string;
         success: string;
         info: string;
         warning: string;
+        descriptive: string;
     };
 };
 
 type PropsType = {
-    variant?: 'small' | 'regular' | 'large' | 'extraLarge' | 'display';
-    severity?: SeverityType;
+    size?: 'small' | 'regular' | 'large' | 'extraLarge' | 'display';
+    variant?: SeverityType | 'descriptive';
     textAlign?: 'left' | 'right' | 'center' | 'justify';
     compact?: boolean;
     strong?: boolean;
 };
 
 const Text = styled.p<PropsType>`
-    color: ${({ severity, theme }): string => (severity ? theme.Text.severity[severity] : theme.Text.default.color)};
-    font-family: ${({ variant, theme }): string =>
-        !variant ? theme.Text.variant.regular.fontFamily : theme.Text.variant[variant].fontFamily};
-    font-size: ${({ variant, theme }): string =>
-        !variant ? theme.Text.variant.regular.fontSize : theme.Text.variant[variant].fontSize};
-    font-weight: ${({ variant, strong, theme }): string => {
+    color: ${({ variant, theme }): string => (variant ? theme.Text.variant[variant] : theme.Text.default.color)};
+    font-family: ${({ size, theme }): string =>
+        !size ? theme.Text.size.regular.fontFamily : theme.Text.size[size].fontFamily};
+    font-size: ${({ size, theme }): string =>
+        !size ? theme.Text.size.regular.fontSize : theme.Text.size[size].fontSize};
+    font-weight: ${({ size, strong, theme }): string => {
         if (strong) {
             return theme.Text.strong.fontWeight;
-        } else if (variant && !strong) {
-            return theme.Text.variant[variant].fontWeight;
+        } else if (size && !strong) {
+            return theme.Text.size[size].fontWeight;
         }
 
-        return theme.Text.variant.regular.fontWeight;
+        return theme.Text.size.regular.fontWeight;
     }};
-    line-height: ${({ variant, compact, theme }): string => {
-        if (compact && variant) {
-            return theme.Text.variant[variant].lineHeight.compact;
-        } else if (!compact && variant) {
-            return theme.Text.variant[variant].lineHeight.default;
-        } else if (compact && !variant) {
-            return theme.Text.variant.regular.lineHeight.compact;
+    line-height: ${({ size, compact, theme }): string => {
+        if (compact && size) {
+            return theme.Text.size[size].lineHeight.compact;
+        } else if (!compact && size) {
+            return theme.Text.size[size].lineHeight.default;
+        } else if (compact && !size) {
+            return theme.Text.size.regular.lineHeight.compact;
         }
 
-        return theme.Text.variant.regular.lineHeight.default;
+        return theme.Text.size.regular.lineHeight.default;
     }};
     text-align: ${({ textAlign }): string => (textAlign ? textAlign : '')};
     margin: 0;
@@ -81,7 +82,7 @@ const composeTextTheme = (themeTools: ThemeTools): TextThemeType => {
         default: {
             color: themeTools.calculateContrastTextColor(colors.background),
         },
-        variant: {
+        size: {
             small: {
                 fontFamily: text.primaryFont,
                 fontSize: text.fontSize.smaller1,
@@ -131,14 +132,15 @@ const composeTextTheme = (themeTools: ThemeTools): TextThemeType => {
         strong: {
             fontWeight: text.fontWeight.bold,
         },
-        severity: {
+        variant: {
             error: colors.severity.error,
             success: colors.severity.success,
             info: colors.severity.info,
             warning: colors.severity.warning,
+            descriptive: colors.severity.info,
         },
     };
 };
 
 export default Text;
-export { TextThemeType, TextVariantStyleType, PropsType, composeTextTheme };
+export { TextThemeType, TextSizeStyleType, PropsType, composeTextTheme };

--- a/src/components/Text/story.tsx
+++ b/src/components/Text/story.tsx
@@ -31,11 +31,13 @@ const demoContent = `
 
 storiesOf('Text', module).add('Default', () => (
     <Text
+        size={select('size', ['small', 'regular', 'large', 'extraLarge', 'display'], 'regular') as PropsType['size']}
         variant={
-            select('variant', ['small', 'regular', 'large', 'extraLarge', 'display'], 'regular') as PropsType['variant']
-        }
-        severity={
-            select('severity', [undefined, 'error', 'success', 'info', 'warning'], undefined) as PropsType['severity']
+            select(
+                'variant',
+                [undefined, 'error', 'success', 'info', 'warning', 'descriptive'],
+                undefined,
+            ) as PropsType['variant']
         }
         textAlign={select('text-align', ['left', 'right', 'center', 'justify'], 'left') as PropsType['textAlign']}
         compact={boolean('compact', false)}

--- a/src/components/Text/test.tsx
+++ b/src/components/Text/test.tsx
@@ -6,44 +6,46 @@ import { mosTheme } from '../../themes/MosTheme';
 
 describe('Text', () => {
     it('should render text with different variants', () => {
-        const smallText = mountWithTheme(<Text variant="small">Small text</Text>);
-        const regularText = mountWithTheme(<Text variant="regular">Regular text</Text>);
-        const largeText = mountWithTheme(<Text variant="large">Large text</Text>);
-        const extraLargeText = mountWithTheme(<Text variant="extraLarge">extraLarge text</Text>);
-        const displayText = mountWithTheme(<Text variant="display">Display text</Text>);
+        const smallText = mountWithTheme(<Text size="small">Small text</Text>);
+        const regularText = mountWithTheme(<Text size="regular">Regular text</Text>);
+        const largeText = mountWithTheme(<Text size="large">Large text</Text>);
+        const extraLargeText = mountWithTheme(<Text size="extraLarge">extraLarge text</Text>);
+        const displayText = mountWithTheme(<Text size="display">Display text</Text>);
 
-        expect(smallText).toHaveStyleRule('font-size', mosTheme.Text.variant.small.fontSize);
-        expect(regularText).toHaveStyleRule('font-size', mosTheme.Text.variant.regular.fontSize);
-        expect(largeText).toHaveStyleRule('font-size', mosTheme.Text.variant.large.fontSize);
-        expect(extraLargeText).toHaveStyleRule('font-size', mosTheme.Text.variant.extraLarge.fontSize);
-        expect(displayText).toHaveStyleRule('font-size', mosTheme.Text.variant.display.fontSize);
+        expect(smallText).toHaveStyleRule('font-size', mosTheme.Text.size.small.fontSize);
+        expect(regularText).toHaveStyleRule('font-size', mosTheme.Text.size.regular.fontSize);
+        expect(largeText).toHaveStyleRule('font-size', mosTheme.Text.size.large.fontSize);
+        expect(extraLargeText).toHaveStyleRule('font-size', mosTheme.Text.size.extraLarge.fontSize);
+        expect(displayText).toHaveStyleRule('font-size', mosTheme.Text.size.display.fontSize);
     });
 
     it('should render text with different severities', () => {
         const defaultText = mountWithTheme(<Text>Descriptive text</Text>);
-        const errorText = mountWithTheme(<Text severity="error">Descriptive text</Text>);
-        const successText = mountWithTheme(<Text severity="success">Descriptive text</Text>);
-        const infoText = mountWithTheme(<Text severity="info">Descriptive text</Text>);
-        const warningText = mountWithTheme(<Text severity="warning">Descriptive text</Text>);
+        const errorText = mountWithTheme(<Text variant="error">Descriptive text</Text>);
+        const successText = mountWithTheme(<Text variant="success">Descriptive text</Text>);
+        const infoText = mountWithTheme(<Text variant="info">Descriptive text</Text>);
+        const warningText = mountWithTheme(<Text variant="warning">Descriptive text</Text>);
+        const descriptiveText = mountWithTheme(<Text variant="descriptive">Descriptive text</Text>);
 
         expect(defaultText).toHaveStyleRule('color', mosTheme.Text.default.color);
-        expect(errorText).toHaveStyleRule('color', mosTheme.Text.severity.error);
-        expect(successText).toHaveStyleRule('color', mosTheme.Text.severity.success);
-        expect(infoText).toHaveStyleRule('color', mosTheme.Text.severity.info);
-        expect(warningText).toHaveStyleRule('color', mosTheme.Text.severity.warning);
+        expect(errorText).toHaveStyleRule('color', mosTheme.Text.variant.error);
+        expect(successText).toHaveStyleRule('color', mosTheme.Text.variant.success);
+        expect(infoText).toHaveStyleRule('color', mosTheme.Text.variant.info);
+        expect(warningText).toHaveStyleRule('color', mosTheme.Text.variant.warning);
+        expect(descriptiveText).toHaveStyleRule('color', mosTheme.Text.variant.descriptive);
     });
 
     it('should render text with compact styling', () => {
         const defaultCompact = mountWithTheme(<Text compact>Descriptive text</Text>);
 
         const extraLargeCompact = mountWithTheme(
-            <Text variant="extraLarge" compact>
+            <Text size="extraLarge" compact>
                 Descriptive text
             </Text>,
         );
 
-        expect(defaultCompact).toHaveStyleRule('line-height', mosTheme.Text.variant.regular.lineHeight.compact);
-        expect(extraLargeCompact).toHaveStyleRule('line-height', mosTheme.Text.variant.extraLarge.lineHeight.compact);
+        expect(defaultCompact).toHaveStyleRule('line-height', mosTheme.Text.size.regular.lineHeight.compact);
+        expect(extraLargeCompact).toHaveStyleRule('line-height', mosTheme.Text.size.extraLarge.lineHeight.compact);
     });
 
     it('should render text with strong styling', () => {

--- a/src/components/Text/test.tsx
+++ b/src/components/Text/test.tsx
@@ -5,7 +5,7 @@ import 'jest-styled-components';
 import { mosTheme } from '../../themes/MosTheme';
 
 describe('Text', () => {
-    it('should render text with different variants', () => {
+    it('should render text with different sizes', () => {
         const smallText = mountWithTheme(<Text size="small">Small text</Text>);
         const regularText = mountWithTheme(<Text size="regular">Regular text</Text>);
         const largeText = mountWithTheme(<Text size="large">Large text</Text>);
@@ -19,7 +19,7 @@ describe('Text', () => {
         expect(displayText).toHaveStyleRule('font-size', mosTheme.Text.size.display.fontSize);
     });
 
-    it('should render text with different severities', () => {
+    it('should render text with different variants', () => {
         const defaultText = mountWithTheme(<Text>Descriptive text</Text>);
         const errorText = mountWithTheme(<Text variant="error">Descriptive text</Text>);
         const successText = mountWithTheme(<Text variant="success">Descriptive text</Text>);

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -59,7 +59,7 @@ const TextArea: FC<PropsType> = props => {
                 />
                 {props.characterLimit && (
                     <Box justifyContent="flex-end" padding={[0, 12, 6]} onClick={focusField} style={{ cursor: 'text' }}>
-                        <Text severity="info">{`${props.value.length} / ${props.characterLimit}`}</Text>
+                        <Text variant="descriptive">{`${props.value.length} / ${props.characterLimit}`}</Text>
                     </Box>
                 )}
             </StyledTextAreaWrapper>

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -82,7 +82,7 @@ const Toast: FC<PropsType> = props => {
                                 <StyledToast severity={props.severity}>
                                     {!isSmall && (
                                         <Box alignSelf="flex-start" margin={[18, 6, 18, 18]}>
-                                            <Text as="span" severity={props.severity}>
+                                            <Text as="span" variant={props.severity}>
                                                 <Icon size="medium" icon={icon} />
                                             </Text>
                                         </Box>

--- a/src/components/Toast/style.tsx
+++ b/src/components/Toast/style.tsx
@@ -40,7 +40,7 @@ const StyledToast = styled.div<ToastPropsType>`
     box-shadow: 0 3px 48px rgba(0, 0, 0, 0.3);
     border-radius: ${({ theme }): string => theme.Toast.borderRadius};
     background-color: ${({ theme }): string => theme.Toast.backgroundColor};
-    border-left: ${({ severity, theme }): string => `4px solid ${theme.Text.severity[severity]}`};
+    border-left: ${({ severity, theme }): string => `4px solid ${theme.Text.variant[severity]}`};
     pointer-events: auto;
 
     a {

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -76,7 +76,7 @@ class Toggle extends Component<PropsType, StateType> {
                     </StyledToggleSkin>
                 </Box>
                 <Box margin={trbl(9, 0, 0, 0)}>
-                    <Text severity={this.props.disabled || this.props.unavailable ? 'info' : undefined}>
+                    <Text variant={this.props.disabled || this.props.unavailable ? 'descriptive' : undefined}>
                         {this.props.disabledIcon && this.props.disabled && <Icon size="medium" icon={lockedIcon} />}{' '}
                         {this.props.label}
                     </Text>

--- a/src/components/_CustomTheme/sampleContent.tsx
+++ b/src/components/_CustomTheme/sampleContent.tsx
@@ -228,7 +228,7 @@ const SampleContent: FunctionComponent<PropsType> = (props): JSX.Element => {
                                     <Box>
                                         <Text>Can a boolean only be either true or false?</Text>
                                     </Box>
-                                    <Text severity="info">In my opinion a boolean should also be "maybe".</Text>
+                                    <Text variant="descriptive">In my opinion a boolean should also be "maybe".</Text>
                                 </label>
                             }
                             field={

--- a/src/themes/MosTheme/MosTheme.theme.ts
+++ b/src/themes/MosTheme/MosTheme.theme.ts
@@ -626,7 +626,7 @@ const theme: ThemeType = {
         default: {
             color: colors.grey800,
         },
-        variant: {
+        size: {
             small: {
                 fontFamily: bodyFont,
                 fontSize: fontSize.smaller1,
@@ -676,11 +676,12 @@ const theme: ThemeType = {
         strong: {
             fontWeight: fontWeight.bold,
         },
-        severity: {
+        variant: {
             error: colors.red500,
             success: colors.green400,
             info: colors.grey500,
             warning: colors.yellow500,
+            descriptive: colors.grey500,
         },
     },
     TextArea: {


### PR DESCRIPTION
### This PR:

resolves #431 

**Breaking changes** 🔥
- Refactor `variant` prop on `Text` into `size` prop
- Refactor `severity` prop on `Text` into `variant` and add `descriptive` as variant.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
