### PR TITLE
Deploy design system site instead of storybook to GH pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
       run: yarn --frozen-lockfile
     - name: Building bricks
       run: yarn build
+    - name: Generate pages
+      run: cd docs && node lib/articles-to-pages.js
     - name: Installing site dependencies
       run: cd docs && yarn --frozen-lockfile
     - name: Building site

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,8 @@ jobs:
       run: cd docs && yarn build
     - name: Static export
       run: cd docs && yarn export-to-ghpages
+    - name: Bypass jekyll
+      run: cd docs && touch ./dist/.nojekyll
     - name: Deploy to github
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,10 +39,9 @@ jobs:
       run: cd docs && yarn export-to-ghpages
     - name: Deploy to github
       uses: peaceiris/actions-gh-pages@v3
-      env:
-        GITHUB_TOKEN: ${{ secrets.MOS_EU_GITHUB_TOKEN }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./docs/dist/
       with:
-        username: "myonlinestore-ci-eu"
-        useremail: "team-tech+myonlinestore-ci-eu@myonlinestore.com"
+        github_token: ${{ secrets.MOS_EU_GITHUB_TOKEN }}
+        publish_branch: gh-pages
+        publish_dir: ./docs/dist/
+        user_name: "myonlinestore-ci-eu"
+        user_email: "team-tech+myonlinestore-ci-eu@myonlinestore.com"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,9 +34,9 @@ jobs:
     - name: Installing site dependencies
       run: cd docs && yarn --frozen-lockfile
     - name: Building site
-      run: yarn build
+      run: cd docs && yarn build
     - name: Static export
-      run: yarn export-to-ghpages
+      run: cd docs && yarn export-to-ghpages
     - name: Deploy to github
       uses: peaceiris/actions-gh-pages@v3
       env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,30 +1,46 @@
 name: Deploy
 on:
   push:
-    branches:
-      - master
+    # branches:
+    #   - master
+
 
 jobs:
-  deploy-storybook:
+  deploy-site:
     if: github.actor != 'myonlinestore-ci-eu'
     runs-on: ubuntu-latest
     steps:
     - name: Checking out git repository
       uses: actions/checkout@v2-beta
-    - name: Configuring GitHub user
-      run: |
-        git config --global user.email team-tech+myonlinestore-ci-eu@myonlinestore.com
-        git config --global user.name myonlinestore-ci-eu
     - name: Setting up Node environment
       uses: actions/setup-node@v1
       with:
         node-version: '10.x'
         registry-url: 'https://registry.npmjs.org'
+    - name: Get yarn cache
+      id: yarn-cache
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - name: Hydrating cache 
+      uses: actions/cache@v1
+      with:
+        path: ${{ steps.yarn-cache.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    - name: Building bricks
+      run: yarn build
     - name: Installing dependencies
-      run: yarn install --frozen-lockfile
-    - name: Running tests
-      run: yarn test
-    - name: Deploying storybook to gh-pages
-      run: yarn deploy-storybook --ci
+      run: cd docs && yarn --frozen-lockfile
+    - name: Building site
+      run: yarn build
+    - name: Static export
+      run: yarn export-to-ghpages
+    - name: Deploy to github
+      uses: peaceiris/actions-gh-pages@v3
       env:
-        GH_TOKEN: ${{ secrets.MOS_EU_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PUBLISH_BRANCH: gh-pages
+        PUBLISH_DIR: ./docs/dist/
+      with:
+        username: "myonlinestore-ci-eu"
+        useremail: "team-tech+myonlinestore-ci-eu@myonlinestore.com"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,9 +27,11 @@ jobs:
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
+    - name: Installing bricks dependencies
+      run: yarn --frozen-lockfile
     - name: Building bricks
       run: yarn build
-    - name: Installing dependencies
+    - name: Installing site dependencies
       run: cd docs && yarn --frozen-lockfile
     - name: Building site
       run: yarn build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Deploy to github
       uses: peaceiris/actions-gh-pages@v3
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.MOS_EU_GITHUB_TOKEN }}
         PUBLISH_BRANCH: gh-pages
         PUBLISH_DIR: ./docs/dist/
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy
 on:
   push:
-    # branches:
-    #   - master
+    branches:
+      - master
 
 
 jobs:

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+bricks.myonlinestore.com

--- a/docs/components/Head.tsx
+++ b/docs/components/Head.tsx
@@ -4,6 +4,7 @@ import NextHead from 'next/head';
 const Head: FC = () => {
     return (
         <NextHead>
+            <title>Bricks | A design system by MyOnlineStore</title>
             <link
                 href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,400,400i,600,600i,700,700i"
                 rel="stylesheet"

--- a/docs/lib/articles-to-pages.js
+++ b/docs/lib/articles-to-pages.js
@@ -12,6 +12,8 @@ if (!fs.existsSync(generatedDir)) {
 
 //Function to create the contents of a generated page file
 const createPage = (path, dirName) => {
+    console.log(`Creating page in path: ${path}`);
+
     return `
     import React, { FC } from 'react';
         import Document from '${path}';

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,6 +26,8 @@
   "scripts": {
     "update-bricks": "cd ../ && yarn build && cd docs",
     "update-docs": "cd ../ && yarn docs && cd docs && rimraf node_modules && yarn",
-    "start": "next"
+    "start": "next",
+    "build": "next build",
+    "export-to-ghpages": "next export -o ./dist && cp ./CNAME ./dist/CNAME"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "update-bricks": "cd ../ && yarn build && cd docs",
     "update-docs": "cd ../ && yarn docs && cd docs && rimraf node_modules && yarn",
     "start": "next",
-    "build": "rimraf ./generated && next build",
+    "build": "rimraf ./pages/generated && next build",
     "export-to-ghpages": "next export -o ./dist && cp ./CNAME ./dist/CNAME"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -21,13 +21,14 @@
     "styled-components": "^4.4.0"
   },
   "devDependencies": {
-    "babel-plugin-styled-components": "^1.8.0"
+    "babel-plugin-styled-components": "^1.8.0",
+    "rimraf": "^3.0.2"
   },
   "scripts": {
     "update-bricks": "cd ../ && yarn build && cd docs",
     "update-docs": "cd ../ && yarn docs && cd docs && rimraf node_modules && yarn",
     "start": "next",
-    "build": "next build",
+    "build": "rimraf ./generated && next build",
     "export-to-ghpages": "next export -o ./dist && cp ./CNAME ./dist/CNAME"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "update-bricks": "cd ../ && yarn build && cd docs",
     "update-docs": "cd ../ && yarn docs && cd docs && rimraf node_modules && yarn",
     "start": "next",
-    "build": "rimraf ./pages/generated && next build",
-    "export-to-ghpages": "next export -o ./dist && cp ./CNAME ./dist/CNAME"
+    "build": "next build",
+    "export-to-ghpages": "rimraf ./dist && next export -o ./dist && cp ./CNAME ./dist/CNAME"
   }
 }

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -217,9 +217,9 @@ const Index = () => {
                             <Box direction="column" width="100%" height="207px">
                                 <ReferralRow
                                     title="Frontend Oss: March Meetup"
-                                    href="https://www.meetup.com/FrontendOss/"
+                                    href="https://www.meetup.com/FrontendOss/events/268599763/"
                                     firstSubtitle="MyOnlineStore"
-                                    secondSubtitle="Mar 20 '20"
+                                    secondSubtitle="Mar 24 '20"
                                     thirdSubtitle="FREE"
                                     imgSrc={frontendBadgeImg}
                                 />

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -5404,6 +5404,13 @@ rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"


### PR DESCRIPTION
### This PR:

Deploys the design system website to GH pages instead of storybook. Storybook will remain visible on the Now deploys.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
