### PR TITLE
Added explicit styling to IconButton states

### DIFF
--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -41,16 +41,19 @@ const StyledIconButton = styled(BareButton)<Pick<PropsType, 'variant'>>`
 
         const hover = `
             transform: scale(1.1);
+            background-color: transparent;
             color: ${theme.IconButton[buttonVariant].hover.color};
         `;
 
         const active = `
             transform: scale(0.9);
+            background-color: transparent;
             color: ${theme.IconButton[buttonVariant].hover.color};
         `;
 
         const focus = `
             transform: scale(1.1);
+            background-color: transparent;
             color: ${theme.IconButton[buttonVariant].hover.color};
         `;
 


### PR DESCRIPTION
### This PR:
Adds explicit background styling to the IconButton to prevent unwanted style inheritance on hover/focus/active states:

![image](https://user-images.githubusercontent.com/10552400/74432943-c314c780-4e5f-11ea-8416-d258009d53fc.png)


**Breaking changes** 🔥
- none

**Backwards compatible additions** ✨
- none

**Bugfixes/Changed internals** 🎈
- Adds explicit background styling to prevent unwanted style inheritance on hover/focus/active states.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
