### PR TITLE
Add color board component

### DIFF
--- a/docs/components/ColorBoard.tsx
+++ b/docs/components/ColorBoard.tsx
@@ -1,0 +1,86 @@
+import React, { FC } from 'react';
+import { Box, colors } from '@myonlinestore/bricks';
+import styled from 'styled-components';
+
+type SquareProps = {
+    background: string;
+};
+
+const Square = styled.div<SquareProps>`
+    width: 48px;
+    height: 48px;
+    display: inline-block;
+    color: #ffffff;
+    font-size: 15px;
+    font-family: 'Source Sans Pro', Verdana;
+    background: ${({ background }) => background};
+    display: flex;
+    justify-content: center;
+    align-items: center;
+`;
+
+type PropsType = {};
+
+const ColorBoard: FC<PropsType> = () => {
+    return (
+        <Box direction="column" padding={[12, 0]}>
+            <Box>
+                <Square background={colors.red100}>100</Square>
+                <Square background={colors.red200}>200</Square>
+                <Square background={colors.red300}>300</Square>
+                <Square background={colors.red400}>400</Square>
+                <Square background={colors.red500}>500</Square>
+                <Square background={colors.red600}>600</Square>
+                <Square background={colors.red700}>700</Square>
+                <Square background={colors.red800}>800</Square>
+                <Square background={colors.red900}>900</Square>
+            </Box>
+            <Box>
+                <Square background={colors.yellow100}>100</Square>
+                <Square background={colors.yellow200}>200</Square>
+                <Square background={colors.yellow300}>300</Square>
+                <Square background={colors.yellow400}>400</Square>
+                <Square background={colors.yellow500}>500</Square>
+                <Square background={colors.yellow600}>600</Square>
+                <Square background={colors.yellow700}>700</Square>
+                <Square background={colors.yellow800}>800</Square>
+                <Square background={colors.yellow900}>900</Square>
+            </Box>
+            <Box>
+                <Square background={colors.green100}>100</Square>
+                <Square background={colors.green200}>200</Square>
+                <Square background={colors.green300}>300</Square>
+                <Square background={colors.green400}>400</Square>
+                <Square background={colors.green500}>500</Square>
+                <Square background={colors.green600}>600</Square>
+                <Square background={colors.green700}>700</Square>
+                <Square background={colors.green800}>800</Square>
+                <Square background={colors.green900}>900</Square>
+            </Box>
+            <Box>
+                <Square background={colors.blue100}>100</Square>
+                <Square background={colors.blue200}>200</Square>
+                <Square background={colors.blue300}>300</Square>
+                <Square background={colors.blue400}>400</Square>
+                <Square background={colors.blue500}>500</Square>
+                <Square background={colors.blue600}>600</Square>
+                <Square background={colors.blue700}>700</Square>
+                <Square background={colors.blue800}>800</Square>
+                <Square background={colors.blue900}>900</Square>
+            </Box>
+            <Box>
+                <Square background={colors.grey100}>100</Square>
+                <Square background={colors.grey200}>200</Square>
+                <Square background={colors.grey300}>300</Square>
+                <Square background={colors.grey400}>400</Square>
+                <Square background={colors.grey500}>500</Square>
+                <Square background={colors.grey600}>600</Square>
+                <Square background={colors.grey700}>700</Square>
+                <Square background={colors.grey800}>800</Square>
+                <Square background={colors.grey900}>900</Square>
+            </Box>
+        </Box>
+    );
+};
+
+export default ColorBoard;

--- a/docs/markdown/design/colors.mdx
+++ b/docs/markdown/design/colors.mdx
@@ -1,3 +1,5 @@
+import ColorBoard from '../../components/ColorBoard';
+
 # Colors
 #### Usage and guidelines
 Color is an important tool in our design system. It is used to guide attention and add meaning. We follow color guidelines to optimize the use of this important tool.
@@ -23,7 +25,7 @@ Green-base | Grey-base | White
 Silver-base | Yellow-base | Red-base | Blue-base
 
 #### Variant colors
-Green | Yellow | Red | Blue | Grey | Silver | White
+<ColorBoard />
 
 ***
 


### PR DESCRIPTION
### This PR:

Add color board component to colors design page in docs site.

**Backwards compatible additions** ✨
- Color board 🌈 

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
