### PR TITLE
Fix now2 and GH pages deploys for 2.x

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,20 +32,20 @@ jobs:
     - name: Building bricks
       run: yarn build
     - name: Generate pages
-      run: cd docs && node lib/articles-to-pages.js
+      run: cd packages/components/docs && node lib/articles-to-pages.js
     - name: Installing site dependencies
-      run: cd docs && yarn --frozen-lockfile
+      run: cd packages/components/docs && yarn --frozen-lockfile
     - name: Building site
-      run: cd docs && yarn build
+      run: cd packages/components/docs && yarn build
     - name: Static export
-      run: cd docs && yarn export-to-ghpages
+      run: cd packages/components/docs && yarn export-to-ghpages
     - name: Bypass jekyll
-      run: cd docs && touch ./dist/.nojekyll
+      run: cd packages/components/docs && touch ./dist/.nojekyll
     - name: Deploy to github
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.MOS_EU_GITHUB_TOKEN }}
         publish_branch: gh-pages
-        publish_dir: ./docs/dist/
+        publish_dir: ./packages/components/docs/dist/
         user_name: "myonlinestore-ci-eu"
         user_email: "team-tech+myonlinestore-ci-eu@myonlinestore.com"

--- a/now.json
+++ b/now.json
@@ -17,14 +17,4 @@
         }
     ],
     "cleanUrls": true,
-    "routes": [
-        {
-            "src": "/bricks/packages/components/",
-            "headers": {
-                "cache-control": "s-maxage=1000"
-            },
-            "dest": "/packages/components/",
-            "continue": true
-        }
-    ]
 }

--- a/now.json
+++ b/now.json
@@ -16,5 +16,5 @@
             "use": "@now/static-build"
         }
     ],
-    "cleanUrls": true,
+    "cleanUrls": true
 }

--- a/now.json
+++ b/now.json
@@ -16,13 +16,14 @@
             "use": "@now/static-build"
         }
     ],
+    "cleanUrls": true,
     "routes": [
         {
-            "src": "/",
+            "src": "/bricks/packages/components/",
             "headers": {
                 "cache-control": "s-maxage=1000"
             },
-            "dest": "/packages/components/$1",
+            "dest": "/packages/components/",
             "continue": true
         }
     ]

--- a/now.json
+++ b/now.json
@@ -18,11 +18,12 @@
     ],
     "routes": [
         {
-            "src": "/bricks/packages/components",
+            "src": "/bricks/packages/components/(.*)",
             "headers": {
                 "cache-control": "s-maxage=1000"
             },
-            "dest": "/packages/components/$1"
+            "dest": "/packages/components/$1",
+            "continue": true
         }
     ]
 }

--- a/now.json
+++ b/now.json
@@ -18,7 +18,7 @@
     ],
     "routes": [
         {
-            "src": "/bricks/packages/components/(.*)",
+            "src": "/",
             "headers": {
                 "cache-control": "s-maxage=1000"
             },

--- a/now.json
+++ b/now.json
@@ -10,11 +10,5 @@
     "github": {
         "silent": true
     },
-    "builds": [
-        {
-            "src": "packages/components/package.json",
-            "use": "@now/static-build"
-        }
-    ],
     "cleanUrls": true
 }

--- a/now.json
+++ b/now.json
@@ -5,19 +5,24 @@
         "env": {
             "NPM_TOKEN": "@npm_token",
             "BUILDING_FOR_NOW": "true"
-        }   
+        }
     },
     "github": {
         "silent": true
     },
     "builds": [
-        { "src": "packages/components/package.json", "use": "@now/static-build" }
+        {
+            "src": "packages/components/package.json",
+            "use": "@now/static-build"
+        }
     ],
     "routes": [
         {
-            "src": "/bricks/packages/components", 
-            "headers": {"cache-control": "s-maxage=1000"},
-            "dest": "/packages/components/public"
+            "src": "/bricks/packages/components",
+            "headers": {
+                "cache-control": "s-maxage=1000"
+            },
+            "dest": "/packages/components/$1"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "peerDependencies": {},
   "scripts": {
     "build": "lerna run build",
+    "now-build": "cd packages/components && MODE='static' build-storybook -o ./public -s .storybook/public",
     "cs-fix": "prettier --write ./packages/**/src/**/*.{ts,tsx}",
     "cs": "prettier --list-different ./packages/**/src/**/*.{ts,tsx}",
     "dev:components": "cd packages/components && yarn dev",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "peerDependencies": {},
   "scripts": {
     "build": "lerna run build",
-    "now-build": "cd packages/components && MODE='static' build-storybook -o ./public -s .storybook/public",
+    "now-build": "cd packages/components && MODE='static' build-storybook -o ../../public -s .storybook/public",
     "cs-fix": "prettier --write ./packages/**/src/**/*.{ts,tsx}",
     "cs": "prettier --list-different ./packages/**/src/**/*.{ts,tsx}",
     "dev:components": "cd packages/components && yarn dev",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -60,7 +60,6 @@
   },
   "scripts": {
     "build": "rimraf ./dist && yarn types && rollup -c ../../rollup.config.js",
-    "now-build": "MODE='static' build-storybook -o ./public -s .storybook/public",
     "dev": "start-storybook -p 9001 -s .storybook/public",
     "deploy-storybook": "storybook-to-ghpages -o public",
     "docs": "node scripts/copy-readme.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -60,7 +60,7 @@
   },
   "scripts": {
     "build": "rimraf ./dist && yarn types && rollup -c ../../rollup.config.js",
-    "now-build": "MODE='static' build-storybook --quiet -s .storybook/public -o packages/components/public",
+    "now-build": "MODE='static' build-storybook -o ./public -s .storybook/public",
     "dev": "start-storybook -p 9001 -s .storybook/public",
     "deploy-storybook": "storybook-to-ghpages -o public",
     "docs": "node scripts/copy-readme.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -60,7 +60,7 @@
   },
   "scripts": {
     "build": "rimraf ./dist && yarn types && rollup -c ../../rollup.config.js",
-    "now-build": "build-storybook -o ./public -s .storybook/public",
+    "now-build": "MODE='static' build-storybook -o ./public -s .storybook/public",
     "dev": "start-storybook -p 9001 -s .storybook/public",
     "deploy-storybook": "storybook-to-ghpages -o public",
     "docs": "node scripts/copy-readme.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -60,7 +60,7 @@
   },
   "scripts": {
     "build": "rimraf ./dist && yarn types && rollup -c ../../rollup.config.js",
-    "now-build": "MODE='static' build-storybook -o ./public -s .storybook/public",
+    "now-build": "MODE='static' build-storybook --quiet -s .storybook/public -o packages/components/public",
     "dev": "start-storybook -p 9001 -s .storybook/public",
     "deploy-storybook": "storybook-to-ghpages -o public",
     "docs": "node scripts/copy-readme.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,4 @@
 import path from 'path';
-import { readdirSync } from 'fs';
 import visualizer from 'rollup-plugin-visualizer';
 import commonjs from 'rollup-plugin-commonjs';
 import resolve from 'rollup-plugin-node-resolve';


### PR DESCRIPTION
### This PR:

Fix storybook deploys and update paths for GH pages deploys. Since the `builds` field in the `now.json` is deprecated (https://zeit.co/docs/configuration#project/builds) I added a `now-build` script in the root package.json. 

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
