### PR TITLE
Added correct types to svg components

### DIFF
--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myonlinestore/bricks-assets",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "MyOnlineStore",

--- a/packages/assets/scripts/types.js
+++ b/packages/assets/scripts/types.js
@@ -11,12 +11,12 @@ async function main() {
     const illustrations = fs.readdirSync(path.resolve(__dirname, '..', 'src', 'illustrations'));
 
     let index = `/// <reference path="../env.d.ts" />\n`;
-    let types = `/// <reference types="react" />\nimport { ComponentType } from 'react';\n`;
+    let types = `/// <reference types="react" />\nimport { ComponentType, SVGProps } from 'react';\n`;
 
     icons.forEach(file => {
         const name = transformName(file, 'Icon');
         index += `\nexport { default as ${name} } from './icons/${file}';`;
-        types += `\nexport const ${name}: ComponentType`;
+        types += `\nexport const ${name}: ComponentType<SVGProps<SVGSVGElement>>`;
     });
 
     illustrations.forEach(file => {


### PR DESCRIPTION
### This PR:

It is currently impossible to set props like "width" and "style" on an svg element exported from `@myonlinestore/bricks-assets`. This PR adds the correct types.

**Breaking changes** 🔥

**Backwards compatible additions** ✨

**Bugfixes/Changed internals** 🎈
`@myonlinestore/bricks-assets` now exports types with correctly typed props.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
