### PR TITLE
Fix broken styling on plain Button variant

### DIFF
--- a/packages/components/src/components/Button/index.tsx
+++ b/packages/components/src/components/Button/index.tsx
@@ -91,7 +91,7 @@ const StyledButton = styled(Base)<PropsType>`
             ${idle}
             padding: 11px ${compact ? ' 12px' : '24px'};
             border-radius: ${theme.Button.common.borderRadius};
-            ${variant === 'plain' ? `text-decoration: ${theme.Button.plain.idle.textDecoration}` : ''}
+            ${variant === 'plain' ? `text-decoration: ${theme.Button.plain.idle.textDecoration};` : ''}
 
             &:hover {
                 ${!loading && !disabled ? hover : idle}


### PR DESCRIPTION
### This PR:

resolves broken styling. The hover state and underline were missing.

**Breaking changes** 🔥
- none

**Backwards compatible additions** ✨
- none

**Bugfixes/Changed internals** 🎈
- `;`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
