### PR TITLE
Design System - Add PreviewPane component

### DIFF
--- a/packages/components/docs/components/PreviewPane.tsx
+++ b/packages/components/docs/components/PreviewPane.tsx
@@ -1,0 +1,51 @@
+import React, { FC, useState } from 'react';
+import { Box, Contrast, NativeSelect, Heading } from '@myonlinestore/bricks';
+import styled from 'styled-components';
+
+type PropsType = {};
+
+const StyledContrast = styled(Contrast)`
+    border-radius: 9px;
+`;
+
+const options = [
+    {
+        value: '0',
+        label: 'hoi',
+    },
+    {
+        value: '1',
+        label: 'poep',
+    },
+];
+
+const components = [<div key={0}>WAJOOOO</div>, <div key={1}>POEP</div>];
+
+const PreviewPane: FC<PropsType> = props => {
+    const [selectedComponent, setSelectedComponent] = useState(0);
+
+    return (
+        <StyledContrast>
+            <Box padding={[36]} direction="column" width="100%">
+                <Box>
+                    <Box padding={[12, 12, 48, 0]}>
+                        <Heading hierarchy={5} as="h5">
+                            Examples
+                        </Heading>
+                        <NativeSelect
+                            value={selectedComponent.toString()}
+                            onChange={value => setSelectedComponent(parseInt(value, 2))}
+                            options={options}
+                        />
+                    </Box>
+                </Box>
+
+                <Box style={{ backgroundColor: 'white' }} padding={[48]}>
+                    {components[selectedComponent]}
+                </Box>
+            </Box>
+        </StyledContrast>
+    );
+};
+
+export default PreviewPane;

--- a/packages/components/docs/components/PreviewPane.tsx
+++ b/packages/components/docs/components/PreviewPane.tsx
@@ -1,48 +1,64 @@
-import React, { FC, useState } from 'react';
-import { Box, Contrast, NativeSelect, Heading } from '@myonlinestore/bricks';
+import React, { FC, useState, ReactNode } from 'react';
+import { Box, Contrast, NativeSelect, Heading, colors } from '@myonlinestore/bricks';
 import styled from 'styled-components';
 
-type PropsType = {};
+export type OptionType = {
+    value: string;
+    label: string;
+};
+
+export type ExamplesType = {
+    value: string;
+    component: ReactNode;
+};
+
+type PropsType = {
+    options: Array<OptionType>;
+    examples: Array<ExamplesType>;
+};
 
 const StyledContrast = styled(Contrast)`
+    margin-top: 36px;
+    margin-bottom: 36px;
     border-radius: 9px;
 `;
 
-const options = [
-    {
-        value: '0',
-        label: 'hoi',
-    },
-    {
-        value: '1',
-        label: 'poep',
-    },
-];
+const StyledSelectBox = styled(Box)`
+    width: 282px;
+    margin-left: 36px;
+`;
 
-const components = [<div key={0}>WAJOOOO</div>, <div key={1}>POEP</div>];
+const StyledContentBox = styled(Box)`
+    border-radius: 9px;
+    background: ${colors.white};
+    padding: 36px;
+    align-items: center;
+`;
 
 const PreviewPane: FC<PropsType> = props => {
-    const [selectedComponent, setSelectedComponent] = useState(0);
+    const [selectedExample, setSelectedExample] = useState(props.options[0].value);
 
     return (
         <StyledContrast>
             <Box padding={[36]} direction="column" width="100%">
                 <Box>
-                    <Box padding={[12, 12, 48, 0]}>
+                    <Box padding={[0, 0, 36, 0]} alignItems="center">
                         <Heading hierarchy={5} as="h5">
                             Examples
                         </Heading>
-                        <NativeSelect
-                            value={selectedComponent.toString()}
-                            onChange={value => setSelectedComponent(parseInt(value, 2))}
-                            options={options}
-                        />
+                        <StyledSelectBox>
+                            <NativeSelect
+                                value={selectedExample}
+                                onChange={setSelectedExample}
+                                options={props.options}
+                            />
+                        </StyledSelectBox>
                     </Box>
                 </Box>
 
-                <Box style={{ backgroundColor: 'white' }} padding={[48]}>
-                    {components[selectedComponent]}
-                </Box>
+                <StyledContentBox>
+                    {props.examples.find(example => example.value === selectedExample)?.component}
+                </StyledContentBox>
             </Box>
         </StyledContrast>
     );

--- a/packages/components/docs/containers/examples/ButtonExamplesContainer.tsx
+++ b/packages/components/docs/containers/examples/ButtonExamplesContainer.tsx
@@ -1,0 +1,40 @@
+import React, { FC } from 'react';
+import PreviewPane from '../../components/PreviewPane';
+import { Button } from '@myonlinestore/bricks';
+
+const options = [
+    {
+        value: 'primary',
+        label: 'Button - Primary',
+    },
+    {
+        value: 'secondary',
+        label: 'Button - Secondary',
+    },
+    {
+        value: 'destructive',
+        label: 'Button - Destructive',
+    },
+    {
+        value: 'warning',
+        label: 'Button - Warning',
+    },
+    {
+        value: 'plain',
+        label: 'Button - Cancel',
+    },
+];
+
+const examples = [
+    { value: 'primary', component: <Button title="Primary" variant="primary" /> },
+    { value: 'secondary', component: <Button title="Secondary" variant="secondary" /> },
+    { value: 'destructive', component: <Button title="Destructive" variant="destructive" /> },
+    { value: 'warning', component: <Button title="Warning" variant="warning" /> },
+    { value: 'plain', component: <Button title="Cancel" variant="plain" /> },
+];
+
+const ButtonExamplesContainer: FC<{}> = props => {
+    return <PreviewPane options={options} examples={examples} />;
+};
+
+export default ButtonExamplesContainer;

--- a/packages/components/docs/markdown/components/buttons.mdx
+++ b/packages/components/docs/markdown/components/buttons.mdx
@@ -1,4 +1,5 @@
 import { Button, Box } from '@myonlinestore/bricks';
+import PreviewPane from '../../components/PreviewPane';
 
 
 # Buttons
@@ -27,6 +28,7 @@ All default buttons are 36px in height and have a padding on both sides of 24px.
 
 ##### Examples
 ```Primary | Secondary | Destructive | Warning | Cancel```
+<PreviewPane />
 
 ***
 

--- a/packages/components/docs/markdown/components/buttons.mdx
+++ b/packages/components/docs/markdown/components/buttons.mdx
@@ -1,12 +1,7 @@
-import { Button, Box } from '@myonlinestore/bricks';
-import PreviewPane from '../../components/PreviewPane';
+import ButtonExamplesContainer from '../../containers/examples/ButtonExamplesContainer';
 
 
 # Buttons
-
-<Box>
-    <Button variant="primary" title="Click me!" />
-</Box>
 
 ## Default buttons
 Buttons make actions instantly visible on a page. Depending on the type of action there are several types of buttons available. The most common are the default buttons. You will find these buttons throughout every part of our interface.
@@ -26,11 +21,7 @@ All default buttons are 36px in height and have a padding on both sides of 24px.
 * Destructive and warning state buttons are to be used only for delete or actions which are otherwise hard to recover from.
 * Buttons should be positioned in consistent locations in the interface.
 
-##### Examples
-```Primary | Secondary | Destructive | Warning | Cancel```
-<PreviewPane />
-
-***
+<ButtonExamplesContainer />
 
 ## Icon buttons
 

--- a/packages/components/docs/package.json
+++ b/packages/components/docs/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@mdx-js/mdx": "0.15.0-0",
     "@myonlinestore/bricks": "file:../dist",
-    "@myonlinestore/bricks-assets": "^0.0.4",
+    "@myonlinestore/bricks-assets": "^0.1.1",
     "@types/styled-components": "^4.1.19",
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-mdx": "1.1.0",
@@ -26,7 +26,7 @@
     "rimraf": "^3.0.2"
   },
   "scripts": {
-    "update-bricks": "cd ../ && yarn build && cd docs",
+    "update-bricks": "cd ../ && yarn build && cd docs && rimraf node-modules && yarn",
     "update-docs": "rimraf pages/generated && node lib/articles-to-pages.js",
     "start": "next",
     "build": "next build",

--- a/packages/components/docs/yarn.lock
+++ b/packages/components/docs/yarn.lock
@@ -929,10 +929,10 @@
   dependencies:
     prop-types "^15.6.1"
 
-"@myonlinestore/bricks-assets@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@myonlinestore/bricks-assets/-/bricks-assets-0.0.4.tgz#e0d9d597c1c1092b359c4c6e7fc89d761e239601"
-  integrity sha512-3uYYz5qUqdhGWXCx/MuU1LNJmBcLm0wtL5ejHqLepnZOneGujb9tDjEBTpc8XS20rfia6QLFqjMDBdAzYqFvzQ==
+"@myonlinestore/bricks-assets@^0.1.1":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@myonlinestore/bricks-assets/-/bricks-assets-0.1.2.tgz#6a4e514e05fd183852be443b36efc228623d011b"
+  integrity sha512-YOJW8ikg8EkqtgmQ2FY8mcX97kKJOk8q2fLpYVrRLbc1t+Etd9Amd/RxUYL1mfxsqxV1MfhAknyJvFChXDEpFw==
 
 "@myonlinestore/bricks@file:../dist":
   version "0.0.0"

--- a/packages/components/src/components/Contrast/index.tsx
+++ b/packages/components/src/components/Contrast/index.tsx
@@ -6,6 +6,7 @@ import StyledContrast from './style';
 
 type PropsType = {
     enable?: boolean;
+    className?: string;
 };
 
 const contrastTheme = (theme: ThemeType): ThemeType => {
@@ -19,7 +20,7 @@ const ContrastThemeProvider: FunctionComponent<{ enable?: boolean }> = ({ enable
 );
 
 const Contrast: FunctionComponent<PropsType> = (props): JSX.Element => (
-    <StyledContrast>
+    <StyledContrast className={props.className}>
         <ContrastThemeProvider enable={props.enable !== false}>{props.children}</ContrastThemeProvider>
     </StyledContrast>
 );


### PR DESCRIPTION
### This PR:

Adds a `PreviewPane` components to the Design System site. This component can be used with `options` and `examples` props to show examples of usages of components.

**Backwards compatible additions** ✨
- `PreviewPane` component for the DS site.

**Bugfixes/Changed internals** 🎈
- `Contrast` now passes `className` to allow custom styling

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
