### PR TITLE
Design System: Automatically link to first article in a category

### DIFF
--- a/packages/components/docs/containers/Header.tsx
+++ b/packages/components/docs/containers/Header.tsx
@@ -6,14 +6,27 @@ import styled from 'styled-components';
 
 type ArticleDataType = {
     srcDirs: Array<string>;
-    articles: {
+    articles: Array<{
         dir: string;
         files: Array<string>;
-    };
+    }>;
 };
 
 //tslint:disable-next-line
 const articleData: ArticleDataType = require('../lib/get-article-data');
+
+const getHref = (category: string) => {
+    // Find the first article in this category and link to it
+    const firstArticle = articleData.articles.find(article => article.dir === category)?.files[0];
+    const firstArticleSlug = firstArticle ? firstArticle.replace(/\.mdx?$/, '') : '';
+
+    return `/generated/${category}/${firstArticleSlug}`;
+};
+
+const getTitle = (category: string) => {
+    // Format the link title
+    return `${category.charAt(0).toUpperCase() + category.slice(1)}`;
+};
 
 const StyledHeader = styled.div`
     display: flex;
@@ -46,8 +59,8 @@ const Header: FC = props => {
                 <HeadingLinkContainer>
                     {articleData.srcDirs.map((category, index) => (
                         <HeadingLink
-                            href={`/generated/${category}`}
-                            title={`${category.charAt(0).toUpperCase() + category.slice(1)}`}
+                            href={`${getHref(category)}`}
+                            title={`${getTitle(category)}`}
                             category={category}
                             key={index}
                         />


### PR DESCRIPTION
### This PR:

Makes the header navigation link to a category link to the first article in that category instead of to a generic index page.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
