### PR TITLE
feat: implement 3.0 FormRow design 

### DIFF
--- a/packages/components/src/components/FormRow/index.tsx
+++ b/packages/components/src/components/FormRow/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, FunctionComponent } from 'react';
 import Box from '../Box';
-import trbl from '../../utility/trbl';
+import Measure from 'react-measure';
 import { StyledFormRow, StyledDisabledText } from './style';
 
 type PropsType = {
@@ -13,26 +13,39 @@ type PropsType = {
 
 const FormRow: FunctionComponent<PropsType> = (props): JSX.Element => {
     return (
-        <StyledFormRow>
-            <Box basis={'180px'} direction="row" grow={1} maxWidth="241px" margin={trbl(18, 9, 0, 0)} wrap>
-                <Box grow={1} wrap={false}>
-                    <Box direction={props.description ? 'column' : 'row'} grow={props.badge ? 0 : 1}>
-                        <StyledDisabledText disabled={props.disabled} strong>
-                            {props.label}
-                        </StyledDisabledText>
-                        {props.description && (
-                            <StyledDisabledText disabled={props.disabled} variant="descriptive">
-                                {props.description}
-                            </StyledDisabledText>
-                        )}
-                    </Box>
-                    <Box margin={[-9, 3]}>{props.badge !== undefined && props.badge}</Box>
-                </Box>
-            </Box>
-            <Box basis={'180px'} grow={1} maxWidth="470px" margin={trbl(9, 0)} alignItems="flex-start" wrap>
-                {props.field}
-            </Box>
-        </StyledFormRow>
+        <Measure client>
+            {({ measureRef, contentRect }) => {
+                return (
+                    <StyledFormRow ref={measureRef}>
+                        <Box basis={'180px'} direction="row" grow={1} maxWidth="241px" margin={[24, 9, 0, 0]} wrap>
+                            <Box grow={1} wrap={false}>
+                                <Box direction={props.description ? 'column' : 'row'} grow={props.badge ? 0 : 1}>
+                                    <StyledDisabledText disabled={props.disabled} strong>
+                                        {props.label}
+                                    </StyledDisabledText>
+                                    {props.description && (
+                                        <StyledDisabledText disabled={props.disabled} variant="descriptive">
+                                            {props.description}
+                                        </StyledDisabledText>
+                                    )}
+                                </Box>
+                                <Box margin={[-9, 3]}>{props.badge !== undefined && props.badge}</Box>
+                            </Box>
+                        </Box>
+                        <Box
+                            basis={'180px'}
+                            grow={1}
+                            maxWidth="470px"
+                            margin={[contentRect.client && contentRect.client.width < 369 ? 6 : 15, 0]}
+                            alignItems="flex-start"
+                            wrap
+                        >
+                            {props.field}
+                        </Box>
+                    </StyledFormRow>
+                );
+            }}
+        </Measure>
     );
 };
 

--- a/packages/components/src/components/FormRow/index.tsx
+++ b/packages/components/src/components/FormRow/index.tsx
@@ -1,12 +1,14 @@
 import React, { ReactNode, FunctionComponent } from 'react';
 import Box from '../Box';
 import trbl from '../../utility/trbl';
-import { StyledFormRow } from './style';
+import { StyledFormRow, StyledDisabledText } from './style';
 
 type PropsType = {
     label: ReactNode;
-    badge?: ReactNode;
     field: ReactNode;
+    description?: ReactNode;
+    badge?: ReactNode;
+    disabled?: boolean;
 };
 
 const FormRow: FunctionComponent<PropsType> = (props): JSX.Element => {
@@ -14,7 +16,16 @@ const FormRow: FunctionComponent<PropsType> = (props): JSX.Element => {
         <StyledFormRow>
             <Box basis={'180px'} direction="row" grow={1} maxWidth="241px" margin={trbl(18, 9, 0, 0)} wrap>
                 <Box grow={1} wrap={false}>
-                    <Box grow={props.badge ? 0 : 1}>{props.label}</Box>
+                    <Box direction={props.description ? 'column' : 'row'} grow={props.badge ? 0 : 1}>
+                        <StyledDisabledText disabled={props.disabled} strong>
+                            {props.label}
+                        </StyledDisabledText>
+                        {props.description && (
+                            <StyledDisabledText disabled={props.disabled} variant="descriptive">
+                                {props.description}
+                            </StyledDisabledText>
+                        )}
+                    </Box>
                     <Box margin={[-9, 3]}>{props.badge !== undefined && props.badge}</Box>
                 </Box>
             </Box>

--- a/packages/components/src/components/FormRow/story.tsx
+++ b/packages/components/src/components/FormRow/story.tsx
@@ -57,36 +57,14 @@ class DemoComponent extends Component<PropsType, StateType> {
                         label={<label>What is your name?</label>}
                         disabled={disabled}
                         description={`Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
-                            similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
-                            corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.`}
+                            similique sint quae exercitationem molestiae aspernatur cum. `}
                         field={
                             <Box wrap width="100%">
-                                <Box>
-                                    <Box margin={trbl(0, 9, 18, 0)} justifyContent="stretch" grow={1} width="40%">
-                                        <TextField
-                                            prefix="Initials"
-                                            name="Initials"
-                                            value={this.state.initials}
-                                            onChange={(initials: string): void => this.setState({ initials })}
-                                        />
-                                    </Box>
-                                    <Box margin={trbl(0, 9, 18, 0)} justifyContent="stretch" grow={1} width="60%">
-                                        <TextField
-                                            prefix="First name"
-                                            name="First name"
-                                            value={this.state.firstname}
-                                            onChange={(firstname: string): void => this.setState({ firstname })}
-                                        />
-                                    </Box>
-                                </Box>
-                                <Box margin={trbl(0, 9, 18, 0)} justifyContent="stretch" grow={1}>
-                                    <TextField
-                                        prefix="Surname"
-                                        name="Surname"
-                                        value={this.state.surname}
-                                        onChange={(surname: string): void => this.setState({ surname })}
-                                    />
-                                </Box>
+                                <TextField
+                                    name="Initials"
+                                    value={this.state.initials}
+                                    onChange={(initials: string): void => this.setState({ initials })}
+                                />
                             </Box>
                         }
                     />
@@ -94,26 +72,14 @@ class DemoComponent extends Component<PropsType, StateType> {
                         label={<label>Where do you live?</label>}
                         disabled={disabled}
                         description={`Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
-                            similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
-                            corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.`}
+                            similique sint quae exercitationem molestiae aspernatur cum. `}
                         field={
                             <Box wrap width="100%">
-                                <Box margin={trbl(0, 9, 18, 0)} justifyContent="stretch" grow={1}>
-                                    <TextField
-                                        name="Country"
-                                        prefix="Country"
-                                        value={this.state.country}
-                                        onChange={(country: string): void => this.setState({ country })}
-                                    />
-                                </Box>
-                                <Box margin={trbl(0, 9, 18, 0)} justifyContent="stretch" grow={1}>
-                                    <TextField
-                                        name="City"
-                                        prefix="City"
-                                        value={this.state.city}
-                                        onChange={(city: string): void => this.setState({ city })}
-                                    />
-                                </Box>
+                                <TextField
+                                    name="Country"
+                                    value={this.state.country}
+                                    onChange={(country: string): void => this.setState({ country })}
+                                />
                             </Box>
                         }
                     />
@@ -159,8 +125,7 @@ class DemoComponent extends Component<PropsType, StateType> {
                         label={'Options'}
                         disabled={disabled}
                         description={`Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
-                            similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
-                            corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.`}
+                            similique sint quae exercitationem molestiae aspernatur cum. `}
                         field={
                             <Separated before after>
                                 <Checkbox
@@ -295,7 +260,7 @@ storiesOf('FormRow', module)
     .add('No Descriptions', () => <DemoComponent descriptions={false} />)
     .add('With badge', () => (
         <FormRow
-            label={<Text>{text('label', 'Label text')}</Text>}
+            label={text('label', 'Label text')}
             badge={
                 <Text size="small" variant="success">
                     {text('badge', 'PRO')}

--- a/packages/components/src/components/FormRow/story.tsx
+++ b/packages/components/src/components/FormRow/story.tsx
@@ -275,7 +275,11 @@ storiesOf('FormRow', module)
     ))
     .add('With Skeletons', () => (
         <FormRow
-            label={<Skeleton.Text lines={1} baseWidth={180} />}
+            label={
+                <Box width="100%" inline margin={[0, 12, 0, 0]}>
+                    <Skeleton.Text lines={1} baseWidth={180} />
+                </Box>
+            }
             // 38px is the height of an TextField field
             field={<Skeleton.Rect width="100%" height="38px" />}
         />

--- a/packages/components/src/components/FormRow/story.tsx
+++ b/packages/components/src/components/FormRow/story.tsx
@@ -9,7 +9,7 @@ import TextField from '../TextField';
 import Toggle from '../Toggle';
 import trbl from '../../utility/trbl';
 import Separated from '../Separated';
-import { text } from '@storybook/addon-knobs';
+import { text, boolean } from '@storybook/addon-knobs';
 import { Skeleton } from '../..';
 
 type PropsType = {
@@ -48,22 +48,17 @@ class DemoComponent extends Component<PropsType, StateType> {
     }
 
     public render(): JSX.Element {
+        const disabled = boolean('disabled', false);
+
         if (this.props.descriptions) {
             return (
                 <form>
                     <FormRow
-                        label={
-                            <label>
-                                <Box>
-                                    <Text>What is your name?</Text>
-                                </Box>
-                                <Text variant="descriptive">
-                                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
-                                    similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
-                                    corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
-                                </Text>
-                            </label>
-                        }
+                        label={<label>What is your name?</label>}
+                        disabled={disabled}
+                        description={`Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
+                            similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
+                            corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.`}
                         field={
                             <Box wrap width="100%">
                                 <Box>
@@ -96,18 +91,11 @@ class DemoComponent extends Component<PropsType, StateType> {
                         }
                     />
                     <FormRow
-                        label={
-                            <label>
-                                <Box>
-                                    <Text>Where do you live?</Text>
-                                </Box>
-                                <Text variant="descriptive">
-                                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
-                                    similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
-                                    corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
-                                </Text>
-                            </label>
-                        }
+                        label={<label>Where do you live?</label>}
+                        disabled={disabled}
+                        description={`Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
+                            similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
+                            corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.`}
                         field={
                             <Box wrap width="100%">
                                 <Box margin={trbl(0, 9, 18, 0)} justifyContent="stretch" grow={1}>
@@ -130,18 +118,11 @@ class DemoComponent extends Component<PropsType, StateType> {
                         }
                     />
                     <FormRow
-                        label={
-                            <label>
-                                <Box>
-                                    <Text>Can a boolean only be either true or false?</Text>
-                                </Box>
-                                <Text variant="descriptive">
-                                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
-                                    similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
-                                    corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
-                                </Text>
-                            </label>
-                        }
+                        label={<label>Can a boolean only be either true or false?</label>}
+                        disabled={disabled}
+                        description={`Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
+                            similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
+                            corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.`}
                         field={
                             <Separated before after>
                                 <RadioButton
@@ -175,16 +156,11 @@ class DemoComponent extends Component<PropsType, StateType> {
                         }
                     />
                     <FormRow
-                        label={
-                            <>
-                                <Text>Options</Text>
-                                <Text variant="descriptive">
-                                    Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
-                                    similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
-                                    corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.
-                                </Text>
-                            </>
-                        }
+                        label={'Options'}
+                        disabled={disabled}
+                        description={`Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
+                            similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
+                            corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.`}
                         field={
                             <Separated before after>
                                 <Checkbox
@@ -210,11 +186,8 @@ class DemoComponent extends Component<PropsType, StateType> {
             return (
                 <form>
                     <FormRow
-                        label={
-                            <label>
-                                <Text>What is your name?</Text>
-                            </label>
-                        }
+                        label={<label>What is your name?</label>}
+                        disabled={disabled}
                         field={
                             <Box wrap width="100%">
                                 <Box margin={trbl(0, 9, 0, 0)} width="100%" justifyContent="stretch" grow={1}>
@@ -229,11 +202,8 @@ class DemoComponent extends Component<PropsType, StateType> {
                         }
                     />
                     <FormRow
-                        label={
-                            <label>
-                                <Text>Where do you live?</Text>
-                            </label>
-                        }
+                        label={<label>Where do you live?</label>}
+                        disabled={disabled}
                         field={
                             <Box wrap width="100%">
                                 <Box margin={trbl(0, 9, 0, 0)} width="100%" justifyContent="stretch" grow={1}>
@@ -248,11 +218,8 @@ class DemoComponent extends Component<PropsType, StateType> {
                         }
                     />
                     <FormRow
-                        label={
-                            <label>
-                                <Text>Can a boolean only be true or false?</Text>
-                            </label>
-                        }
+                        label={<label>Can a boolean only be true or false?</label>}
+                        disabled={disabled}
                         field={
                             <Separated before after>
                                 <RadioButton
@@ -286,11 +253,8 @@ class DemoComponent extends Component<PropsType, StateType> {
                         }
                     />
                     <FormRow
-                        label={
-                            <label>
-                                <Text>Do you like toggles?</Text>
-                            </label>
-                        }
+                        label={<label>Do you like toggles?</label>}
+                        disabled={disabled}
                         field={
                             <Toggle
                                 name="toggle"
@@ -303,11 +267,8 @@ class DemoComponent extends Component<PropsType, StateType> {
                         }
                     />
                     <FormRow
-                        label={
-                            <label>
-                                <Text>Do you like checkboxes</Text>
-                            </label>
-                        }
+                        label={<label>Do you like checkboxes</label>}
+                        disabled={disabled}
                         field={
                             <Separated before after>
                                 <Checkbox

--- a/packages/components/src/components/FormRow/style.tsx
+++ b/packages/components/src/components/FormRow/style.tsx
@@ -13,6 +13,7 @@ type StyledDisabledTextType = TextPropsType & {
 };
 
 const StyledDisabledText = styled(Text)<StyledDisabledTextType>`
+    width: 100%;
     ${({ theme, disabled }): string => (disabled ? `color: ${theme.FormRow.disabled.color}` : '')}
 `;
 

--- a/packages/components/src/components/FormRow/style.tsx
+++ b/packages/components/src/components/FormRow/style.tsx
@@ -1,4 +1,20 @@
 import styled from '../../utility/styled';
+import Text, { PropsType as TextPropsType } from '../Text';
+import ThemeTools from '../../themes/CustomTheme/ThemeTools';
+
+type FormRowThemeType = {
+    disabled: {
+        color: string;
+    };
+};
+
+type StyledDisabledTextType = TextPropsType & {
+    disabled?: boolean;
+};
+
+const StyledDisabledText = styled(Text)<StyledDisabledTextType>`
+    ${({ theme, disabled }): string => (disabled ? `color: ${theme.FormRow.disabled.color}` : '')}
+`;
 
 const StyledFormRow = styled.div`
     display: flex;
@@ -6,4 +22,14 @@ const StyledFormRow = styled.div`
     flex-grow: 1;
 `;
 
-export { StyledFormRow };
+const composeFormRowTheme = (themeTools: ThemeTools): FormRowThemeType => {
+    const { colors } = themeTools.themeSettings;
+
+    return {
+        disabled: {
+            color: colors.silver.darker1,
+        },
+    };
+};
+
+export { StyledFormRow, StyledDisabledText, FormRowThemeType, composeFormRowTheme };

--- a/packages/components/src/themes/CustomTheme/genTheme.ts
+++ b/packages/components/src/themes/CustomTheme/genTheme.ts
@@ -35,6 +35,7 @@ import { composeScrollBoxTheme } from '../../components/ScrollBox/style';
 import { composeIllustrationTheme } from '../../components/Illustration/style';
 import { composeTextualButton } from '../../components/TextualButton';
 import { composeProgressTheme } from '../../components/Progress/style';
+import { composeFormRowTheme } from '../../components/FormRow/style';
 
 const generateThemeObject = (
     providedOptions: ThemeTypes.ProvidedThemeOptionsType,
@@ -77,6 +78,7 @@ const generateThemeObject = (
         Button: composeButtonTheme(themeTools),
         Checkbox: composeCheckboxTheme(themeTools),
         Contrast: composeContrastTheme(themeTools),
+        FormRow: composeFormRowTheme(themeTools),
         Heading: composeHeadingTheme(themeTools),
         IconButton: composeIconButtonTheme(themeTools),
         Illustration: composeIllustrationTheme(),

--- a/packages/components/src/themes/MosTheme/MosTheme.theme.ts
+++ b/packages/components/src/themes/MosTheme/MosTheme.theme.ts
@@ -255,6 +255,11 @@ const theme: ThemeType = {
             },
         },
     },
+    FormRow: {
+        disabled: {
+            color: colors.grey400,
+        },
+    },
     Heading: {
         1: {
             fontFamily: headingFont,

--- a/packages/components/src/types/OffsetType/index.ts
+++ b/packages/components/src/types/OffsetType/index.ts
@@ -4,6 +4,7 @@ export type OffsetType =
     | 6
     | 9
     | 12
+    | 15
     | 18
     | 24
     | 30
@@ -14,6 +15,7 @@ export type OffsetType =
     | -6
     | -9
     | -12
+    | -15
     | -18
     | -24
     | -30

--- a/packages/components/src/types/ThemeType/index.ts
+++ b/packages/components/src/types/ThemeType/index.ts
@@ -3,6 +3,7 @@ import { BreadcrumbsThemeType } from '../../components/Breadcrumbs/style';
 import { ButtonThemeType } from '../../components/Button';
 import { CheckboxThemeType } from '../../components/Checkbox/style';
 import { ContrastThemeType } from '../../components/Contrast/style';
+import { FormRowThemeType } from '../../components/FormRow/style';
 import { HeadingThemeType } from '../../components/Heading';
 import { IconButtonThemeType } from '../../components/IconButton';
 import { IllustrationThemeType } from '../../components/Illustration/style';
@@ -37,6 +38,7 @@ type ThemeType = {
     Button: ButtonThemeType;
     Checkbox: CheckboxThemeType;
     Contrast: ContrastThemeType;
+    FormRow: FormRowThemeType;
     Heading: HeadingThemeType;
     IconButton: IconButtonThemeType;
     Illustration: IllustrationThemeType;


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- FormRow is now part of the ThemeType to decide it's disabled styling.

**Backwards compatible additions** ✨
- `disabled` prop added to `FormRow`

**Bugfixes/Changed internals** 🎈
- Added a styled component to the `FormRow` that renders a disabled variant of the text.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
