### PR TITLE
fix: Toggle margin

### DIFF
--- a/packages/components/src/components/Toggle/index.tsx
+++ b/packages/components/src/components/Toggle/index.tsx
@@ -44,7 +44,7 @@ class Toggle extends Component<PropsType, StateType> {
     public render(): JSX.Element {
         return (
             <Box onClick={this.handleChange}>
-                <Box margin={trbl(12, 12, 0, 0)}>
+                <Box margin={trbl(15, 12, 0, 0)}>
                     <StyledToggleSkin
                         elementFocus={this.state.focus}
                         disabled={this.props.disabled}
@@ -65,7 +65,7 @@ class Toggle extends Component<PropsType, StateType> {
                         />
                     </StyledToggleSkin>
                 </Box>
-                <Box margin={trbl(6, 0, 0, 0)}>
+                <Box margin={trbl(9, 0, 0, 0)}>
                     <Text variant={this.props.disabled || this.props.unavailable ? 'info' : undefined}>
                         {this.props.label}
                     </Text>


### PR DESCRIPTION
### This PR:

The new Toggles did not align properly in the FormRows because they're smaller. With this adjustment everything looks great again 😎 .

**Bugfixes/Changed internals** 🎈
- Toggle margin

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
