### PR TITLE
fix: Bricks 3.0 - Styling Improvements

### DIFF
--- a/packages/components/src/components/Button/index.tsx
+++ b/packages/components/src/components/Button/index.tsx
@@ -75,7 +75,7 @@ type PropsType = BasePropsType & {
 };
 
 const StyledButton = styled(Base)<PropsType>`
-    ${({ theme, variant, compact, disabled, loading }): string => {
+    ${({ theme, variant, disabled, loading }): string => {
         const idle = `
             background-color: ${theme.Button[variant].idle.backgroundColor};
             box-shadow: ${theme.Button[variant].idle.boxShadow};
@@ -103,7 +103,6 @@ const StyledButton = styled(Base)<PropsType>`
 
         return `
             ${idle}
-            padding: 6px ${compact ? ' 12px' : '24px'};
             border-radius: ${theme.Button.common.borderRadius};
             ${variant === 'plain' ? `border: ${theme.Button.plain.idle.border};` : ''}
 
@@ -158,9 +157,11 @@ const StyledButton = styled(Base)<PropsType>`
         `;
     }};
 
-    ${({ theme, variant }): string => {
+    ${({ theme, variant, compact }): string => {
         if (variant === 'plain') {
             return `
+                padding: 5px ${compact ? '11px' : '23px'};
+
                 &::before {
                     color: ${theme.Button.disabled.plain.color};
                     background: ${theme.Button.disabled.plain.backgroundColor};
@@ -175,6 +176,8 @@ const StyledButton = styled(Base)<PropsType>`
 
         if (variant === 'secondary') {
             return `
+                padding: 6px ${compact ? ' 12px' : '24px'};
+
                 &::before {
                     color: ${theme.Button.disabled.secondary.color};
                     background: ${theme.Button.disabled.secondary.backgroundColor};
@@ -188,6 +191,8 @@ const StyledButton = styled(Base)<PropsType>`
         }
 
         return `
+            padding: 6px ${compact ? ' 12px' : '24px'};
+
             &::before {
                 color: ${theme.Button.disabled.primary.color};
                 background: ${theme.Button.disabled.primary.backgroundColor};

--- a/packages/components/src/components/Button/index.tsx
+++ b/packages/components/src/components/Button/index.tsx
@@ -113,6 +113,17 @@ const StyledButton = styled(Base)<PropsType>`
 
             &:focus {
                 ${!loading && !disabled ? focus : idle}
+
+                &:hover {
+                    ${
+                        !loading && !disabled
+                            ? `
+                            background-color: ${theme.Button[variant].hover.backgroundColor};
+                            color: ${theme.Button[variant].hover.color};
+                    `
+                            : ''
+                    }
+                }
             }
 
             &:active {

--- a/packages/components/src/components/Checkbox/index.tsx
+++ b/packages/components/src/components/Checkbox/index.tsx
@@ -46,8 +46,8 @@ class Checkbox extends Component<PropsType, StateType> {
         const htmlChecked = this.props.checked === true;
 
         return (
-            <Box onClick={this.changeHandler} data-testid={this.props['data-testid']}>
-                <Box shrink={0}>
+            <Box onClick={this.changeHandler} data-testid={this.props['data-testid']} alignItems="center">
+                <Box margin={[0, 12, 0, 0]}>
                     <StyledCheckboxSkin
                         checkedState={this.props.checked}
                         elementFocus={this.state.focus}
@@ -74,13 +74,12 @@ class Checkbox extends Component<PropsType, StateType> {
                         />
                     </StyledCheckboxSkin>
                 </Box>
-                {this.props.label !== undefined && (
-                    <Box margin={[-3, 0, 0, 12]}>
-                        <Text>
-                            <label htmlFor={this.props.name}>{this.props.label}</label>
-                        </Text>
-                    </Box>
-                )}
+                <Box inline direction="row" align-items="center">
+                    <Text>
+                        {/* force a line-height if there is no label for proper vertical alignment */}
+                        <label htmlFor={this.props.name}>{this.props.label ? this.props.label : '\u00A0'}</label>
+                    </Text>
+                </Box>
             </Box>
         );
     }

--- a/packages/components/src/components/FormRow/index.tsx
+++ b/packages/components/src/components/FormRow/index.tsx
@@ -17,7 +17,7 @@ const FormRow: FunctionComponent<PropsType> = (props): JSX.Element => {
             {({ measureRef, contentRect }) => {
                 return (
                     <StyledFormRow ref={measureRef}>
-                        <Box basis={'180px'} direction="row" grow={1} maxWidth="241px" margin={[24, 9, 0, 0]} wrap>
+                        <Box basis={'180px'} direction="row" grow={1} maxWidth="241px" margin={[21, 9, 0, 0]} wrap>
                             <Box grow={1} wrap={false}>
                                 <Box direction={props.description ? 'column' : 'row'} grow={props.badge ? 0 : 1}>
                                     <StyledDisabledText disabled={props.disabled} strong>

--- a/packages/components/src/components/FormRow/story.tsx
+++ b/packages/components/src/components/FormRow/story.tsx
@@ -7,10 +7,10 @@ import Text from '../Text';
 import Box from '../Box';
 import TextField from '../TextField';
 import Toggle from '../Toggle';
-import trbl from '../../utility/trbl';
 import Separated from '../Separated';
 import { text, boolean } from '@storybook/addon-knobs';
 import { Skeleton } from '../..';
+import TextArea from '../TextArea';
 
 type PropsType = {
     descriptions: boolean;
@@ -18,15 +18,12 @@ type PropsType = {
 
 type StateType = {
     selected: string;
-    initials: string;
-    firstname: string;
-    surname: string;
-    city: string;
-    country: string;
-    toggled: boolean;
+    name: string;
+    story: string;
     cheese: boolean;
     checked: boolean;
     bacon: boolean;
+    supersize: boolean;
 };
 
 class DemoComponent extends Component<PropsType, StateType> {
@@ -35,223 +32,139 @@ class DemoComponent extends Component<PropsType, StateType> {
 
         this.state = {
             selected: '1',
-            initials: '',
-            firstname: '',
-            surname: '',
-            city: '',
-            country: '',
-            toggled: false,
+            name: '',
+            story: '',
             bacon: false,
             cheese: true,
             checked: false,
+            supersize: false,
         };
     }
 
     public render(): JSX.Element {
         const disabled = boolean('disabled', false);
+        const description = this.props.descriptions
+            ? `Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
+        similique sint quae exercitationem molestiae aspernatur cum.`
+            : '';
 
-        if (this.props.descriptions) {
-            return (
-                <form>
-                    <FormRow
-                        label={<label>What is your name?</label>}
-                        disabled={disabled}
-                        description={`Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
-                            similique sint quae exercitationem molestiae aspernatur cum. `}
-                        field={
-                            <Box wrap width="100%">
-                                <TextField
-                                    name="Initials"
-                                    value={this.state.initials}
-                                    onChange={(initials: string): void => this.setState({ initials })}
-                                />
-                            </Box>
-                        }
-                    />
-                    <FormRow
-                        label={<label>Where do you live?</label>}
-                        disabled={disabled}
-                        description={`Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
-                            similique sint quae exercitationem molestiae aspernatur cum. `}
-                        field={
-                            <Box wrap width="100%">
-                                <TextField
-                                    name="Country"
-                                    value={this.state.country}
-                                    onChange={(country: string): void => this.setState({ country })}
-                                />
-                            </Box>
-                        }
-                    />
-                    <FormRow
-                        label={<label>Can a boolean only be either true or false?</label>}
-                        disabled={disabled}
-                        description={`Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
-                            similique sint quae exercitationem molestiae aspernatur cum. Necessitatibus,
-                            corrupti veritatis. Placeat, tempora! Vitae rem, nobis rerum natus odit debitis.`}
-                        field={
-                            <Separated before after>
-                                <RadioButton
-                                    name="bool"
-                                    label="True"
-                                    value="1"
-                                    checked={this.state.selected === '1'}
-                                    onChange={({ value }): void => {
-                                        this.setState({ selected: value });
-                                    }}
-                                />
-                                <RadioButton
-                                    name="bool"
-                                    label="False"
-                                    value="2"
-                                    checked={this.state.selected === '2'}
-                                    onChange={({ value }): void => {
-                                        this.setState({ selected: value });
-                                    }}
-                                />
-                                <RadioButton
-                                    name="bool"
-                                    label="Sometimes"
-                                    value="3"
-                                    checked={this.state.selected === '3'}
-                                    onChange={({ value }): void => {
-                                        this.setState({ selected: value });
-                                    }}
-                                />
-                            </Separated>
-                        }
-                    />
-                    <FormRow
-                        label={'Options'}
-                        disabled={disabled}
-                        description={`Lorem ipsum dolor sit amet consectetur adipisicing elit. Deleniti non quasi
-                            similique sint quae exercitationem molestiae aspernatur cum. `}
-                        field={
-                            <Separated before after>
-                                <Checkbox
-                                    name="cheese"
-                                    value="cheese"
-                                    label="Extra cheese"
-                                    checked={this.state.cheese}
-                                    onChange={({ checked }): void => this.setState({ cheese: checked as boolean })}
-                                />
-                                <Checkbox
-                                    name="bacon"
-                                    value="bacon"
-                                    label="Extra bacon"
-                                    checked={this.state.bacon}
-                                    onChange={({ checked }): void => this.setState({ bacon: checked as boolean })}
-                                />
-                            </Separated>
-                        }
-                    />
-                </form>
-            );
-        } else {
-            return (
-                <form>
-                    <FormRow
-                        label={<label>What is your name?</label>}
-                        disabled={disabled}
-                        field={
-                            <Box wrap width="100%">
-                                <Box margin={trbl(0, 9, 0, 0)} width="100%" justifyContent="stretch" grow={1}>
-                                    <TextField
-                                        prefix="Name"
-                                        name="Name"
-                                        value={this.state.firstname}
-                                        onChange={(firstname: string): void => this.setState({ firstname })}
-                                    />
-                                </Box>
-                            </Box>
-                        }
-                    />
-                    <FormRow
-                        label={<label>Where do you live?</label>}
-                        disabled={disabled}
-                        field={
-                            <Box wrap width="100%">
-                                <Box margin={trbl(0, 9, 0, 0)} width="100%" justifyContent="stretch" grow={1}>
-                                    <TextField
-                                        name="Country"
-                                        prefix="Country"
-                                        value={this.state.country}
-                                        onChange={(country: string): void => this.setState({ country })}
-                                    />
-                                </Box>
-                            </Box>
-                        }
-                    />
-                    <FormRow
-                        label={<label>Can a boolean only be true or false?</label>}
-                        disabled={disabled}
-                        field={
-                            <Separated before after>
-                                <RadioButton
-                                    name="bool"
-                                    label="True"
-                                    value="1"
-                                    checked={this.state.selected === '1'}
-                                    onChange={({ value }): void => {
-                                        this.setState({ selected: value });
-                                    }}
-                                />
-                                <RadioButton
-                                    name="bool"
-                                    label="False"
-                                    value="2"
-                                    checked={this.state.selected === '2'}
-                                    onChange={({ value }): void => {
-                                        this.setState({ selected: value });
-                                    }}
-                                />
-                                <RadioButton
-                                    name="bool"
-                                    label="Sometimes"
-                                    value="3"
-                                    checked={this.state.selected === '3'}
-                                    onChange={({ value }): void => {
-                                        this.setState({ selected: value });
-                                    }}
-                                />
-                            </Separated>
-                        }
-                    />
-                    <FormRow
-                        label={<label>Do you like toggles?</label>}
-                        disabled={disabled}
-                        field={
-                            <Toggle
-                                name="toggle"
-                                value="toggle"
-                                id="toggle"
-                                label={'Toggle to indicate your preference!'}
-                                checked={this.state.toggled}
-                                onChange={({ checked }): void => this.setState({ toggled: checked })}
+        return (
+            <form>
+                <FormRow
+                    label={<label>What is your name?</label>}
+                    disabled={disabled}
+                    description={description}
+                    field={
+                        <Box wrap width="100%">
+                            <TextField
+                                name="name"
+                                value={this.state.name}
+                                onChange={(name: string): void => this.setState({ name })}
+                                disabled={disabled}
+                                placeholder="E.g. John Doe"
                             />
-                        }
-                    />
-                    <FormRow
-                        label={<label>Do you like checkboxes</label>}
-                        disabled={disabled}
-                        field={
-                            <Separated before after>
-                                <Checkbox
-                                    onChange={(): void =>
-                                        this.setState({
-                                            checked: !this.state.checked,
-                                        })
-                                    }
-                                    value="bar"
-                                    checked={this.state.checked}
-                                    name="foo"
-                                />
-                            </Separated>
-                        }
-                    />
-                </form>
-            );
-        }
+                        </Box>
+                    }
+                />
+                <FormRow
+                    label={<label>What is your story?</label>}
+                    disabled={disabled}
+                    description={description}
+                    field={
+                        <Box wrap width="100%">
+                            <TextArea
+                                name="story"
+                                value={this.state.story}
+                                onChange={(story: string): void => this.setState({ story })}
+                                disabled={disabled}
+                                placeholder="Like how did you get here?"
+                            />
+                        </Box>
+                    }
+                />
+                <FormRow
+                    label={<label>Can a boolean only be either true or false?</label>}
+                    disabled={disabled}
+                    description={description}
+                    field={
+                        <Separated before after>
+                            <RadioButton
+                                name="bool"
+                                label="True"
+                                value="1"
+                                checked={this.state.selected === '1'}
+                                onChange={({ value }): void => {
+                                    this.setState({ selected: value });
+                                }}
+                                disabled={disabled}
+                            />
+                            <RadioButton
+                                name="bool"
+                                label="False"
+                                value="2"
+                                checked={this.state.selected === '2'}
+                                onChange={({ value }): void => {
+                                    this.setState({ selected: value });
+                                }}
+                                disabled={disabled}
+                            />
+                            <RadioButton
+                                name="bool"
+                                label="Sometimes"
+                                value="3"
+                                checked={this.state.selected === '3'}
+                                onChange={({ value }): void => {
+                                    this.setState({ selected: value });
+                                }}
+                                disabled={disabled}
+                            />
+                        </Separated>
+                    }
+                />
+                <FormRow
+                    label={<label>What else would you like?</label>}
+                    disabled={disabled}
+                    description={description}
+                    field={
+                        <Separated before after>
+                            <Checkbox
+                                name="cheese"
+                                value="cheese"
+                                label="Extra cheese"
+                                checked={this.state.cheese}
+                                onChange={() => this.setState({ cheese: !this.state.cheese })}
+                                disabled={disabled}
+                            />
+                            <Checkbox
+                                name="bacon"
+                                value="bacon"
+                                label="Extra bacon"
+                                checked={this.state.bacon}
+                                onChange={() => this.setState({ bacon: !this.state.bacon })}
+                                disabled={disabled}
+                            />
+                        </Separated>
+                    }
+                />
+                <FormRow
+                    label={<label>Supersized?</label>}
+                    disabled={disabled}
+                    description={description}
+                    field={
+                        <Separated before after>
+                            <Toggle
+                                name="supersize"
+                                value="supersize"
+                                label="Yes, supersize me!"
+                                checked={this.state.supersize}
+                                onChange={() => this.setState({ supersize: !this.state.supersize })}
+                                disabled={disabled}
+                            />
+                        </Separated>
+                    }
+                />
+            </form>
+        );
     }
 }
 
@@ -267,9 +180,9 @@ storiesOf('FormRow', module)
                 </Text>
             }
             field={
-                <Box direction="row" alignItems="center">
+                <Separated before after>
                     <Toggle checked={true} name="storyToggle" value={'true'} onChange={(): string => 'void'} />
-                </Box>
+                </Separated>
             }
         />
     ))

--- a/packages/components/src/components/Separated/index.tsx
+++ b/packages/components/src/components/Separated/index.tsx
@@ -11,12 +11,14 @@ type PropsType = {
 const calculateMargin = (count: number, index: number, before?: boolean, after?: boolean): TrblType => {
     const isFirst = index === 0;
     const isLast = index === count - 1;
-    const margin = 12;
+    const isSingle = count === 1;
+    const margin = 6;
 
-    if (isFirst) return trbl(before ? margin : 0, 0, isLast && after ? margin : 0, 0);
-    if (isLast && after) return trbl(margin, 0, margin, 0);
+    if (isSingle) return trbl(before ? margin : 0, 0, after ? margin : 0, 0);
+    if (isFirst) return trbl(before ? margin : 0, 0, margin, 0);
+    if (isLast) return trbl(0, 0, after ? margin : 0, 0);
 
-    return trbl(margin, 0, 0, 0);
+    return trbl(0, 0, margin, 0);
 };
 
 const Separated: FunctionComponent<PropsType> = ({ children, before, after }): JSX.Element => {

--- a/packages/components/src/components/Separated/test.tsx
+++ b/packages/components/src/components/Separated/test.tsx
@@ -13,7 +13,7 @@ describe('Separated', () => {
             </Seperated>,
         );
 
-        expect(component.find('[data-test="A"]').parent()).toHaveStyleRule('margin-top', '12px');
+        expect(component.find('[data-test="A"]').parent()).toHaveStyleRule('margin-top', '6px');
     });
 
     it('should add seperation to the last item when after is set', () => {
@@ -25,7 +25,7 @@ describe('Separated', () => {
             </Seperated>,
         );
 
-        expect(component.find('[data-test="C"]').parent()).toHaveStyleRule('margin-bottom', '12px');
+        expect(component.find('[data-test="C"]').parent()).toHaveStyleRule('margin-bottom', '6px');
     });
 
     it('should add seperation to the first/last item when after is set', () => {
@@ -35,6 +35,6 @@ describe('Separated', () => {
             </Seperated>,
         );
 
-        expect(component.find('[data-test="A"]').parent()).toHaveStyleRule('margin-bottom', '12px');
+        expect(component.find('[data-test="A"]').parent()).toHaveStyleRule('margin-bottom', '6px');
     });
 });

--- a/packages/components/src/components/TextArea/style.tsx
+++ b/packages/components/src/components/TextArea/style.tsx
@@ -90,6 +90,7 @@ const StyledTextAreaWrapper = styled.div<TextAreaWrapperPropsType>`
 `;
 
 const StyledTextArea = styled.textarea<TextAreaPropsType>`
+    margin: 0;
     padding: 5px 11px;
     box-sizing: border-box;
     width: 100%;

--- a/packages/components/src/components/TextField/style.tsx
+++ b/packages/components/src/components/TextField/style.tsx
@@ -177,7 +177,6 @@ const StyledWrapper = styled.div<WrapperPropsType>`
     overflow: hidden;
     width: 100%;
     box-sizing: border-box;
-    margin-top: 3px;
 
     ${({ focus, disabled, severity, theme }): string => {
         if (severity === 'error' && focus && !disabled) {

--- a/packages/components/src/components/TextField/style.tsx
+++ b/packages/components/src/components/TextField/style.tsx
@@ -177,6 +177,7 @@ const StyledWrapper = styled.div<WrapperPropsType>`
     overflow: hidden;
     width: 100%;
     box-sizing: border-box;
+    margin-top: 3px;
 
     ${({ focus, disabled, severity, theme }): string => {
         if (severity === 'error' && focus && !disabled) {

--- a/packages/components/src/components/TextualButton/index.tsx
+++ b/packages/components/src/components/TextualButton/index.tsx
@@ -40,7 +40,7 @@ const StyledTextContainer = styled.span<Pick<PropsType, 'variant'> & { hover: bo
 `;
 
 const TextualButton: FC<PropsType> = props => {
-    const [isHovering, setHovering] = useState(true);
+    const [isHovering, setHovering] = useState(false);
 
     return (
         <StyledTextualButton

--- a/packages/components/src/components/TextualButton/index.tsx
+++ b/packages/components/src/components/TextualButton/index.tsx
@@ -31,7 +31,7 @@ const StyledTextContainer = styled.span<Pick<PropsType, 'variant'> & { hover: bo
         content: '';
         transition: background 300ms;
         position: absolute;
-        bottom: -1px;
+        bottom: 1px;
         left: 0;
         width: 100%;
         height: 1px;
@@ -40,7 +40,7 @@ const StyledTextContainer = styled.span<Pick<PropsType, 'variant'> & { hover: bo
 `;
 
 const TextualButton: FC<PropsType> = props => {
-    const [isHovering, setHovering] = useState(false);
+    const [isHovering, setHovering] = useState(true);
 
     return (
         <StyledTextualButton

--- a/packages/components/src/components/Toggle/index.tsx
+++ b/packages/components/src/components/Toggle/index.tsx
@@ -42,8 +42,8 @@ class Toggle extends Component<PropsType, StateType> {
 
     public render(): JSX.Element {
         return (
-            <Box onClick={this.handleChange}>
-                <Box margin={trbl(15, 12, 0, 0)}>
+            <Box onClick={this.handleChange} alignItems="center">
+                <Box margin={trbl(0, 12, 0, 0)}>
                     <StyledToggleSkin
                         elementFocus={this.state.focus}
                         disabled={this.props.disabled}
@@ -64,8 +64,11 @@ class Toggle extends Component<PropsType, StateType> {
                         />
                     </StyledToggleSkin>
                 </Box>
-                <Box margin={trbl(9, 0, 0, 0)}>
-                    <Text variant={this.props.disabled ? 'info' : undefined}>{this.props.label}</Text>
+                <Box inline direction="row" align-items="center">
+                    <Text variant={this.props.disabled ? 'info' : undefined}>
+                        {/* force a line-height if there is no label for proper vertical alignment */}
+                        {this.props.label ? this.props.label : '\u00A0'}
+                    </Text>
                 </Box>
             </Box>
         );

--- a/packages/components/src/themes/MosTheme/MosTheme.theme.ts
+++ b/packages/components/src/themes/MosTheme/MosTheme.theme.ts
@@ -189,8 +189,8 @@ const theme: ThemeType = {
                 border: `1px solid ${colors.grey300}`,
             },
             hover: {
-                backgroundColor: colors.grey100,
-                color: colors.grey500,
+                backgroundColor: rgba(0, 0, 0, 0.03),
+                color: colors.grey600,
                 boxShadow: 'none',
             },
             focus: {

--- a/packages/components/src/types/OffsetType/index.ts
+++ b/packages/components/src/types/OffsetType/index.ts
@@ -6,6 +6,7 @@ export type OffsetType =
     | 12
     | 15
     | 18
+    | 21
     | 24
     | 30
     | 36
@@ -17,6 +18,7 @@ export type OffsetType =
     | -12
     | -15
     | -18
+    | -21
     | -24
     | -30
     | -36


### PR DESCRIPTION
### This PR:

**Backwards compatible additions** ✨
- Add a :focus:hover state to buttons, buttons still have a hover even when focused

**Bugfixes/Changed internals** 🎈
- Labels and form fields didn't align correctly.
- The plain button still had incorrect styling
- The line under the textual button seems to be positioned a bit too far down:

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
