### PR TITLE
fix(Button): Remove ::before

### DIFF
--- a/packages/components/src/components/Button/index.tsx
+++ b/packages/components/src/components/Button/index.tsx
@@ -134,10 +134,6 @@ const StyledButton = styled(Base)<PropsType>`
 
                 transform: none;
                 cursor: not-allowed;
-
-                &::before {
-                    opacity: 1;
-                }
             }
         `;
     }};
@@ -146,11 +142,6 @@ const StyledButton = styled(Base)<PropsType>`
         if (variant === 'plain') {
             return `
                 padding: 5px ${compact ? '11px' : '23px'};
-
-                &::before {
-                    color: ${theme.Button.disabled.plain.color};
-                    background: ${theme.Button.disabled.plain.backgroundColor};
-                }
 
                 &:disabled {
                     color: ${theme.Button.disabled.plain.color};
@@ -163,10 +154,6 @@ const StyledButton = styled(Base)<PropsType>`
             return `
                 padding: 6px ${compact ? ' 12px' : '24px'};
 
-                &::before {
-                    color: ${theme.Button.disabled.secondary.color};
-                    background: ${theme.Button.disabled.secondary.backgroundColor};
-                }
 
                 &:disabled {
                     color: ${theme.Button.disabled.secondary.color};
@@ -177,11 +164,6 @@ const StyledButton = styled(Base)<PropsType>`
 
         return `
             padding: 6px ${compact ? ' 12px' : '24px'};
-
-            &::before {
-                color: ${theme.Button.disabled.primary.color};
-                background: ${theme.Button.disabled.primary.backgroundColor};
-            }
 
             &:disabled {
                 color: ${theme.Button.disabled.primary.color};

--- a/packages/components/src/components/Button/index.tsx
+++ b/packages/components/src/components/Button/index.tsx
@@ -129,21 +129,6 @@ const StyledButton = styled(Base)<PropsType>`
                 ${!loading && !disabled ? active : idle}
             }
 
-            &::before {
-                content: '';
-                position: absolute;
-                display: block;
-                left: 0;
-                top: 0;
-                right: 0;
-                bottom: 0;
-                z-index: -2;
-                transition: opacity 0.3s;
-                opacity: ${disabled ? 1 : 0};
-                box-shadow: ${theme.Button[variant].idle.boxShadow};
-                border-radius: ${theme.Button.common.borderRadius};
-            }
-
             &:disabled {
                 ${variant === 'plain' ? `border: ${theme.Button.disabled.plain.border};` : ''}
 


### PR DESCRIPTION
### This PR:

Removes the ::before that is no longer serving any function.

**Bugfixes/Changed internals** 🎈
- Removes ::before from buttons.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
