### PR TITLE
fix(Checkbox): replace intermediate state icon

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,7 +34,7 @@
     "simplebar": "3.0.0-beta.4"
   },
   "devDependencies": {
-    "@myonlinestore/bricks-assets": "0.1.2",
+    "@myonlinestore/bricks-assets": "0.2.0",
     "@types/chroma-js": "^1.4.1",
     "@types/decimal.js": "^7.4.0",
     "@types/deepmerge": "^2.1.0",
@@ -56,7 +56,7 @@
     "styled-components": "^5.0.0"
   },
   "peerDependencies": {
-    "@myonlinestore/bricks-assets": "^0.1.2",
+    "@myonlinestore/bricks-assets": "0.2.0",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
     "react": "^16.8.0",

--- a/packages/components/src/components/Checkbox/index.tsx
+++ b/packages/components/src/components/Checkbox/index.tsx
@@ -2,7 +2,7 @@ import React, { Component, MouseEvent } from 'react';
 import Icon from '../Icon';
 import { StyledCheckbox, StyledCheckboxSkin } from './style';
 import Box from '../Box';
-import { CheckmarkSmallIcon, MinusIcon } from '@myonlinestore/bricks-assets';
+import { CheckmarkSmallIcon, PartialCheckmarkIcon } from '@myonlinestore/bricks-assets';
 import Text from '../Text';
 
 type StateType = {
@@ -59,7 +59,7 @@ class Checkbox extends Component<PropsType, StateType> {
                                 <Icon size="small" color="#fff" icon={<CheckmarkSmallIcon />} />
                             )}
                             {this.props.checked === 'indeterminate' && (
-                                <Icon size="small" color="#fff" icon={<MinusIcon />} />
+                                <Icon size="small" color="#fff" icon={<PartialCheckmarkIcon />} />
                             )}
                         </Box>
                         <StyledCheckbox

--- a/packages/components/src/components/Checkbox/story.tsx
+++ b/packages/components/src/components/Checkbox/story.tsx
@@ -1,33 +1,24 @@
 import { boolean, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
-import React, { Component } from 'react';
+import React, { FC, useState } from 'react';
 import Checkbox from '.';
 
-type StateType = { checked: boolean };
 type PropsType = {};
 
-class Demo extends Component<PropsType, StateType> {
-    public constructor(props: PropsType) {
-        super(props);
+const Demo: FC<PropsType> = () => {
+    const [checked, setChecked] = useState('indeterminate' as boolean | 'indeterminate');
 
-        this.state = {
-            checked: false,
-        };
-    }
-
-    public render(): JSX.Element {
-        return (
-            <Checkbox
-                onChange={({ checked }): void => this.setState({ checked: checked as boolean })}
-                value="bar"
-                checked={this.state.checked}
-                disabled={boolean('disabled', false)}
-                error={boolean('error', false)}
-                name="foo"
-                label={text('label', 'Label')}
-            />
-        );
-    }
-}
+    return (
+        <Checkbox
+            onChange={({ checked }): void => setChecked(checked)}
+            value="bar"
+            checked={checked}
+            disabled={boolean('disabled', false)}
+            error={boolean('error', false)}
+            name="foo"
+            label={text('label', 'Label')}
+        />
+    );
+};
 
 storiesOf('Checkbox', module).add('Default', () => <Demo />);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1909,10 +1909,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@myonlinestore/bricks-assets@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@myonlinestore/bricks-assets/-/bricks-assets-0.1.2.tgz#6a4e514e05fd183852be443b36efc228623d011b"
-  integrity sha512-YOJW8ikg8EkqtgmQ2FY8mcX97kKJOk8q2fLpYVrRLbc1t+Etd9Amd/RxUYL1mfxsqxV1MfhAknyJvFChXDEpFw==
+"@myonlinestore/bricks-assets@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@myonlinestore/bricks-assets/-/bricks-assets-0.2.0.tgz#0a9825b951c9efc5ee8c0eb02e157e04849eb888"
+  integrity sha512-xFKUIw5NzWFPoZgMSOUPi/jidVzAgYEdBw8PKozfBrtGqc0ggEK8QrwMbtliyFkKYSJJHRorLOSCeR7A4dlzhg==
 
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"


### PR DESCRIPTION
### This PR:

Replaces intermediate state icon of Checkbox

**Breaking changes** 🔥
- bricks-asset@0.2.0 peer dependency

**Backwards compatible additions** ✨
- none

**Bugfixes/Changed internals** 🎈
- Component `Checkbox` now uses the correct icon.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
