### PR TITLE
fix(TextualButton): Prevent hover styles being overridden, change fontweight

### DIFF
--- a/packages/components/src/components/TextualButton/index.tsx
+++ b/packages/components/src/components/TextualButton/index.tsx
@@ -22,6 +22,12 @@ export type TextualButtonThemeType = {
 const StyledTextualButton = styled(Base)<PropsType>`
     color: ${({ theme, variant }) => theme.TextualButton[variant].color};
     font-weight: ${({ theme, variant }) => theme.TextualButton[variant].fontWeight};
+    background-color: transparent;
+
+    &:hover {
+        background-color: transparent;
+        color: ${({ theme, variant }) => theme.TextualButton[variant].color};
+    }
 `;
 
 const StyledTextContainer = styled.span<Pick<PropsType, 'variant'> & { hover: boolean }>`

--- a/packages/components/src/themes/MosTheme/MosTheme.theme.ts
+++ b/packages/components/src/themes/MosTheme/MosTheme.theme.ts
@@ -759,11 +759,11 @@ const theme: ThemeType = {
     TextualButton: {
         primary: {
             color: colors.green500,
-            fontWeight: 600,
+            fontWeight: 400,
         },
         secondary: {
             color: colors.grey800,
-            fontWeight: 600,
+            fontWeight: 400,
         },
     },
     Tile: {


### PR DESCRIPTION
…tweight

### This PR:

Prevents overriding of `TextualButton` hover styles and changes the default fontWeight from 600 to 400

**Bugfixes/Changed internals** 🎈
- `TextualButton fontweight 600 -> 400
- Explicitly set `TextualButton` hover styles to prevent overrides.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
