### PR TITLE
fix(Range, Slider): prevent overrides

### DIFF
--- a/packages/components/src/components/Range/style.tsx
+++ b/packages/components/src/components/Range/style.tsx
@@ -77,6 +77,7 @@ const StyledWrapper = styled.div`
             width: 16px;
             height: 16px;
             transition: none;
+            box-sizing: unset;
         }
 
         .input-range__slider:active, .input-range__slider:focus {

--- a/packages/components/src/components/Range/style.tsx
+++ b/packages/components/src/components/Range/style.tsx
@@ -49,12 +49,12 @@ type PropsType = {
 // prettier-ignore
 const StyledWrapper = styled.div`
     ${rangeStyles} padding: 0;
-    box-sizing: border-box;
 
     & {
         .input-range__track,
         .input-range__slider-container {
             ${({ focus }:PropsType): string => (!focus ? 'transition: none;' : '')}
+            box-sizing: unset;
         }
 
         .input-range__track {

--- a/packages/components/src/components/Slider/style.tsx
+++ b/packages/components/src/components/Slider/style.tsx
@@ -49,12 +49,12 @@ type PropsType = {
 // prettier-ignore
 const StyledWrapper = styled(Box)`
     ${sliderStyles} padding: 0;
-    box-sizing: border-box;
 
     & {
         .input-range__track,
         .input-range__slider-container {
             ${({ focus }:PropsType): string => (!focus ? 'transition: none;' : '')}
+            box-sizing: unset;
         }
 
         .input-range__track {

--- a/packages/components/src/components/Slider/style.tsx
+++ b/packages/components/src/components/Slider/style.tsx
@@ -76,6 +76,7 @@ const StyledWrapper = styled(Box)`
             width: 16px;
             height: 16px;
             transition: none;
+            box-sizing: unset;
         }
 
         .input-range__slider:active, .input-range__slider:focus {


### PR DESCRIPTION
### This PR:

Prevents disalignment of range and slider.

*Can be tested with `@myonlinestore/bricks@3.0.1-alpha.1`*

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
