### PR TITLE
fix(Button): Make sure plain button border is rendered in chrome

### DIFF
--- a/packages/components/src/components/Button/index.tsx
+++ b/packages/components/src/components/Button/index.tsx
@@ -142,6 +142,7 @@ const StyledButton = styled(Base)<PropsType>`
         if (variant === 'plain') {
             return `
                 padding: 5px ${compact ? '11px' : '23px'};
+                transform: translateX(0);
 
                 &:disabled {
                     color: ${theme.Button.disabled.plain.color};


### PR DESCRIPTION
### This PR:

The border of the plain button is sometimes not rendered in chrome after content on the page has shifted. This adds a transform that makes sure the button is rerendered correctly after moving. It can be tested using:

`@myonlinestore/bricks@3.0.1-alpha.2`

**Bugfixes/Changed internals** 🎈
- Add transform to Plain button to make sure border renders in chrome.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
