### PR TITLE
fix(InlineNotification): align to flex-start instead of to center

### DIFF
--- a/packages/components/src/components/InlineNotification/index.tsx
+++ b/packages/components/src/components/InlineNotification/index.tsx
@@ -16,8 +16,8 @@ const InlineNotification: FunctionComponent<PropsType> = (props): JSX.Element =>
 
     return (
         <Text variant={props.severity}>
-            <Box inline alignItems="center">
-                <Box inline margin={trbl(0, 6, 0, 0)}>
+            <Box inline alignItems="flex-start">
+                <Box inline margin={trbl(3, 6, 0, 0)}>
                     <Icon size="medium" icon={icon} />
                 </Box>
                 <Box inline>{(Children.count(props.children) > 0 && props.children) || props.message}</Box>


### PR DESCRIPTION
### This PR:

**Bugfixes/Changed internals** 🎈
- Correct alignment of `InlineNotification` in case of multiple lines (ideally this never happens but sometimes it does)

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
