### PR TITLE
docs: fix design system paragraph text variant

### DIFF
--- a/packages/components/docs/lib/componentMap.tsx
+++ b/packages/components/docs/lib/componentMap.tsx
@@ -44,9 +44,9 @@ const componentMap: { [key: string]: FC } = {
             <StyledHr />
         </Box>
     ),
-    p: props => <Text variant="descriptive">{props.children}</Text>,
+    p: props => <Text>{props.children}</Text>,
     li: props => (
-        <Text as="span" variant="descriptive">
+        <Text as="span">
             <li>{props.children}</li>
         </Text>
     ),


### PR DESCRIPTION
### This PR:

Removes `variant="descriptive"` from body text and lists. With the bricks 3.0 changes this is not desired anymore.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
