### PR TITLE
fix(Carousel): Fixed a bug in the carousel styling which misaligns slide buttons

### DIFF
--- a/packages/components/src/components/Carousel/index.tsx
+++ b/packages/components/src/components/Carousel/index.tsx
@@ -26,7 +26,7 @@ const Slide = styled.div<{ active: boolean; x: string }>`
 const SlideButton = styled(IconButton)<{ direction: 'prev' | 'next' }>`
     position: absolute;
     top: calc(50% - 21px);
-    ${({ direction }) => (direction === 'next' ? 'right: 12px' : 'left: 12px')}
+    ${({ direction }) => (direction === 'next' ? 'right: 12px;' : 'left: 12px;')}
     background: rgba(255,255,255, 0.6);
     border-radius: 50%;
     z-index: 3;


### PR DESCRIPTION
### This PR:

Fixed a bug in the carousel styling which misaligns slide buttons

**Breaking changes** 🔥

**Backwards compatible additions** ✨

**Bugfixes/Changed internals** 🎈
This occurs because left/right isn't properly closed, which leads to `left: 12px background: ...` as a single css rule.
![Screenshot 2020-04-24 at 10 38 36](https://user-images.githubusercontent.com/6347900/80192645-ca9edc80-8617-11ea-9c22-6122e0e2c8f8.png)


**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
