### PR TITLE
fix(Table): Added fixed width to draghandler table header

### DIFF
--- a/packages/components/src/components/Table/TableHeaders/index.tsx
+++ b/packages/components/src/components/Table/TableHeaders/index.tsx
@@ -171,7 +171,7 @@ class Headers extends Component<PropsType, StateType> {
         return (
             <thead>
                 <tr>
-                    {this.props.draggable && <StyledHeader headerAlign="start" />}
+                    {this.props.draggable && <StyledHeader width="18px" headerAlign="start" />}
                     {this.props.selectable && (
                         <StyledHeader headerAlign="start">
                             <Checkbox

--- a/packages/components/src/components/Table/story.tsx
+++ b/packages/components/src/components/Table/story.tsx
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/react';
-import React, { Component } from 'react';
+import React, { Component, useState } from 'react';
 import Table from '.';
 import Text from '../Text';
 import IconButton from '../IconButton';
@@ -7,6 +7,7 @@ import { boolean } from '@storybook/addon-knobs';
 import StyledBadge from '../Badge';
 import { TrashIcon, GearIcon } from '@myonlinestore/bricks-assets';
 import Measure from 'react-measure';
+import Toggle from '../Toggle';
 
 type RowType = {
     selected?: boolean;
@@ -206,4 +207,52 @@ storiesOf('Table', module)
                 );
             }}
         </Measure>
-    ));
+    ))
+    .add('Empty', () => {
+        const [isDraggable, setDraggable] = useState(false);
+        const [showRow, setRow] = useState(false);
+
+        return (
+            <>
+                <Toggle
+                    label="Draggable"
+                    value=""
+                    name="draggable-toggle"
+                    checked={isDraggable}
+                    onChange={({ checked }) => {
+                        setDraggable(checked);
+                    }}
+                />
+                <Toggle
+                    label="Show row"
+                    value=""
+                    name="row-toggle"
+                    checked={showRow}
+                    onChange={({ checked }) => {
+                        setRow(checked);
+                    }}
+                />
+                <br />
+                <Table<{ id: string; name: string; price: string }>
+                    onDragEnd={
+                        isDraggable
+                            ? () => {
+                                  alert('dragged');
+                              }
+                            : undefined
+                    }
+                    columns={{
+                        name: {
+                            order: 0,
+                            header: 'Name',
+                        },
+                        price: {
+                            order: 1,
+                            header: 'Price',
+                        },
+                    }}
+                    rows={showRow ? [{ id: '0', name: 'foo', price: '100' }] : []}
+                />
+            </>
+        );
+    });


### PR DESCRIPTION
### This PR:
![Apr-29-2020 10-46-49](https://user-images.githubusercontent.com/6347900/80579275-0b2c9a80-8a0a-11ea-89e6-116e0e0e303c.gif)

This PR fixes a visual inconsistency when toggling an `onDragEnd` on an empty (no rows) `Table` component

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- None

**Bugfixes/Changed internals** 🎈
- Draghandler now has a fixed width, which avoids shifting tableheaders
- Added a story that allows you to reproduce this issue

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
