### PR TITLE
refactor(Select): Split Select into subcomponents

### DIFF
--- a/packages/components/src/components/Select/SelectInput.tsx
+++ b/packages/components/src/components/Select/SelectInput.tsx
@@ -1,0 +1,164 @@
+import React, { FC, ChangeEvent, ReactNode, RefObject } from 'react';
+import Box from '../Box';
+import { StyledPlaceholder, StyledSelection, StyledCaret } from './style';
+import Icon from '../Icon';
+import styled, { withTheme } from 'styled-components';
+import ThemeType from '../../types/ThemeType';
+import { SearchIcon, CaretDownIcon, CaretUpIcon } from '@myonlinestore/bricks-assets';
+import colors from '../../themes/MosTheme/colors';
+import { OffsetType } from '../../types/OffsetType';
+import { OptionBaseType } from '.';
+
+type InputPropsType = {
+    open: boolean;
+    focus: boolean;
+    disabled?: boolean;
+};
+
+const SelectInputContainer = styled.div<InputPropsType>`
+    transition: border-color 150ms, box-shadow 150ms, background 150ms;
+    box-sizing: border-box;
+    width: 100%;
+    border-radius: ${({ theme }) => theme.Select.common.borderRadius};
+    line-height: 1.6; // results in 24px with 15px fontSize
+
+    ${({ theme, focus, open, disabled }) => {
+        if (focus && !open && !disabled) {
+            return `
+                background: ${theme.Select.common.background};
+                border: solid 1px ${theme.Select.select.focus.borderColor};
+                box-shadow: ${theme.Select.select.focus.boxShadow};
+            `;
+        } else if (disabled) {
+            return `
+                background: ${theme.Select.select.disabled.background};
+                border: solid 1px ${theme.Select.select.disabled.borderColor};
+                box-shadow: none;
+                cursor: not-allowed;
+            `;
+        } else {
+            return `
+                background: ${theme.Select.common.background};
+                border: solid 1px ${theme.Select.common.borderColor};
+                box-shadow: none;
+            `;
+        }
+    }}
+
+    input {
+        appearance: none;
+        outline: none;
+        border: none;
+        padding: 0;
+        background: transparent;
+        font-size: ${({ theme }) => theme.Select.common.fontSize};
+        font-family: ${({ theme }) => theme.Select.common.fontFamily};
+        color: ${({ theme }) => theme.Select.select.idle.color};
+        line-height: 1.6; // results in 24px with 15px fontSize
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+
+        &::placeholder {
+            font-style: italic;
+            color: ${({ theme }) => theme.Select.select.focus.placeholderColor};
+            opacity: 1;
+        }
+    }
+`;
+
+type PropsType = {
+    isOpen: boolean;
+    hasFocus: boolean;
+    disabled: boolean;
+    input: string;
+    inputWrapperRef: RefObject<HTMLDivElement>;
+    inputRef: RefObject<HTMLInputElement>;
+    'data-testid'?: string;
+    placeholder: string;
+    selected?: ReactNode;
+    theme: ThemeType;
+    selectedOption: OptionBaseType;
+    onChange(value: string): void;
+    onOpen(): void;
+};
+
+const SelectInput: FC<PropsType> = props => {
+    return (
+        <SelectInputContainer
+            open={props.isOpen}
+            focus={props.hasFocus}
+            disabled={props.disabled}
+            ref={props.inputWrapperRef}
+            role="searchbox"
+            aria-autocomplete="list"
+            aria-controls={props.isOpen ? 'select-window' : undefined}
+            data-testid={props['data-testid'] ? `${props['data-testid']}-input` : undefined}
+            onClick={!props.isOpen ? props.onOpen : undefined}
+        >
+            <Box alignItems="stretch">
+                {(props.isOpen && !props.disabled && (
+                    // 1px less padding to compensate for the border
+                    <Box alignItems="center" padding={[5 as OffsetType, 11 as OffsetType]} grow={1}>
+                        <Box alignItems="center" margin={[0, 6, 0, 0]}>
+                            <Icon icon={<SearchIcon />} size="small" color={colors.grey400} />
+                        </Box>
+                        <input
+                            ref={props.inputRef}
+                            type="text"
+                            placeholder={props.placeholder}
+                            value={props.input}
+                            data-testid={props['data-testid'] ? `${props['data-testid']}-input-field` : undefined}
+                            onChange={(event: ChangeEvent<HTMLInputElement>): void => {
+                                event.stopPropagation();
+                                props.onChange(event.target.value);
+                            }}
+                        />
+                    </Box>
+                )) ||
+                    (props.selected !== undefined && props.selectedOption.value !== '' && (
+                        // 1px less padding to compensate for the border
+                        <Box padding={[5 as OffsetType, 11 as OffsetType]} alignItems="center" grow={1}>
+                            {props.selected}
+                        </Box>
+                    )) || (
+                        // 1px less padding to compensate for the border
+                        <Box alignItems="center" padding={[5 as OffsetType, 11 as OffsetType]} grow={1}>
+                            {(props.selectedOption.value !== '' && (
+                                <StyledSelection
+                                    data-testid={
+                                        props['data-testid'] ? `${props['data-testid']}-input-selection` : undefined
+                                    }
+                                    disabled={props.disabled}
+                                >
+                                    {props.selectedOption.label}
+                                </StyledSelection>
+                            )) || (
+                                <StyledPlaceholder
+                                    disabled={props.disabled}
+                                    data-testid={
+                                        props['data-testid'] ? `${props['data-testid']}-placeholder` : undefined
+                                    }
+                                >
+                                    {props.placeholder}
+                                </StyledPlaceholder>
+                            )}
+                        </Box>
+                    )}
+                <StyledCaret>
+                    <Icon
+                        icon={props.isOpen ? <CaretUpIcon /> : <CaretDownIcon />}
+                        size="medium"
+                        color={
+                            props.disabled
+                                ? props.theme.Select.select.disabled.caretColor
+                                : props.theme.Select.select.idle.caretColor
+                        }
+                        title={props.isOpen ? 'close' : 'open'}
+                    />
+                </StyledCaret>
+            </Box>
+        </SelectInputContainer>
+    );
+};
+
+export default withTheme(SelectInput);

--- a/packages/components/src/components/Select/SelectModal.tsx
+++ b/packages/components/src/components/Select/SelectModal.tsx
@@ -1,0 +1,73 @@
+import React, { FC, RefObject, Children } from 'react';
+import ScrollBox from '../ScrollBox';
+import Box from '../Box';
+import { createPortal } from 'react-dom';
+import Text from '../Text';
+import styled from 'styled-components';
+import { INNER_OFFSET } from './style';
+
+type ContainerPropsType = {
+    open: boolean;
+    rect?: ClientRect;
+    inputHeight?: number;
+};
+
+const SelectModalContainer = styled.div<ContainerPropsType>`
+    box-sizing: border-box;
+    position: fixed;
+    max-height: 240px;
+    top: ${({ rect, inputHeight }) =>
+        rect !== undefined && inputHeight !== undefined ? `${rect.top + INNER_OFFSET + inputHeight}px` : ''};
+    left: ${({ rect }) => (rect !== undefined ? `${rect.left - INNER_OFFSET}px` : '')};
+    width: ${({ rect }) => (rect !== undefined ? `${rect.width + INNER_OFFSET + 6}px` : '')};
+    padding-top: ${({ open }) => (open ? '6px' : '0')};
+    background: ${({ theme }) => theme.Select.common.background};
+    border: ${({ theme, open }) => (open ? `solid 1px ${theme.Select.common.borderColor}` : 'solid 0px transparent')};
+    border-top: none;
+    border-radius: ${({ theme }) => theme.Select.common.borderRadius};
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    ${({ open }) => (!open ? 'cursor: pointer' : '')};
+    z-index: 1000;
+`;
+
+const SelectModal: FC<{
+    isOpen: boolean;
+    'data-testid'?: string;
+    emptyText: string;
+    inputHeight: number;
+    anchorRef: RefObject<HTMLDivElement | null>;
+    modalRef: RefObject<HTMLDivElement>;
+}> = props => {
+    return createPortal(
+        <SelectModalContainer
+            id="select-window"
+            ref={props.modalRef}
+            open={props.isOpen}
+            rect={props.anchorRef.current?.getBoundingClientRect()}
+            inputHeight={props.inputHeight}
+            role="listbox"
+            data-testid={
+                props['data-testid'] ? `${props['data-testid']}-window${props.isOpen ? '-open' : '-closed'}` : undefined
+            }
+        >
+            <ScrollBox autoHideScrollBar={false} showInsetShadow={false}>
+                <div style={{ overflow: 'hidden', display: props.isOpen ? 'block' : 'none' }}>
+                    {(Children.count(props.children) === 0 && (
+                        <Box padding={[12, 18]}>
+                            <Text
+                                data-testid={props['data-testid'] ? `${props['data-testid']}-window-empty` : undefined}
+                            >
+                                {props.emptyText}
+                            </Text>
+                        </Box>
+                    )) ||
+                        props.children}
+                </div>
+            </ScrollBox>
+        </SelectModalContainer>,
+        document.body,
+    );
+};
+
+export default SelectModal;

--- a/packages/components/src/components/Select/index.tsx
+++ b/packages/components/src/components/Select/index.tsx
@@ -1,28 +1,10 @@
-import React, {
-    Children,
-    FC,
-    ChangeEvent,
-    KeyboardEvent,
-    useRef,
-    FormEvent,
-    useState,
-    useEffect,
-    ReactElement,
-    RefObject,
-} from 'react';
-import { createPortal } from 'react-dom';
-import Box from '../Box';
-import ScrollBox from '../ScrollBox';
+import React, { KeyboardEvent, useRef, FormEvent, useState, useEffect, ReactElement } from 'react';
 import Option from './Option';
-import { StyledWrapper, StyledInput, StyledWindow, StyledPlaceholder, StyledSelection, StyledCaret } from './style';
-import Text from '../Text';
-import trbl from '../../utility/trbl';
-import Icon from '../Icon';
+import { StyledWrapper } from './style';
 import { withTheme } from 'styled-components';
 import ThemeType from '../../types/ThemeType';
-import { SearchIcon, CaretDownIcon, CaretUpIcon } from '@myonlinestore/bricks-assets';
-import colors from '../../themes/MosTheme/colors';
-import { OffsetType } from '../../types/OffsetType';
+import SelectModal from './SelectModal';
+import SelectInput from './SelectInput';
 
 type OptionBaseType = {
     value: string;
@@ -44,41 +26,6 @@ type PropsType<GenericOptionType extends OptionBaseType> = {
     onChange(value: string): void;
     renderOption?(option: GenericOptionType, state: OptionStateType): JSX.Element;
     renderSelected?(option: GenericOptionType): JSX.Element;
-};
-
-const SelectModal: FC<{
-    isOpen: boolean;
-    'data-testid'?: string;
-    emptyText: string;
-    inputHeight: number;
-    anchorRef: RefObject<HTMLDivElement | null>;
-    modalRef: RefObject<HTMLDivElement>;
-}> = props => {
-    return createPortal(
-        <StyledWindow
-            id="select-window"
-            ref={props.modalRef}
-            open={props.isOpen}
-            rect={props.anchorRef.current?.getBoundingClientRect()}
-            inputHeight={props.inputHeight}
-            role="listbox"
-            data-testid={
-                props['data-testid'] ? `${props['data-testid']}-window${props.isOpen ? '-open' : '-closed'}` : undefined
-            }
-        >
-            <ScrollBox autoHideScrollBar={false} showInsetShadow={false}>
-                <div style={{ overflow: 'hidden', display: props.isOpen ? 'block' : 'none' }}>
-                    {(Children.count(props.children) === 0 && (
-                        <Box padding={trbl(12, 18)}>
-                            <Text>{props.emptyText}</Text>
-                        </Box>
-                    )) ||
-                        props.children}
-                </div>
-            </ScrollBox>
-        </StyledWindow>,
-        document.body,
-    );
 };
 
 const Select = <GenericOptionType extends OptionBaseType>(props: PropsType<GenericOptionType>): ReactElement => {
@@ -201,7 +148,8 @@ const Select = <GenericOptionType extends OptionBaseType>(props: PropsType<Gener
         (found, option) => {
             return option.value === props.value ? option : found;
         },
-        { value: '', label: '' },
+        // tslint:disable-next-line:no-object-literal-type-assertion
+        { value: '', label: '' } as GenericOptionType,
     );
 
     useEffect(() => {
@@ -223,80 +171,24 @@ const Select = <GenericOptionType extends OptionBaseType>(props: PropsType<Gener
             aria-expanded={isOpen}
             data-testid={props['data-testid']}
         >
-            <StyledInput
-                open={isOpen}
-                focus={hasFocus}
-                disabled={props.disabled}
-                ref={inputWrapperRef}
-                role="searchbox"
-                aria-autocomplete="list"
-                aria-controls={isOpen ? 'select-window' : undefined}
-                data-testid={props['data-testid'] ? `${props['data-testid']}-input` : undefined}
-                onClick={!isOpen ? open : undefined}
-            >
-                <Box alignItems="stretch">
-                    {(isOpen && !props.disabled && (
-                        // 1px less padding to compensate for the border
-                        <Box alignItems="center" padding={[5 as OffsetType, 11 as OffsetType]} grow={1}>
-                            <Box alignItems="center" margin={trbl(0, 6, 0, 0)}>
-                                <Icon icon={<SearchIcon />} size="small" color={colors.grey400} />
-                            </Box>
-                            <input
-                                ref={inputRef}
-                                type="text"
-                                placeholder={props.placeholder}
-                                value={input}
-                                data-testid={props['data-testid'] ? `${props['data-testid']}-input-field` : undefined}
-                                onChange={(event: ChangeEvent<HTMLInputElement>): void => {
-                                    event.stopPropagation();
-                                    handleInput(event.target.value);
-                                }}
-                            />
-                        </Box>
-                    )) ||
-                        (props.renderSelected !== undefined && selectedOption.value !== '' && (
-                            // 1px less padding to compensate for the border
-                            <Box padding={[5 as OffsetType, 11 as OffsetType]} alignItems="center" grow={1}>
-                                {props.renderSelected(selectedOption as GenericOptionType)}
-                            </Box>
-                        )) || (
-                            // 1px less padding to compensate for the border
-                            <Box alignItems="center" padding={[5 as OffsetType, 11 as OffsetType]} grow={1}>
-                                {(props.value !== '' && (
-                                    <StyledSelection
-                                        data-testid={
-                                            props['data-testid'] ? `${props['data-testid']}-input-selection` : undefined
-                                        }
-                                        disabled={props.disabled}
-                                    >
-                                        {selectedOption.label}
-                                    </StyledSelection>
-                                )) || (
-                                    <StyledPlaceholder
-                                        disabled={props.disabled}
-                                        data-testid={
-                                            props['data-testid'] ? `${props['data-testid']}-placeholder` : undefined
-                                        }
-                                    >
-                                        {props.placeholder}
-                                    </StyledPlaceholder>
-                                )}
-                            </Box>
-                        )}
-                    <StyledCaret>
-                        <Icon
-                            icon={isOpen ? <CaretUpIcon /> : <CaretDownIcon />}
-                            size="medium"
-                            color={
-                                props.disabled
-                                    ? props.theme.Select.select.disabled.caretColor
-                                    : props.theme.Select.select.idle.caretColor
-                            }
-                            title={isOpen ? 'close' : 'open'}
-                        />
-                    </StyledCaret>
-                </Box>
-            </StyledInput>
+            <SelectInput
+                selected={props.renderSelected?.(selectedOption)}
+                disabled={props.disabled || false}
+                onChange={value => {
+                    setInput(value);
+                }}
+                onOpen={() => {
+                    setOpen(true);
+                }}
+                hasFocus={hasFocus}
+                isOpen={isOpen}
+                input={input}
+                inputRef={inputRef}
+                inputWrapperRef={inputWrapperRef}
+                placeholder={props.placeholder || ''}
+                selectedOption={selectedOption}
+                data-testid={props['data-testid']}
+            />
             <SelectModal
                 isOpen={isOpen}
                 emptyText={props.emptyText}

--- a/packages/components/src/components/Select/style.tsx
+++ b/packages/components/src/components/Select/style.tsx
@@ -44,7 +44,7 @@ type WrapperPropsType = {
     disabled?: boolean;
 };
 
-const INNER_OFFSET: number = 6;
+export const INNER_OFFSET: number = 6;
 
 type PlaceholderProps = {
     disabled?: boolean;
@@ -96,88 +96,6 @@ const StyledCaret = styled.div`
     right: 9px;
     transform: translateY(-50%);
     z-index: 2;
-`;
-
-type WindowPropsType = {
-    open: boolean;
-    rect?: ClientRect;
-    inputHeight?: number;
-};
-
-const StyledWindow = styled.div<WindowPropsType>`
-    box-sizing: border-box;
-    position: fixed;
-    max-height: 240px;
-    top: ${({ rect, inputHeight }) =>
-        rect !== undefined && inputHeight !== undefined ? `${rect.top + INNER_OFFSET + inputHeight}px` : ''};
-    left: ${({ rect }) => (rect !== undefined ? `${rect.left - INNER_OFFSET}px` : '')};
-    width: ${({ rect }) => (rect !== undefined ? `${rect.width + INNER_OFFSET + 6}px` : '')};
-    padding-top: ${({ open }) => (open ? '6px' : '0')};
-    background: ${({ theme }) => theme.Select.common.background};
-    border: ${({ theme, open }) => (open ? `solid 1px ${theme.Select.common.borderColor}` : 'solid 0px transparent')};
-    border-top: none;
-    border-radius: ${({ theme }) => theme.Select.common.borderRadius};
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-    ${({ open }) => (!open ? 'cursor: pointer' : '')};
-    z-index: 1000;
-`;
-
-type InputPropsType = {
-    open: boolean;
-    focus: boolean;
-    disabled?: boolean;
-};
-
-const StyledInput = styled.div<InputPropsType>`
-    transition: border-color 150ms, box-shadow 150ms, background 150ms;
-    box-sizing: border-box;
-    width: 100%;
-    border-radius: ${({ theme }) => theme.Select.common.borderRadius};
-    line-height: 1.6; // results in 24px with 15px fontSize
-
-    ${({ theme, focus, open, disabled }) => {
-        if (focus && !open && !disabled) {
-            return `
-                background: ${theme.Select.common.background};
-                border: solid 1px ${theme.Select.select.focus.borderColor};
-                box-shadow: ${theme.Select.select.focus.boxShadow};
-            `;
-        } else if (disabled) {
-            return `
-                background: ${theme.Select.select.disabled.background};
-                border: solid 1px ${theme.Select.select.disabled.borderColor};
-                box-shadow: none;
-                cursor: not-allowed;
-            `;
-        } else {
-            return `
-                background: ${theme.Select.common.background};
-                border: solid 1px ${theme.Select.common.borderColor};
-                box-shadow: none;
-            `;
-        }
-    }}
-
-    input {
-        appearance: none;
-        outline: none;
-        border: none;
-        padding: 0;
-        background: transparent;
-        font-size: ${({ theme }) => theme.Select.common.fontSize};
-        font-family: ${({ theme }) => theme.Select.common.fontFamily};
-        color: ${({ theme }) => theme.Select.select.idle.color};
-        line-height: 1.6; // results in 24px with 15px fontSize
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-
-        &::placeholder {
-            font-style: italic;
-            color: ${({ theme }) => theme.Select.select.focus.placeholderColor};
-            opacity: 1;
-        }
-    }
 `;
 
 type SelectionProps = {
@@ -235,13 +153,4 @@ const composeSelectTheme = (themeTools: ThemeTools): SelectThemeType => {
     };
 };
 
-export {
-    StyledWrapper,
-    StyledInput,
-    StyledWindow,
-    SelectThemeType,
-    StyledPlaceholder,
-    StyledSelection,
-    StyledCaret,
-    composeSelectTheme,
-};
+export { StyledWrapper, SelectThemeType, StyledPlaceholder, StyledSelection, StyledCaret, composeSelectTheme };

--- a/packages/components/src/components/Select/test.tsx
+++ b/packages/components/src/components/Select/test.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import Select from '.';
 import { mountWithTheme } from '../../utility/styled/testing';
-import { StyledInput, StyledWindow } from './style';
 import Box from '../Box';
 import Option from './Option';
-import Text from '../Text';
 import MosTheme, { mosTheme } from '../../themes/MosTheme';
 import 'jest-styled-components';
 import { mount } from 'enzyme';
@@ -388,19 +386,15 @@ describe('Select', () => {
         const emptyText = 'mock empty text';
 
         const component = mountWithTheme(
-            <Select onChange={(): void => undefined} value="" emptyText={emptyText} options={[]} />,
+            <Select data-testid="foo" onChange={(): void => undefined} value="" emptyText={emptyText} options={[]} />,
         );
 
-        component
-            .find(StyledInput)
-            .find(Box)
-            .at(1)
-            .simulate('click');
+        component.simulate('click');
 
         expect(
             component
-                .find(StyledWindow)
-                .find(Text)
+                .find('[data-testid="foo-window-empty"]')
+                .hostNodes()
                 .text(),
         ).toEqual(emptyText);
     });

--- a/packages/components/src/components/Select/test.tsx
+++ b/packages/components/src/components/Select/test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Select from '.';
 import { mountWithTheme } from '../../utility/styled/testing';
-import Box from '../Box';
 import Option from './Option';
 import MosTheme, { mosTheme } from '../../themes/MosTheme';
 import 'jest-styled-components';


### PR DESCRIPTION
### This PR:

Progress towards #548 next step would be to implement a context for the Select so SelectModal and SelectInput can be exposed as seperate components

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- None

**Bugfixes/Changed internals** 🎈
- Select is now composed of SelectModal and SelectInput

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
