### PR TITLE
fix(CurrencyField): execute onBlur, onFocus, onClick if defined

### DIFF
--- a/packages/components/src/components/CurrencyField/index.tsx
+++ b/packages/components/src/components/CurrencyField/index.tsx
@@ -188,10 +188,18 @@ const CurrencyField: FC<PropsType> = props => {
                 }
 
                 setDisplayValue(formatDisplayValue(displayValue));
+
+                if (props.onBlur) {
+                    props.onBlur();
+                }
             }}
             onFocus={() => {
                 const unformatted = filterDisplayValue(displayValue);
                 setDisplayValue(unformatted);
+
+                if (props.onFocus) {
+                    props.onFocus();
+                }
             }}
             onClick={() => {
                 if (inputRef.current && inputRef.current.selectionStart) {
@@ -199,6 +207,10 @@ const CurrencyField: FC<PropsType> = props => {
                         displayValue.length === formatDisplayValue(displayValue).length
                             ? inputRef.current.selectionStart
                             : inputRef.current.selectionStart - 1;
+                }
+
+                if (props.onClick) {
+                    props.onClick();
                 }
             }}
         />

--- a/packages/components/src/components/CurrencyField/test.tsx
+++ b/packages/components/src/components/CurrencyField/test.tsx
@@ -477,4 +477,61 @@ describe(CurrencyField.name, () => {
                 .prop('value'),
         ).toEqual('');
     });
+
+    it('should execute onBlur when defined', () => {
+        const blurMock = jest.fn();
+
+        const component = mountWithTheme(
+            <CurrencyField
+                name=""
+                value={19.12}
+                locale="en-US"
+                currency="USD"
+                onChange={jest.fn()}
+                onBlur={blurMock}
+            />,
+        );
+
+        component.find('input').simulate('blur');
+
+        expect(blurMock).toHaveBeenCalled();
+    });
+
+    it('should execute onFocus when defined', () => {
+        const focusMock = jest.fn();
+
+        const component = mountWithTheme(
+            <CurrencyField
+                name=""
+                value={19.12}
+                locale="en-US"
+                currency="USD"
+                onChange={jest.fn()}
+                onFocus={focusMock}
+            />,
+        );
+
+        component.find('input').simulate('focus');
+
+        expect(focusMock).toHaveBeenCalled();
+    });
+
+    it('should execute onClick when defined', () => {
+        const clickMock = jest.fn();
+
+        const component = mountWithTheme(
+            <CurrencyField
+                name=""
+                value={19.12}
+                locale="en-US"
+                currency="USD"
+                onChange={jest.fn()}
+                onClick={clickMock}
+            />,
+        );
+
+        component.find('input').simulate('click');
+
+        expect(clickMock).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
### This PR:

**Bugfixes/Changed internals** 🎈
- `onBlur`, `onFocus`, `onClick` are now called if defined.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
