### PR TITLE
fix(Accordion): Added flex grow property to root element

### DIFF
--- a/packages/components/src/components/Accordion/index.tsx
+++ b/packages/components/src/components/Accordion/index.tsx
@@ -33,33 +33,31 @@ const Accordion: FC<PropsType> = props => {
     };
 
     return (
-        <div data-testid={props['data-testid']}>
-            <Box direction="column">
-                <Box direction="row" position="relative" alignItems="flex-start">
-                    <StyledClickArea
-                        onClick={onClick}
-                        data-testid={props['data-testid'] ? `${props['data-testid']}-click-area` : undefined}
-                    />
-                    <StyledLabel data-testid={props['data-testid'] ? `${props['data-testid']}-label` : undefined}>
-                        {props.label}
-                    </StyledLabel>
-                    <StyledFoldoutIcon
-                        open={props.open}
-                        data-testid={props['data-testid'] ? `${props['data-testid']}-foldout-icon` : undefined}
-                    >
-                        <Icon icon={<ChevronDownSmallIcon />} size="small" />
-                    </StyledFoldoutIcon>
-                </Box>
-                <FoldOut
+        <Box direction="column" grow={1} data-testid={props['data-testid']}>
+            <Box direction="row" position="relative" alignItems="flex-start">
+                <StyledClickArea
+                    onClick={onClick}
+                    data-testid={props['data-testid'] ? `${props['data-testid']}-click-area` : undefined}
+                />
+                <StyledLabel data-testid={props['data-testid'] ? `${props['data-testid']}-label` : undefined}>
+                    {props.label}
+                </StyledLabel>
+                <StyledFoldoutIcon
                     open={props.open}
-                    data-testid={props['data-testid'] ? `${props['data-testid']}-foldout` : undefined}
+                    data-testid={props['data-testid'] ? `${props['data-testid']}-foldout-icon` : undefined}
                 >
-                    <StyledContent data-testid={props['data-testid'] ? `${props['data-testid']}-content` : undefined}>
-                        {props.children}
-                    </StyledContent>
-                </FoldOut>
+                    <Icon icon={<ChevronDownSmallIcon />} size="small" />
+                </StyledFoldoutIcon>
             </Box>
-        </div>
+            <FoldOut
+                open={props.open}
+                data-testid={props['data-testid'] ? `${props['data-testid']}-foldout` : undefined}
+            >
+                <StyledContent data-testid={props['data-testid'] ? `${props['data-testid']}-content` : undefined}>
+                    {props.children}
+                </StyledContent>
+            </FoldOut>
+        </Box>
     );
 };
 


### PR DESCRIPTION
### This PR:
enables the Accordion to flex to full width of its parent.

**Breaking changes** 🔥
- none

**Backwards compatible additions** ✨
- none

**Bugfixes/Changed internals** 🎈
- Added flex grow property to root element

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
