### PR TITLE
fix(TextField): disabled TextField is now also readable in safari

### DIFF
--- a/packages/components/src/components/TextArea/style.tsx
+++ b/packages/components/src/components/TextArea/style.tsx
@@ -78,6 +78,8 @@ const StyledTextAreaWrapper = styled.div<TextAreaWrapperPropsType>`
                 border-color: ${theme.TextArea.disabled.borderColor};
                 box-shadow: none;
                 cursor: not-allowed;
+                -webkit-text-fill-color: currentColor;
+                opacity: 1;
                 `;
         } else {
             return `

--- a/packages/components/src/components/TextArea/style.tsx
+++ b/packages/components/src/components/TextArea/style.tsx
@@ -78,8 +78,6 @@ const StyledTextAreaWrapper = styled.div<TextAreaWrapperPropsType>`
                 border-color: ${theme.TextArea.disabled.borderColor};
                 box-shadow: none;
                 cursor: not-allowed;
-                -webkit-text-fill-color: currentColor;
-                opacity: 1;
                 `;
         } else {
             return `
@@ -122,7 +120,17 @@ const StyledTextArea = styled.textarea<TextAreaPropsType>`
         }};
     }
 
-    ${({ disabled }) => (disabled ? 'cursor: not-allowed;' : '')}
+    ${({ disabled }) => {
+        if (disabled) {
+            return `
+            cursor: not-allowed;
+            -webkit-text-fill-color: currentColor;
+            opacity: 1;
+            `;
+        } else {
+            return '';
+        }
+    }}
 `;
 
 const composeTextAreaTheme = (themeTools: ThemeTools): TextAreaThemeType => {

--- a/packages/components/src/components/TextField/style.tsx
+++ b/packages/components/src/components/TextField/style.tsx
@@ -82,6 +82,8 @@ const StyledInput = styled.input<InputPropsType>`
             return `
                 color: ${theme.TextField.input.disabled.color};
                 cursor: not-allowed;
+                -webkit-text-fill-color: currentColor;
+                opacity: 1;
                 `;
         } else {
             return `


### PR DESCRIPTION
### This PR:

The contents of a disabled textfield were not readable in Safari.

**Bugfixes/Changed internals** 🎈
- disabled TextField contents are now readable in safari

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
