### PR TITLE
fix(Accordion): Moved button area

### DIFF
--- a/packages/components/src/components/Accordion/index.tsx
+++ b/packages/components/src/components/Accordion/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC, ReactNode, MouseEvent } from 'react';
-import { StyledContent, StyledFoldoutIcon, StyledClickArea, StyledLabel } from './style';
+import { StyledContent, StyledFoldoutIcon, StyledLabel } from './style';
 import FoldOut from '../FoldOut';
 import Box from '../Box';
 import { ChevronDownSmallIcon } from '@myonlinestore/bricks-assets';
@@ -35,14 +35,14 @@ const Accordion: FC<PropsType> = props => {
     return (
         <Box direction="column" grow={1} data-testid={props['data-testid']}>
             <Box direction="row" position="relative" alignItems="flex-start">
-                <StyledClickArea
+                <StyledLabel
                     onClick={onClick}
-                    data-testid={props['data-testid'] ? `${props['data-testid']}-click-area` : undefined}
-                />
-                <StyledLabel data-testid={props['data-testid'] ? `${props['data-testid']}-label` : undefined}>
+                    data-testid={props['data-testid'] ? `${props['data-testid']}-label` : undefined}
+                >
                     {props.label}
                 </StyledLabel>
                 <StyledFoldoutIcon
+                    onClick={onClick}
                     open={props.open}
                     data-testid={props['data-testid'] ? `${props['data-testid']}-foldout-icon` : undefined}
                 >

--- a/packages/components/src/components/Accordion/style.tsx
+++ b/packages/components/src/components/Accordion/style.tsx
@@ -6,26 +6,11 @@ type AccordionThemeType = {
     iconColor: string;
 };
 
-const StyledClickArea = styled.button`
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 1;
-    display: block;
-    padding: 0;
-    background: none;
-    border: none;
-    appearance: none;
-    cursor: pointer;
-`;
-
 const StyledLabel = styled.div`
     position: relative;
-    z-index: 2;
+    z-index: 1;
     flex: 1 1 100%;
-    pointer-events: none;
+    cursor: pointer;
 `;
 
 const StyledContent = styled.div`
@@ -34,17 +19,28 @@ const StyledContent = styled.div`
     flex: 1 1 100%;
 `;
 
-const StyledFoldoutIcon = styled.div<{ open: boolean }>`
+const StyledFoldoutIcon = styled.button<{ open: boolean }>`
     position: absolute;
-    right: 0;
-    top: 6px;
+    right: -6px;
+    top: 0;
+    width: 24px;
+    height: 24px;
+    z-index: 3;
+    display: block;
+    padding: 0;
+    background: none;
+    border: none;
+    appearance: none;
+    cursor: pointer;
     transform: ${({ open }) => (open ? `rotate(180deg)` : '')};
     transform-origin: 50% 50%;
     transition: transform 200ms;
-    pointer-events: none;
 
     ${StyledIcon} {
         display: block;
+        position: absolute;
+        top: 6px;
+        right: 6px;
         color: ${({ theme }) => theme.Accordion.iconColor};
     }
 `;
@@ -57,4 +53,4 @@ const composeAccordionTheme = (themeTools: ThemeTools): AccordionThemeType => {
     };
 };
 
-export { StyledClickArea, StyledLabel, StyledFoldoutIcon, StyledContent, AccordionThemeType, composeAccordionTheme };
+export { StyledLabel, StyledFoldoutIcon, StyledContent, AccordionThemeType, composeAccordionTheme };

--- a/packages/components/src/components/Accordion/test.tsx
+++ b/packages/components/src/components/Accordion/test.tsx
@@ -31,10 +31,7 @@ describe('Accordion', () => {
         const foldoutIcon = component.find('[data-testid="Accordion-foldout-icon"]').hostNodes();
         const foldoutComponent = component.find(FoldOut);
 
-        component
-            .find('[data-testid="Accordion-click-area"]')
-            .hostNodes()
-            .simulate('click');
+        foldoutIcon.simulate('click');
 
         expect(foldoutIcon).toHaveLength(1);
         expect(foldoutComponent).toHaveLength(1);


### PR DESCRIPTION
### This PR:

**Bugfixes/Changed internals** 🎈
- Moved the button click area to the foldout icon for a better focus area

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
