### PR TITLE
fix(Accordion): Reset styles explicitly

### DIFF
--- a/packages/components/src/components/Accordion/style.tsx
+++ b/packages/components/src/components/Accordion/style.tsx
@@ -30,11 +30,24 @@ const StyledFoldoutIcon = styled.button<{ open: boolean }>`
     padding: 0;
     background: none;
     border: none;
+    box-shadow: none;
     appearance: none;
     cursor: pointer;
     transform: ${({ open }) => (open ? `rotate(180deg)` : '')};
     transform-origin: 50% 50%;
     transition: transform 200ms;
+
+    &:hover {
+        background: none;
+        border: none;
+        box-shadow: none;
+    }
+
+    &:focus {
+        background: none;
+        border: none;
+        box-shadow: initial;
+    }
 
     ${StyledIcon} {
         display: block;


### PR DESCRIPTION
### This PR:

**Bugfixes/Changed internals** 🎈
- Resets hover and focus styles on Accordion

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
