### PR TITLE
fix(Select): No longer calls value changes twice

### DIFF
--- a/packages/components/src/components/Select/index.tsx
+++ b/packages/components/src/components/Select/index.tsx
@@ -97,11 +97,12 @@ const Select = <GenericOptionType extends OptionBaseType>(props: PropsType<Gener
 
     const [selectedOption, selectOption] = useState(getSelectedOption(props.value));
 
+    /**
+     * Avoid adding any state changes to this handler since it can cause UI yank, rather
+     * use the useEffect below to react to a change in `props.value`.
+     */
     const handleChange = (value: string) => {
         props.onChange(value);
-        selectOption(getSelectedOption(value));
-        setOpen(false);
-        setTarget('');
     };
 
     const handleChangeEvent = (event: FormEvent<HTMLDivElement>) => {
@@ -181,8 +182,15 @@ const Select = <GenericOptionType extends OptionBaseType>(props: PropsType<Gener
         }
     };
 
+    /**
+     * Since this Select can only be used when controlled by external state, this useEffect is the
+     * primary way to handle any actions that follow after a changed value. That way all logic is
+     * normalized for either external state changes as well as changes triggered by the Select itself.
+     */
     useEffect(() => {
         selectOption(getSelectedOption(props.value));
+        setOpen(false);
+        setTarget('');
     }, [props.value]);
 
     /**


### PR DESCRIPTION


### This PR:



**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- None

**Bugfixes/Changed internals** 🎈
- The Select was handling a change twice, once on the actual click and once in a useEffect, which would cause weird behaviour and would make stale selected values show up. I fixed this by centralizing "reacting to changes" within the useEffect. This way the process around this is more straight forward and catches both cases.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
