### PR TITLE
feat(TextField): Feedback prop now supports a data-testid

### DIFF
--- a/packages/components/src/components/InlineNotification/index.tsx
+++ b/packages/components/src/components/InlineNotification/index.tsx
@@ -9,13 +9,14 @@ type PropsType = {
     icon?: ReactNode;
     message?: string;
     severity: SeverityType;
+    'data-testid'?: string;
 };
 
 const InlineNotification: FunctionComponent<PropsType> = (props): JSX.Element => {
     const icon = props.icon !== undefined ? props.icon : SeverityIcons[props.severity];
 
     return (
-        <Text variant={props.severity}>
+        <Text variant={props.severity} data-testid={props['data-testid']}>
             <Box inline alignItems="flex-start">
                 <Box inline margin={trbl(3, 6, 0, 0)}>
                     <Icon size="medium" icon={icon} />

--- a/packages/components/src/components/Text/index.tsx
+++ b/packages/components/src/components/Text/index.tsx
@@ -36,6 +36,7 @@ type TextThemeType = {
 };
 
 type PropsType = {
+    'data-testid'?: string;
     size?: 'small' | 'regular' | 'large' | 'extraLarge' | 'display';
     variant?: SeverityType | 'descriptive';
     textAlign?: 'left' | 'right' | 'center' | 'justify';

--- a/packages/components/src/components/TextField/index.tsx
+++ b/packages/components/src/components/TextField/index.tsx
@@ -14,6 +14,7 @@ type PropsType = {
     type?: string;
     id?: string;
     feedback?: {
+        'data-testid'?: string;
         severity: SeverityType;
         message: string;
     };
@@ -141,6 +142,7 @@ class TextField extends Component<PropsType, StateType> {
                 {this.props.feedback && this.props.feedback.message !== '' && (
                     <Box margin={[3, 0, 0, 0]}>
                         <InlineNotification
+                            data-testid={this.props.feedback['data-testid']}
                             message={this.props.feedback.message}
                             severity={this.props.feedback.severity}
                         />

--- a/packages/components/src/components/TextField/test.tsx
+++ b/packages/components/src/components/TextField/test.tsx
@@ -5,8 +5,6 @@ import { StyledInput, StyledWrapper, StyledAffixWrapper } from './style';
 import { Box } from '../..';
 import MosTheme from '../../themes/MosTheme';
 import { mount } from 'enzyme';
-import CurrencyField from '../CurrencyField';
-import NumberField from '../NumberField';
 
 describe('TextField', () => {
     it('should not change value when disabled', () => {
@@ -140,16 +138,21 @@ describe('TextField', () => {
         ).toBe('bar');
     });
 
-    it('should render the components defined as static property', () => {
+    it('should be able to pass a testid to the feedback prop', () => {
         const changeMock = jest.fn();
-
-        const currencyField = mountWithTheme(
-            <CurrencyField name="" value={1} onChange={changeMock} locale="nl-NL" currency="EUR" />,
+        const component = mountWithTheme(
+            <TextField
+                name=""
+                value="foo"
+                onChange={changeMock}
+                feedback={{
+                    'data-testid': 'feedback',
+                    message: 'foo',
+                    severity: 'error',
+                }}
+            />,
         );
 
-        const numberField = mountWithTheme(<NumberField name="" value={1} onChange={changeMock} />);
-
-        expect(currencyField.find('input').length).toBe(1);
-        expect(numberField.find('input').length).toBe(1);
+        expect(component.findByTestId('feedback')).toHaveLength(1);
     });
 });


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- Feedback prop now supports a data-testid so you can test passed in feedback easier.

**Bugfixes/Changed internals** 🎈
- Removed an obsolete test

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
