### PR TITLE
feat(Toaster): Improved default positioning of toaster container

### DIFF
--- a/packages/components/src/components/Toaster/index.tsx
+++ b/packages/components/src/components/Toaster/index.tsx
@@ -137,6 +137,12 @@ class Toaster extends Component<PropsType, StateType> {
             const newContainer = document.createElement('div');
 
             newContainer.id = portalId;
+            newContainer.style.position = 'fixed';
+            newContainer.style.top = '0';
+            newContainer.style.right = '0';
+            newContainer.style.left = '0';
+            newContainer.style.zIndex = '100';
+
             document.body.prepend(newContainer);
 
             return createPortal(toasts, newContainer);


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- By default the toaster container does not have any positioning. When no container is present, a fixed container positioned to the top is now rendered.

**Bugfixes/Changed internals** 🎈
- None

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
