### PR TITLE
feat(TextArea): TextArea now supports data-testid on the feedback prop

### DIFF
--- a/packages/components/src/components/TextArea/index.tsx
+++ b/packages/components/src/components/TextArea/index.tsx
@@ -2,7 +2,6 @@ import React, { ChangeEvent, FC, useRef, useState } from 'react';
 import StyledTextArea, { StyledTextAreaWrapper } from './style';
 import InlineNotification from '../InlineNotification';
 import SeverityType from '../../types/SeverityType';
-import trbl from '../../utility/trbl';
 import Box from '../Box';
 import Text from '../Text';
 
@@ -14,6 +13,7 @@ type PropsType = {
     resizeable?: boolean;
     disabled?: boolean;
     feedback?: {
+        'data-testid'?: string;
         severity: SeverityType;
         message: string;
     };
@@ -69,8 +69,12 @@ const TextArea: FC<PropsType> = props => {
                 )}
             </StyledTextAreaWrapper>
             {props.feedback && props.feedback.message !== '' && (
-                <Box margin={trbl(3, 0, 0, 0)}>
-                    <InlineNotification message={props.feedback.message} severity={props.feedback.severity} />
+                <Box margin={[3, 0, 0, 0]}>
+                    <InlineNotification
+                        data-testid={props.feedback['data-testid']}
+                        message={props.feedback.message}
+                        severity={props.feedback.severity}
+                    />
                 </Box>
             )}
         </>

--- a/packages/components/src/components/TextArea/test.tsx
+++ b/packages/components/src/components/TextArea/test.tsx
@@ -61,4 +61,20 @@ describe('TextArea', () => {
 
         expect(changeMock).toHaveBeenCalledWith(expectedString, expect.any(Object));
     });
+
+    it('should be able to test with a testid', () => {
+        const changeMock = jest.fn();
+        const component = mountWithTheme(
+            <TextArea
+                value="John"
+                data-testid="foo"
+                name="firstName"
+                onChange={changeMock}
+                feedback={{ severity: 'error', message: 'foo', 'data-testid': 'feedback' }}
+            />,
+        );
+
+        expect(component.findByTestId('foo')).toHaveLength(1);
+        expect(component.findByTestId('feedback')).toHaveLength(1);
+    });
 });


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- TextArea now supports `data-testid` on the feedback prop

**Bugfixes/Changed internals** 🎈
- None

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
