### PR TITLE
fix(Select): Empty text is shown again

### DIFF
--- a/packages/components/src/components/Select/SelectList.tsx
+++ b/packages/components/src/components/Select/SelectList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext } from 'react';
+import React, { FC, useContext, useState, useLayoutEffect } from 'react';
 import ScrollBox from '../ScrollBox';
 import Box from '../Box';
 import Text from '../Text';
@@ -15,13 +15,18 @@ const SelectList: FC<{
     emptyText: string;
     'data-testid'?: string;
 }> = props => {
-    const { options } = useContext(SelectContext);
+    const { options, filter } = useContext(SelectContext);
+    const [isEmpty, setEmpty] = useState(options.length === 0);
+
+    useLayoutEffect(() => {
+        setEmpty(options.length === 0);
+    }, [options, filter]);
 
     return (
         <StyledList data-testid={props['data-testid'] ? `${props['data-testid']}-list}` : undefined}>
             <ScrollBox autoHideScrollBar={false} showInsetShadow={false}>
                 <div style={{ overflow: 'hidden', display: props.isOpen ? 'block' : 'none' }}>
-                    {options.length === 0 && (
+                    {isEmpty && (
                         <Box padding={[12, 18]}>
                             <Text data-testid={props['data-testid'] ? `${props['data-testid']}-list-empty` : undefined}>
                                 {props.emptyText}
@@ -29,10 +34,10 @@ const SelectList: FC<{
                         </Box>
                     )}
                     {/*
-                      * Make sure the children are always rendered, since their lifecycle will update
-                      * the option refs from the context. The children themselves will decide whether
-                      * to return `null` or not based on the filter.
-                      */}
+                     * Make sure the children are always rendered, since their lifecycle will update
+                     * the option refs from the context. The children themselves will decide whether
+                     * to return `null` or not based on the filter.
+                     */}
                     {props.children}
                 </div>
             </ScrollBox>

--- a/packages/components/src/components/Select/SelectList.tsx
+++ b/packages/components/src/components/Select/SelectList.tsx
@@ -1,8 +1,9 @@
-import React, { FC, Children } from 'react';
+import React, { FC, useContext } from 'react';
 import ScrollBox from '../ScrollBox';
 import Box from '../Box';
 import Text from '../Text';
 import styled from 'styled-components';
+import { SelectContext } from '.';
 
 const StyledList = styled.div`
     max-height: 240px;
@@ -13,21 +14,30 @@ const SelectList: FC<{
     isOpen: boolean;
     emptyText: string;
     'data-testid'?: string;
-}> = props => (
-    <StyledList data-testid={props['data-testid'] ? `${props['data-testid']}-list}` : undefined}>
-        <ScrollBox autoHideScrollBar={false} showInsetShadow={false}>
-            <div style={{ overflow: 'hidden', display: props.isOpen ? 'block' : 'none' }}>
-                {(Children.count(props.children) === 0 && (
-                    <Box padding={[12, 18]}>
-                        <Text data-testid={props['data-testid'] ? `${props['data-testid']}-list-empty` : undefined}>
-                            {props.emptyText}
-                        </Text>
-                    </Box>
-                )) ||
-                    props.children}
-            </div>
-        </ScrollBox>
-    </StyledList>
-);
+}> = props => {
+    const { options } = useContext(SelectContext);
+
+    return (
+        <StyledList data-testid={props['data-testid'] ? `${props['data-testid']}-list}` : undefined}>
+            <ScrollBox autoHideScrollBar={false} showInsetShadow={false}>
+                <div style={{ overflow: 'hidden', display: props.isOpen ? 'block' : 'none' }}>
+                    {options.length === 0 && (
+                        <Box padding={[12, 18]}>
+                            <Text data-testid={props['data-testid'] ? `${props['data-testid']}-list-empty` : undefined}>
+                                {props.emptyText}
+                            </Text>
+                        </Box>
+                    )}
+                    {/*
+                      * Make sure the children are always rendered, since their lifecycle will update
+                      * the option refs from the context. The children themselves will decide whether
+                      * to return `null` or not based on the filter.
+                      */}
+                    {props.children}
+                </div>
+            </ScrollBox>
+        </StyledList>
+    );
+};
 
 export default SelectList;

--- a/packages/components/src/components/Select/index.tsx
+++ b/packages/components/src/components/Select/index.tsx
@@ -50,6 +50,7 @@ export const SelectContext = createContext({
     hasFocus: false,
     targeted: '',
     selectedOption: { value: '', label: '' },
+    options: [] as Array<OptionBaseType>,
     setTarget(value: string) {
         console.warn(`${PROVIDER_WARNING}, could not set target to value: "${value}"`);
     },
@@ -237,6 +238,7 @@ const Select = <GenericOptionType extends OptionBaseType>(props: PropsType<Gener
                 isDisabled: props.disabled || false,
                 hasFocus,
                 targeted,
+                options: options.current,
                 setOpen,
                 setFilter: handleFilter,
                 setValue: handleChange,

--- a/packages/components/src/components/Select/test.tsx
+++ b/packages/components/src/components/Select/test.tsx
@@ -495,4 +495,38 @@ describe('Select', () => {
 
         expect(component.find(Select).prop('options')).toHaveLength(options.length);
     });
+
+    it('should display the empty text when all options are filtered out', () => {
+        const component = mountWithTheme(
+            <Select
+                onChange={(): void => undefined}
+                value=""
+                emptyText="empty"
+                data-testid="select"
+                options={[
+                    {
+                        value: 'A',
+                        label: 'A',
+                    },
+                    {
+                        value: 'B',
+                        label: 'B',
+                    },
+                ]}
+            />,
+        );
+
+        component.find(Select).simulate('keyDown', {
+            key: ' ',
+        });
+
+        component.find('input').simulate('change', {
+            target: {
+                value: 'AAAAAAAAAAA',
+            },
+        });
+
+        expect(component.find('[data-testid^="select-option-"]').hostNodes().length).toBe(0);
+        expect(component.findByTestId('select-list-empty').length).toBe(1);
+    });
 });


### PR DESCRIPTION
### This PR:
 
#577 

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- Options has been added to the `SelectContext`

**Bugfixes/Changed internals** 🎈
- Empty text is shown again when no options are eligible for picking.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).
