### PR TITLE
feat(Button): Added onFocus and onBlur props

### DIFF
--- a/packages/components/src/components/Button/base/index.tsx
+++ b/packages/components/src/components/Button/base/index.tsx
@@ -10,7 +10,12 @@ type PropsType = {
     id?: string;
     loading?: boolean;
     'data-testid'?: string;
-} & Partial<Pick<HTMLProps<HTMLButtonElement | HTMLAnchorElement>, 'onClick' | 'onMouseEnter' | 'onMouseLeave'>>;
+} & Partial<
+    Pick<
+        HTMLProps<HTMLButtonElement | HTMLAnchorElement>,
+        'onClick' | 'onMouseEnter' | 'onMouseLeave' | 'onFocus' | 'onBlur'
+    >
+>;
 
 const ButtonBase: FunctionComponent<PropsType> = (props): JSX.Element => {
     const isLink = props.href !== undefined;
@@ -18,6 +23,18 @@ const ButtonBase: FunctionComponent<PropsType> = (props): JSX.Element => {
     const clickAction = (event: MouseEvent<HTMLButtonElement>): void => {
         if (props.onClick !== undefined && props.disabled !== true && props.loading !== true) {
             props.onClick(event);
+        }
+    };
+
+    const focusAction = (event: React.FocusEvent<HTMLButtonElement | HTMLAnchorElement>): void => {
+        if (props.onFocus !== undefined && props.disabled !== true && props.loading !== true) {
+            props.onFocus(event);
+        }
+    };
+
+    const blurAction = (event: React.FocusEvent<HTMLButtonElement | HTMLAnchorElement>): void => {
+        if (props.onBlur !== undefined && props.disabled !== true && props.loading !== true) {
+            props.onBlur(event);
         }
     };
 
@@ -33,6 +50,8 @@ const ButtonBase: FunctionComponent<PropsType> = (props): JSX.Element => {
                 data-testid={props['data-testid']}
                 onMouseEnter={props.onMouseEnter}
                 onMouseLeave={props.onMouseLeave}
+                onFocus={focusAction}
+                onBlur={blurAction}
             >
                 {props.children}
             </StyledAnchor>
@@ -51,6 +70,8 @@ const ButtonBase: FunctionComponent<PropsType> = (props): JSX.Element => {
             data-testid={props['data-testid']}
             onMouseEnter={props.onMouseEnter}
             onMouseLeave={props.onMouseLeave}
+            onFocus={focusAction}
+            onBlur={blurAction}
         >
             {props.children}
         </StyledButton>

--- a/packages/components/src/components/Button/base/test.tsx
+++ b/packages/components/src/components/Button/base/test.tsx
@@ -105,6 +105,46 @@ describe('ButtonBase implementations', () => {
             expect(clickMock).toHaveBeenCalled();
             expect(clickEvent.target).toBeDefined();
         });
+
+        it('should call the passed action on focus', () => {
+            // tslint:disable-next-line:no-any
+            let focusEvent: any = {};
+
+            const focusMock = jest.fn(event => {
+                focusEvent = event;
+            });
+
+            const component = mount(
+                <MosTheme>
+                    <Implementation onFocus={focusMock} />
+                </MosTheme>,
+            );
+
+            component.simulate('focus');
+
+            expect(focusMock).toHaveBeenCalled();
+            expect(focusEvent.target).toBeDefined();
+        });
+
+        it('should call the passed action on blur', () => {
+            // tslint:disable-next-line:no-any
+            let blurEvent: any = {};
+
+            const blurMock = jest.fn(event => {
+                blurEvent = event;
+            });
+
+            const component = mount(
+                <MosTheme>
+                    <Implementation onBlur={blurMock} />
+                </MosTheme>,
+            );
+
+            component.simulate('blur');
+
+            expect(blurMock).toHaveBeenCalled();
+            expect(blurEvent.target).toBeDefined();
+        });
     });
 
     /**


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- none

**Backwards compatible additions** ✨
- Adds `onFocus` and `onBlur` to the buttons.

**Bugfixes/Changed internals** 🎈
- none

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>