### PR TITLE
feat(Table): Added disabled prop to row

### DIFF
--- a/packages/components/src/components/Table/Row/index.tsx
+++ b/packages/components/src/components/Table/Row/index.tsx
@@ -103,6 +103,7 @@ class Row extends Component<PropsType, StateType> {
                             name=""
                             value=""
                             checked={this.props.selected}
+                            disabled={this.props.row.disabled}
                             onChange={({ checked, event }): void => this.props.onSelection(event, checked as boolean)}
                         />
                     </Cell>

--- a/packages/components/src/components/Table/Row/test.tsx
+++ b/packages/components/src/components/Table/Row/test.tsx
@@ -6,6 +6,7 @@ import StyledRow from './style';
 import { mosTheme } from '../../../themes/MosTheme';
 import { ContrastThemeProvider } from '../../Contrast';
 import 'jest-styled-components';
+import Checkbox from '../../Checkbox';
 
 describe('Table Rows', () => {
     it('should handle mouse focus and blur when draggable', () => {
@@ -73,5 +74,59 @@ describe('Table Rows', () => {
 
         component.find(StyledRow).simulate('mouseLeave');
         expect(component.find(ContrastThemeProvider).prop('enable')).toBe(false);
+    });
+
+    it('should be able to toggle the checkbox', () => {
+        const onSelectionMock = jest.fn();
+
+        const component = mountWithTheme(
+            <table>
+                <tbody>
+                    <Rows
+                        row={{ id: '61651320', price: 19.12, name: 'foo0', image: 'imageurl', disabled: false }}
+                        columns={{
+                            id: { header: 'Product ID' },
+                            name: { header: 'name' },
+                            price: { header: 'Price' },
+                        }}
+                        selected={false}
+                        selectable
+                        draggable
+                        index={1}
+                        onSelection={onSelectionMock}
+                    />
+                </tbody>
+            </table>,
+        );
+
+        component.find(Checkbox).simulate('click');
+        expect(onSelectionMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not be able to toggle the checkbox when disabled', () => {
+        const onSelectionMock = jest.fn();
+
+        const component = mountWithTheme(
+            <table>
+                <tbody>
+                    <Rows
+                        row={{ id: '61651320', price: 19.12, name: 'foo0', image: 'imageurl', disabled: true }}
+                        columns={{
+                            id: { header: 'Product ID' },
+                            name: { header: 'name' },
+                            price: { header: 'Price' },
+                        }}
+                        selected={false}
+                        selectable
+                        draggable
+                        index={1}
+                        onSelection={onSelectionMock}
+                    />
+                </tbody>
+            </table>,
+        );
+
+        component.find(Checkbox).simulate('click');
+        expect(onSelectionMock).not.toHaveBeenCalled();
     });
 });

--- a/packages/components/src/components/Table/TableHeaders/index.tsx
+++ b/packages/components/src/components/Table/TableHeaders/index.tsx
@@ -29,7 +29,7 @@ type PropsType = {
         column: string;
         direction: SortDirectionType;
     };
-    onCheck(checked: boolean): void;
+    onCheck(checked: boolean | 'indeterminate'): void;
     onSort?(column: string, direction: SortDirectionType): void;
 };
 
@@ -178,7 +178,7 @@ class Headers extends Component<PropsType, StateType> {
                                 checked={this.props.checked}
                                 name=""
                                 value=""
-                                onChange={({ checked }): void => this.props.onCheck(checked as boolean)}
+                                onChange={({ checked }): void => this.props.onCheck(checked)}
                             />
                         </StyledHeader>
                     )}

--- a/packages/components/src/components/Table/story.tsx
+++ b/packages/components/src/components/Table/story.tsx
@@ -11,6 +11,7 @@ import Toggle from '../Toggle';
 
 type RowType = {
     selected?: boolean;
+    disabled?: boolean;
     id: string;
     price: number;
     name: string;
@@ -72,6 +73,8 @@ class Demo extends Component<PropsType, StateType> {
                     price: -0.7,
                     name: 'Grapes',
                     image: 'https://picsum.photos/60/60?image=674',
+                    disabled: true,
+                    selected: false,
                 },
             ],
         };

--- a/packages/components/src/components/Table/test.tsx
+++ b/packages/components/src/components/Table/test.tsx
@@ -1,7 +1,7 @@
 /// <reference path="../../_declarations/global.d.ts" />
 import React from 'react';
 import { DragDropContext } from 'react-beautiful-dnd';
-import Table from '.';
+import Table, { BaseRowType } from '.';
 import { mountWithTheme } from '../../utility/styled/testing';
 import Cell from './Cell';
 import Card from './Card';
@@ -365,11 +365,77 @@ describe('Table', () => {
         ).toEqual(false);
     });
 
-    it('should select all rows when the header checkbox is checked', () => {
+    it('should select all rows when the header checkbox is checked', async () => {
         const mockHandler = jest.fn();
 
         const rows = [
-            { id: '61651320', selected: true, price: 19.12, name: 'foo0', image: 'imageurl' },
+            { id: '61651320', selected: false, price: 19.12, name: 'foo0', image: 'imageurl' },
+            { id: '61651321', selected: false, price: 19.2, name: 'foo1', image: 'imageurl' },
+            { id: '61651322', selected: false, price: 21.12, name: 'foo2', image: 'imageurl' },
+            { id: '61651323', selected: false, price: 22.12, name: 'foo3', image: 'imageurl' },
+        ];
+
+        const component = mountWithTheme(
+            <Table
+                columns={{
+                    id: { header: 'Product ID' },
+                    name: { header: 'name' },
+                    price: { header: 'Price' },
+                }}
+                rows={rows}
+                onSelection={mockHandler}
+            />,
+        );
+
+        component
+            .find(Checkbox)
+            .first()
+            .simulate('click');
+
+        component.update();
+
+        const checkedRows = mockHandler.mock.calls[0][0].filter((row: BaseRowType) => row.selected);
+
+        expect(checkedRows.length).toBe(4);
+    });
+
+    it('should select just the enabled rows when the header checkbox is clicked', () => {
+        const mockHandler = jest.fn();
+
+        const rows = [
+            { id: '61651320', selected: false, price: 19.12, name: 'foo0', image: 'imageurl', disabled: true },
+            { id: '61651321', selected: false, price: 19.2, name: 'foo1', image: 'imageurl' },
+            { id: '61651322', selected: false, price: 21.12, name: 'foo2', image: 'imageurl' },
+            { id: '61651323', selected: false, price: 22.12, name: 'foo3', image: 'imageurl' },
+        ];
+
+        const component = mountWithTheme(
+            <Table
+                columns={{
+                    id: { header: 'Product ID' },
+                    name: { header: 'name' },
+                    price: { header: 'Price' },
+                }}
+                rows={rows}
+                onSelection={mockHandler}
+            />,
+        );
+
+        component
+            .find(Checkbox)
+            .first()
+            .simulate('click');
+
+        const checkedRows = mockHandler.mock.calls[0][0].filter((row: BaseRowType) => row.selected);
+
+        expect(checkedRows.length).toBe(3);
+    });
+
+    it('should deselect just the enabled rows when the header checkbox is clicked after a full selection', () => {
+        const mockHandler = jest.fn();
+
+        const rows = [
+            { id: '61651320', selected: true, price: 19.12, name: 'foo0', image: 'imageurl', disabled: true },
             { id: '61651321', selected: true, price: 19.2, name: 'foo1', image: 'imageurl' },
             { id: '61651322', selected: true, price: 21.12, name: 'foo2', image: 'imageurl' },
             { id: '61651323', selected: true, price: 22.12, name: 'foo3', image: 'imageurl' },
@@ -392,10 +458,9 @@ describe('Table', () => {
             .first()
             .simulate('click');
 
-        // tslint:disable-next-line
-        const checkedRows = mockHandler.mock.calls[0].filter((row: any): any => row.checked);
+        const checkedRows = mockHandler.mock.calls[0][0].filter((row: BaseRowType) => row.selected);
 
-        expect(checkedRows.length).toBe(0);
+        expect(checkedRows.length).toBe(1);
     });
 
     it('should sort rows when a column is given a sorting function and the select in the CompactHeader is clicked', () => {

--- a/packages/components/src/components/Table/test.tsx
+++ b/packages/components/src/components/Table/test.tsx
@@ -365,7 +365,7 @@ describe('Table', () => {
         ).toEqual(false);
     });
 
-    it('should select all rows when the header checkbox is checked', async () => {
+    it('should select all rows when the header checkbox is checked', () => {
         const mockHandler = jest.fn();
 
         const rows = [


### PR DESCRIPTION
### This PR:

Adds the possibility to disable checkboxes in a table row.

**Breaking changes** 🔥
- none

**Backwards compatible additions** ✨
- `disabled` prop on a Table row

**Bugfixes/Changed internals** 🎈
- Fixed a few tests

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>