### PR TITLE
feat(TextArea): Added onBlur prop

### DIFF
--- a/packages/components/src/components/TextArea/index.tsx
+++ b/packages/components/src/components/TextArea/index.tsx
@@ -31,7 +31,9 @@ const TextArea: FC<PropsType> = props => {
     const onBlur = (): void => {
         setFocus(false);
 
-        if (props.onBlur !== undefined) props.onBlur();
+        if (props.onBlur) {
+            props.onBlur();
+        }
     };
 
     const onChange = (event: ChangeEvent<HTMLTextAreaElement>): void => {

--- a/packages/components/src/components/TextArea/index.tsx
+++ b/packages/components/src/components/TextArea/index.tsx
@@ -21,11 +21,18 @@ type PropsType = {
     placeholder?: string;
     'data-testid'?: string;
     onChange(value: string, event: ChangeEvent<HTMLTextAreaElement>): void;
+    onBlur?(): void;
 };
 
 const TextArea: FC<PropsType> = props => {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const [focus, setFocus] = useState(false);
+
+    const handleBlur = (): void => {
+        setFocus(false);
+
+        if (props.onBlur !== undefined) props.onBlur();
+    };
 
     const onChange = (event: ChangeEvent<HTMLTextAreaElement>): void => {
         if (!props.disabled)
@@ -60,7 +67,7 @@ const TextArea: FC<PropsType> = props => {
                     placeholder={props.placeholder}
                     onChange={onChange}
                     onFocus={() => setFocus(true)}
-                    onBlur={() => setFocus(false)}
+                    onBlur={handleBlur}
                 />
                 {props.characterLimit && !props.disabled && (
                     <Box justifyContent="flex-end" padding={[0, 12, 6]} onClick={focusField} style={{ cursor: 'text' }}>

--- a/packages/components/src/components/TextArea/index.tsx
+++ b/packages/components/src/components/TextArea/index.tsx
@@ -28,7 +28,7 @@ const TextArea: FC<PropsType> = props => {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const [focus, setFocus] = useState(false);
 
-    const handleBlur = (): void => {
+    const onBlur = (): void => {
         setFocus(false);
 
         if (props.onBlur !== undefined) props.onBlur();
@@ -67,7 +67,7 @@ const TextArea: FC<PropsType> = props => {
                     placeholder={props.placeholder}
                     onChange={onChange}
                     onFocus={() => setFocus(true)}
-                    onBlur={handleBlur}
+                    onBlur={onBlur}
                 />
                 {props.characterLimit && !props.disabled && (
                     <Box justifyContent="flex-end" padding={[0, 12, 6]} onClick={focusField} style={{ cursor: 'text' }}>

--- a/packages/components/src/components/TextArea/test.tsx
+++ b/packages/components/src/components/TextArea/test.tsx
@@ -14,6 +14,18 @@ describe('TextArea', () => {
         expect(changeMock).not.toHaveBeenCalled();
     });
 
+    it('should not break when no onBlur is provided', () => {
+        const component = mountWithTheme(
+            <TextArea value="John" name="firstName" onChange={(): void => undefined} />,
+        );
+
+        const fn = (): void => {
+            component.find(StyledTextArea).simulate('blur');
+        };
+
+        expect(fn).not.toThrow();
+    });
+
     it('should handle a change', () => {
         const changeMock = jest.fn();
 

--- a/packages/components/src/components/TextArea/test.tsx
+++ b/packages/components/src/components/TextArea/test.tsx
@@ -15,15 +15,25 @@ describe('TextArea', () => {
     });
 
     it('should not break when no onBlur is provided', () => {
-        const component = mountWithTheme(
-            <TextArea value="John" name="firstName" onChange={(): void => undefined} />,
-        );
+        const component = mountWithTheme(<TextArea value="John" name="firstName" onChange={(): void => undefined} />);
 
         const fn = (): void => {
             component.find(StyledTextArea).simulate('blur');
         };
 
         expect(fn).not.toThrow();
+    });
+
+    it('should trigger the onBlur callback when onBlur is provided', () => {
+        const blurMock = jest.fn();
+
+        const component = mountWithTheme(
+            <TextArea value="John" name="firstName" onChange={(): void => undefined} onBlur={blurMock} />,
+        );
+
+        component.find(StyledTextArea).simulate('blur');
+
+        expect(blurMock).toHaveBeenCalled();
     });
 
     it('should handle a change', () => {


### PR DESCRIPTION
### This PR:

This PR adds an onBlur function to the TextArea component

**Backwards compatible additions** ✨
- Component `TextArea` now supports an `onBlur` prop to handle onBlur callbacks.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>