### PR TITLE
fix(PromotionBadge): Now rendered as a span instead of a div

### DIFF
--- a/packages/components/src/components/PromotionBadge/index.tsx
+++ b/packages/components/src/components/PromotionBadge/index.tsx
@@ -19,7 +19,7 @@ type VariantStyleType = {
     fontFamily: string;
 };
 
-const StyledPromotionBadge = styled.div<PropsType>`
+const StyledPromotionBadge = styled.span<PropsType>`
     ${({ theme, variant }): string => {
         return `
             font-family: ${theme.PromotionBadge[variant].fontFamily};


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- none

**Backwards compatible additions** ✨
- none

**Bugfixes/Changed internals** 🎈
- PromotionBadge is now rendered as a span instead of a div to prevent nesting errors

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>