### PR TITLE
feat(CurrencyField, NumberField): Add maximumValue and characterLimit

### DIFF
--- a/packages/components/src/components/CurrencyField/test.tsx
+++ b/packages/components/src/components/CurrencyField/test.tsx
@@ -308,6 +308,56 @@ describe(CurrencyField.name, () => {
         expect(component.find('input').prop('value')).toEqual('19.12');
     });
 
+    it('should not allow values larger than the maximum value', () => {
+        const changeMock = jest.fn();
+
+        const component = mountWithTheme(
+            <CurrencyField
+                disableNegative={true}
+                name=""
+                value={19.12}
+                maximumValue={20}
+                locale="en-GB"
+                currency="EUR"
+                onChange={changeMock}
+            />,
+        );
+
+        component.find('input').simulate('change', {
+            target: {
+                value: '21',
+            },
+        });
+
+        expect(component.find('input').prop('value')).toEqual('19.12');
+        expect(changeMock).not.toHaveBeenCalled();
+    });
+
+    it('should not allow values longer than the character limit', () => {
+        const changeMock = jest.fn();
+
+        const component = mountWithTheme(
+            <CurrencyField
+                disableNegative={true}
+                name=""
+                value={19.12}
+                characterLimit={5}
+                locale="en-GB"
+                currency="EUR"
+                onChange={changeMock}
+            />,
+        );
+
+        component.find('input').simulate('change', {
+            target: {
+                value: '191.13',
+            },
+        });
+
+        expect(component.find('input').prop('value')).toEqual('19.12');
+        expect(changeMock).not.toHaveBeenCalled();
+    });
+
     it('should allow negative input when disableNegative prop is false', () => {
         const changeMock = jest.fn();
 

--- a/packages/components/src/components/NumberField/test.tsx
+++ b/packages/components/src/components/NumberField/test.tsx
@@ -34,6 +34,32 @@ describe(NumberField.name, () => {
         expect(changeMock).toHaveBeenCalledWith(0);
     });
 
+    it('should not allow values larger than the maximum value', () => {
+        const changeMock = jest.fn();
+        const component = mountWithTheme(
+            <NumberField name="" value={19} maximumValue={30} disableNegative onChange={changeMock} />,
+        );
+
+        component.find('input').simulate('change', { target: { value: '32' } });
+        component.find('input').simulate('blur');
+
+        expect(component.find('input').prop('value')).toEqual('19');
+        expect(changeMock).not.toHaveBeenCalled();
+    });
+
+    it('should not allow values longer than the character limit', () => {
+        const changeMock = jest.fn();
+        const component = mountWithTheme(
+            <NumberField name="" value={19} characterLimit={3} disableNegative onChange={changeMock} />,
+        );
+
+        component.find('input').simulate('change', { target: { value: '3232' } });
+        component.find('input').simulate('blur');
+
+        expect(component.find('input').prop('value')).toEqual('19');
+        expect(changeMock).not.toHaveBeenCalled();
+    });
+
     it('should be able to handle localized float values', () => {
         const changeMock = jest.fn();
 

--- a/packages/components/src/components/TextField/story.tsx
+++ b/packages/components/src/components/TextField/story.tsx
@@ -43,6 +43,18 @@ const Demo: FC<PropsType> = (props): JSX.Element => {
         allowDecimals: boolean('allowDecimals', false),
         minimumFractionDigits: number('minimumFractionDigits', 0),
         maximumFractionDigits: number('maximumFractionDigits', 2),
+        characterLimit: number('characterLimit', 10),
+        maximumValue: number('maximumValue', 1000000),
+        locale,
+    };
+
+    const currencyProps = {
+        value: numberValue,
+        onChange: setNumberValue,
+        disableNegative: boolean('disable negative numbers', false),
+        allowDecimals: boolean('allowDecimals', false),
+        characterLimit: number('characterLimit', 10),
+        maximumValue: number('maximumValue', 1000000),
         locale,
     };
 
@@ -55,7 +67,7 @@ const Demo: FC<PropsType> = (props): JSX.Element => {
         return (
             <CurrencyField
                 {...sharedProps}
-                {...numberProps}
+                {...currencyProps}
                 currency={select('currency', ['USD', 'EUR', 'JPY', 'GBP', 'AUD'], 'EUR')}
                 minor={boolean('minor', false)}
                 feedback={{


### PR DESCRIPTION
### This PR:

Adds the possibility to have a character limit and maximum value in both the `NumberField` and the `CurrencyField`.

**Backwards compatible additions** ✨
- optional `maximumValue` prop for `NumberField` and `CurrencyField`.
- optional `characterLimit` prop for `NumberField` and `CurrencyField`.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>