### PR TITLE
feat(RadioButton): Added check to prevent onChange when disabled

### DIFF
--- a/packages/components/src/components/RadioButton/index.tsx
+++ b/packages/components/src/components/RadioButton/index.tsx
@@ -49,7 +49,7 @@ const RadioButton: FC<PropsType> = props => {
                         onBlur={toggleFocus}
                         onChange={handleChange}
                         checked={props.checked}
-                        disabled={props.disabled}
+                        disabled={props.disabled ? props.disabled : false}
                         type="radio"
                         name={props.name}
                         value={props.value}

--- a/packages/components/src/components/RadioButton/index.tsx
+++ b/packages/components/src/components/RadioButton/index.tsx
@@ -27,10 +27,12 @@ const RadioButton: FC<PropsType> = props => {
     };
 
     const handleChange = (): void => {
-        props.onChange({
-            checked: !props.checked,
-            value: props.value,
-        });
+        if (!props.disabled) {
+            props.onChange({
+                checked: !props.checked,
+                value: props.value,
+            });
+        }
     };
 
     return (
@@ -47,6 +49,7 @@ const RadioButton: FC<PropsType> = props => {
                         onBlur={toggleFocus}
                         onChange={handleChange}
                         checked={props.checked}
+                        disabled={props.disabled}
                         type="radio"
                         name={props.name}
                         value={props.value}

--- a/packages/components/src/components/RadioButton/test.tsx
+++ b/packages/components/src/components/RadioButton/test.tsx
@@ -78,6 +78,34 @@ describe('RadioButton', () => {
         );
     });
 
+    it('should not fire onChange when disabled', () => {
+        const changeMock = jest.fn();
+
+        const component = mountWithTheme(
+            <RadioButton
+                checked={false}
+                disabled
+                name="foo"
+                value="foo"
+                label="foo"
+                onChange={changeMock}
+                data-testid="foo"
+            />,
+        );
+
+        component
+            .find('[data-testid="foo"]')
+            .hostNodes()
+            .simulate('change');
+
+        component
+            .find('[data-testid="foo"]')
+            .hostNodes()
+            .simulate('click');
+
+        expect(changeMock).toHaveBeenCalledTimes(0);
+    });
+
     it('should show an error state', () => {
         const radioButton = mountWithTheme(
             <RadioButton


### PR DESCRIPTION
### This PR:

**Bugfixes/Changed internals** 🎈
- Added check to prevent onChange when disabled

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>