### PR TITLE
fix(FormRow): Change label to div

### DIFF
--- a/packages/components/src/components/FormRow/index.tsx
+++ b/packages/components/src/components/FormRow/index.tsx
@@ -20,7 +20,7 @@ const FormRow: FunctionComponent<PropsType> = (props): JSX.Element => {
                         <Box basis={'180px'} direction="row" grow={1} maxWidth="241px" margin={[21, 9, 0, 0]} wrap>
                             <Box grow={1} wrap={false}>
                                 <Box direction={props.description ? 'column' : 'row'} grow={props.badge ? 0 : 1}>
-                                    <StyledDisabledText disabled={props.disabled} strong>
+                                    <StyledDisabledText as="div" disabled={props.disabled} strong>
                                         {props.label}
                                     </StyledDisabledText>
                                     {props.description && (


### PR DESCRIPTION
### This PR:

This prevents nesting errors when using components based on `div`s in the label of a `FormRow` (example uses: checkboxes, radiobuttons).

**Bugfixes/Changed internals** 🎈
- The label of the `FormRow` now renders as a `div` instead of a `p`.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>