### PR TITLE
feat(FoldOut): Added excerpt mode to FoldOut component

### DIFF
--- a/packages/components/src/components/FoldOut/index.tsx
+++ b/packages/components/src/components/FoldOut/index.tsx
@@ -5,10 +5,14 @@ import Measure from 'react-measure';
 type ContentProps = {
     contentHeight?: number;
     isOpen: PropsType['open'];
+    excerptHeight?: PropsType['excerptHeight'];
+    backgroundColor?: PropsType['backgroundColor'];
 };
 
 type PropsType = {
     open: boolean;
+    excerptHeight?: number;
+    backgroundColor?: string;
 };
 
 const FoldOut: FC<PropsType> = props => (
@@ -16,7 +20,9 @@ const FoldOut: FC<PropsType> = props => (
         {({ measureRef, contentRect }) => (
             <StyledFoldOut
                 isOpen={props.open}
-                contentHeight={contentRect.client ? contentRect.client.height : undefined}
+                contentHeight={contentRect.client?.height}
+                excerptHeight={props.excerptHeight}
+                backgroundColor={props.backgroundColor}
             >
                 <div ref={measureRef}>{props.children}</div>
             </StyledFoldOut>

--- a/packages/components/src/components/FoldOut/index.tsx
+++ b/packages/components/src/components/FoldOut/index.tsx
@@ -5,13 +5,13 @@ import Measure from 'react-measure';
 type ContentProps = {
     contentHeight?: number;
     isOpen: PropsType['open'];
-    previewHeight?: PropsType['previewContent'];
+    previewHeight?: PropsType['previewHeight'];
     backgroundColor?: PropsType['backgroundColor'];
 };
 
 type PropsType = {
     open: boolean;
-    previewContent?: number;
+    previewHeight?: number;
     backgroundColor?: string;
 };
 
@@ -21,7 +21,7 @@ const FoldOut: FC<PropsType> = props => (
             <StyledFoldOut
                 isOpen={props.open}
                 contentHeight={contentRect.client?.height}
-                previewHeight={props.previewContent}
+                previewHeight={props.previewHeight}
                 backgroundColor={props.backgroundColor}
             >
                 <div ref={measureRef}>{props.children}</div>

--- a/packages/components/src/components/FoldOut/index.tsx
+++ b/packages/components/src/components/FoldOut/index.tsx
@@ -5,13 +5,13 @@ import Measure from 'react-measure';
 type ContentProps = {
     contentHeight?: number;
     isOpen: PropsType['open'];
-    excerptHeight?: PropsType['excerptHeight'];
+    previewHeight?: PropsType['previewContent'];
     backgroundColor?: PropsType['backgroundColor'];
 };
 
 type PropsType = {
     open: boolean;
-    excerptHeight?: number;
+    previewContent?: number;
     backgroundColor?: string;
 };
 
@@ -21,7 +21,7 @@ const FoldOut: FC<PropsType> = props => (
             <StyledFoldOut
                 isOpen={props.open}
                 contentHeight={contentRect.client?.height}
-                excerptHeight={props.excerptHeight}
+                previewHeight={props.previewContent}
                 backgroundColor={props.backgroundColor}
             >
                 <div ref={measureRef}>{props.children}</div>

--- a/packages/components/src/components/FoldOut/story.tsx
+++ b/packages/components/src/components/FoldOut/story.tsx
@@ -66,7 +66,7 @@ const ExcerptDemo: FC<PropsType> = () => {
 
     return (
         <Box direction="column" alignContent="center" padding={[24]} style={{ backgroundColor: '#d3d5d9' }}>
-            <FoldOut open={isOpen} excerptHeight={70} backgroundColor="#d3d5d9">
+            <FoldOut open={isOpen} previewContent={70} backgroundColor="#d3d5d9">
                 <Box padding={trbl(0, 0, 12)}>
                     <Text>{demoContent}</Text>
                 </Box>

--- a/packages/components/src/components/FoldOut/story.tsx
+++ b/packages/components/src/components/FoldOut/story.tsx
@@ -66,7 +66,7 @@ const ExcerptDemo: FC<PropsType> = () => {
 
     return (
         <Box direction="column" alignContent="center" padding={[24]} style={{ backgroundColor: '#d3d5d9' }}>
-            <FoldOut open={isOpen} previewContent={70} backgroundColor="#d3d5d9">
+            <FoldOut open={isOpen} previewHeight={70} backgroundColor="#d3d5d9">
                 <Box padding={trbl(0, 0, 12)}>
                     <Text>{demoContent}</Text>
                 </Box>

--- a/packages/components/src/components/FoldOut/story.tsx
+++ b/packages/components/src/components/FoldOut/story.tsx
@@ -1,13 +1,15 @@
 import { storiesOf } from '@storybook/react';
-import React, { Component } from 'react';
+import React, { useState, FC } from 'react';
 import FoldOut from '.';
 import trbl from '../../utility/trbl';
 import Button from '../Button';
 import Box from '../Box';
 import Text from '../Text';
+import IconButton from '../IconButton';
+import { ChevronDownSmallIcon, ChevronUpSmallIcon } from '@myonlinestore/bricks-assets';
 
-type StateType = {
-    isOpen: boolean;
+type PropsType = {
+    isOpen?: boolean;
 };
 
 const demoContent = `
@@ -36,37 +38,52 @@ const demoContent = `
     To sit on my throne as the prince of Bel-air
 `;
 
-class DemoComponent extends Component<{}, StateType> {
-    public constructor(props: {}) {
-        super(props);
+const Demo: FC<PropsType> = () => {
+    const [isOpen, toggleOpen] = useState(false);
 
-        this.state = {
-            isOpen: false,
-        };
-    }
+    return (
+        <div>
+            <FoldOut open={isOpen}>
+                <Box padding={trbl(0, 0, 12)}>
+                    <Text>{demoContent}</Text>
+                </Box>
+            </FoldOut>
+            <Button
+                onClick={() => {
+                    toggleOpen(!isOpen);
+                }}
+                title="open FoldOut"
+                variant="secondary"
+            >
+                Toggle
+            </Button>
+        </div>
+    );
+};
 
-    public render(): JSX.Element {
-        return (
-            <div>
-                <FoldOut open={this.state.isOpen}>
-                    <Box padding={trbl(0, 0, 12)}>
-                        <Text>{demoContent}</Text>
-                    </Box>
-                </FoldOut>
-                <Button
-                    onClick={(): void =>
-                        this.setState({
-                            isOpen: !this.state.isOpen,
-                        })
-                    }
-                    title="open FoldOut"
-                    variant="secondary"
-                >
-                    Toggle
-                </Button>
-            </div>
-        );
-    }
-}
+const ExcerptDemo: FC<PropsType> = () => {
+    const [isOpen, toggleOpen] = useState(false);
 
-storiesOf('FoldOut', module).add('With a toggle', () => <DemoComponent />);
+    return (
+        <Box direction="column" alignContent="center" padding={[24]} style={{ backgroundColor: '#d3d5d9' }}>
+            <FoldOut open={isOpen} excerptHeight={70} backgroundColor="#d3d5d9">
+                <Box padding={trbl(0, 0, 12)}>
+                    <Text>{demoContent}</Text>
+                </Box>
+            </FoldOut>
+            <IconButton
+                onClick={() => {
+                    toggleOpen(!isOpen);
+                }}
+                title="open FoldOut"
+                variant="primary"
+                iconSize="small"
+                icon={isOpen ? <ChevronUpSmallIcon /> : <ChevronDownSmallIcon />}
+            />
+        </Box>
+    );
+};
+
+storiesOf('FoldOut', module)
+    .add('With a button toggle', () => <Demo />)
+    .add('With excerpt preview', () => <ExcerptDemo />);

--- a/packages/components/src/components/FoldOut/style.tsx
+++ b/packages/components/src/components/FoldOut/style.tsx
@@ -9,6 +9,10 @@ const animateOverflow = keyframes`
 const StyledFoldOut = styled.div`
     transition: height 300ms cubic-bezier(0.5, 0, 0.1, 1);
     height: ${(props: ContentProps): string => {
+        if (props.excerptHeight && !props.isOpen) {
+            return `${props.excerptHeight}px`;
+        }
+
         if (!props.isOpen) {
             return '0';
         }
@@ -25,6 +29,26 @@ const StyledFoldOut = styled.div`
             return css`
                 overflow: visible;
                 animation: 500ms ${animateOverflow};
+            `;
+        }
+
+        if (props.excerptHeight && !props.isOpen) {
+            return css`
+                overflow: hidden;
+                position: relative;
+
+                &:after {
+                    content: '';
+                    position: absolute;
+                    left: 0;
+                    right: 0;
+                    top: 0;
+                    bottom: 0;
+                    background: linear-gradient(
+                        transparent 50%,
+                        ${props.backgroundColor ? props.backgroundColor : '#FFFFFF'} 100%
+                    );
+                }
             `;
         }
 

--- a/packages/components/src/components/FoldOut/style.tsx
+++ b/packages/components/src/components/FoldOut/style.tsx
@@ -9,8 +9,8 @@ const animateOverflow = keyframes`
 const StyledFoldOut = styled.div`
     transition: height 300ms cubic-bezier(0.5, 0, 0.1, 1);
     height: ${(props: ContentProps): string => {
-        if (props.excerptHeight && !props.isOpen) {
-            return `${props.excerptHeight}px`;
+        if (props.previewHeight && !props.isOpen) {
+            return `${props.previewHeight}px`;
         }
 
         if (!props.isOpen) {
@@ -32,7 +32,7 @@ const StyledFoldOut = styled.div`
             `;
         }
 
-        if (props.excerptHeight && !props.isOpen) {
+        if (props.previewHeight && !props.isOpen) {
             return css`
                 overflow: hidden;
                 position: relative;
@@ -44,10 +44,7 @@ const StyledFoldOut = styled.div`
                     right: 0;
                     top: 0;
                     bottom: 0;
-                    background: linear-gradient(
-                        transparent 50%,
-                        ${props.backgroundColor ? props.backgroundColor : '#FFFFFF'} 100%
-                    );
+                    background: linear-gradient(transparent 50%, ${props.backgroundColor || '#FFFFFF'} 100%);
                 }
             `;
         }


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- none

**Backwards compatible additions** ✨
- Added a prop `excerptHeight` to determine to preview a part of the foldouts content

**Bugfixes/Changed internals** 🎈
- none

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>