### PR TITLE
feat(Notification): Allow react nodes as message via children

### DIFF
--- a/packages/components/src/components/Notification/index.tsx
+++ b/packages/components/src/components/Notification/index.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactNode } from 'react';
+import React, { Children, FunctionComponent, ReactNode } from 'react';
 import trbl from '../../utility/trbl';
 import Icon from '../Icon';
 import Box from '../Box';
@@ -7,20 +7,21 @@ import { SeverityIcons } from '../../types/SeverityType';
 
 type PropsType = {
     severity: keyof typeof SeverityIcons;
-    message: string;
+    message?: string;
     icon?: ReactNode;
+    'data-testid'?: string;
 };
 
 const Notification: FunctionComponent<PropsType> = (props): JSX.Element => {
     const icon = props.icon !== undefined ? props.icon : SeverityIcons[props.severity];
 
     return (
-        <StyledNotification severity={props.severity}>
+        <StyledNotification severity={props.severity} data-testid={props['data-testid']}>
             <Box padding={trbl(12, 18)} alignItems={'flex-start'}>
                 <Box margin={trbl(3, 6, 0, 0)}>
                     <Icon size="medium" icon={icon} />
                 </Box>
-                {props.message}
+                <Box inline>{(Children.count(props.children) > 0 && props.children) || props.message}</Box>
             </Box>
         </StyledNotification>
     );

--- a/packages/components/src/components/Notification/story.tsx
+++ b/packages/components/src/components/Notification/story.tsx
@@ -2,6 +2,7 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import Notification from '.';
 import { MehIcon } from '@myonlinestore/bricks-assets';
+import Link from '../Link';
 
 storiesOf('Notification', module)
     .add('Success', () => <Notification severity="success" message="Wow, Great job!" />)
@@ -10,4 +11,9 @@ storiesOf('Notification', module)
     .add('Info', () => <Notification severity="info" message="Oops, something wen't wrong. Please try again." />)
     .add('With a custom icon', () => (
         <Notification severity="warning" message="Meh, I am not impressed." icon={<MehIcon />} />
+    ))
+    .add('With react node children', () => (
+        <Notification severity="info">
+            A message with React nodes like a <Link title="Link" target="_blank" href="https://google.com" />
+        </Notification>
     ));

--- a/packages/components/src/components/Notification/test.tsx
+++ b/packages/components/src/components/Notification/test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Notification from '.';
 import { mountWithTheme } from '../../utility/styled/testing';
 
-describe('Native Select', () => {
+describe('Notification', () => {
     it('should be testable with a test-id', () => {
         const component = mountWithTheme(<Notification severity="info" data-testid="foo" />);
 

--- a/packages/components/src/components/Notification/test.tsx
+++ b/packages/components/src/components/Notification/test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Notification from '.';
+import { mountWithTheme } from '../../utility/styled/testing';
+
+describe('Native Select', () => {
+    it('should be testable with a test-id', () => {
+        const component = mountWithTheme(<Notification severity="info" data-testid="foo" />);
+
+        expect(component.findByTestId('foo')).toHaveLength(1);
+    });
+
+    it('should render a message when no children are present', () => {
+        const component = mountWithTheme(<Notification severity="info" message="A message via prop" />);
+
+        expect(component.text()).toBe('A message via prop');
+    });
+
+    it('should render children instead of the message prop', () => {
+        const component = mountWithTheme(
+            <Notification severity="info" message="No message">
+                But children
+            </Notification>,
+        );
+
+        expect(component.text()).toBe('But children');
+    });
+});


### PR DESCRIPTION
### This PR:

Makes it possible to use react nodes in the message via the children, just like the InlineNotification

**Backwards compatible additions** ✨
- Added `data-testid` prop
- Made `message` prop optional

**Bugfixes/Changed internals** 🎈
- Check if component has children and render them instead of the `message`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>