### PR TITLE
feat(Link)!: Add severity colors to Link

### DIFF
--- a/packages/components/src/components/Link/index.tsx
+++ b/packages/components/src/components/Link/index.tsx
@@ -1,9 +1,11 @@
 import React, { Children, FunctionComponent, MouseEvent } from 'react';
+import SeverityType from '../../types/SeverityType';
 import StyledLink, { StyledButton } from './style';
 
 type PropsType = {
     href?: string;
     className?: string;
+    severity?: SeverityType;
     title: string;
     target?: '_blank' | '_self';
     'data-testid'?: string;
@@ -26,6 +28,7 @@ const Link: FunctionComponent<PropsType> = (props): JSX.Element => {
                 title={props.title}
                 target={props.target}
                 href={props.href}
+                severity={props.severity ? props.severity : 'default'}
                 data-testid={props['data-testid']}
             >
                 {Children.count(props.children) > 0 ? props.children : props.title}
@@ -39,6 +42,7 @@ const Link: FunctionComponent<PropsType> = (props): JSX.Element => {
             type="button"
             onClick={clickAction}
             title={props.title}
+            severity={props.severity ? props.severity : 'default'}
             data-testid={props['data-testid']}
         >
             {Children.count(props.children) > 0 ? props.children : props.title}

--- a/packages/components/src/components/Link/index.tsx
+++ b/packages/components/src/components/Link/index.tsx
@@ -2,10 +2,12 @@ import React, { Children, FunctionComponent, MouseEvent } from 'react';
 import SeverityType from '../../types/SeverityType';
 import StyledLink, { StyledButton } from './style';
 
+type LinkSeverityType = SeverityType | 'default';
+
 type PropsType = {
     href?: string;
     className?: string;
-    severity?: SeverityType;
+    severity?: LinkSeverityType;
     title: string;
     target?: '_blank' | '_self';
     'data-testid'?: string;
@@ -51,4 +53,4 @@ const Link: FunctionComponent<PropsType> = (props): JSX.Element => {
 };
 
 export default Link;
-export { PropsType };
+export { PropsType, LinkSeverityType };

--- a/packages/components/src/components/Link/story.tsx
+++ b/packages/components/src/components/Link/story.tsx
@@ -1,10 +1,11 @@
 import { select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
-import Link, { PropsType } from '.';
+import Link, { LinkSeverityType, PropsType } from '.';
 import Text from '../Text';
 
 const targetOptions = ['_self', '_blank'];
+const severityOptions: Array<LinkSeverityType> = ['default', 'error', 'warning', 'success', 'info'];
 
 storiesOf('Buttons/Link', module)
     .add('Default', () => (
@@ -13,6 +14,7 @@ storiesOf('Buttons/Link', module)
                 target={select('target', targetOptions, targetOptions[0]) as PropsType['target']}
                 href=""
                 title="Google search"
+                severity={select('severity', severityOptions, severityOptions[0])}
             />
         </Text>
     ))
@@ -20,6 +22,7 @@ storiesOf('Buttons/Link', module)
         <Text>
             <Link
                 title="Google search"
+                severity={select('severity', severityOptions, severityOptions[0])}
                 onClick={(): void => {
                     /**/
                 }}

--- a/packages/components/src/components/Link/style.tsx
+++ b/packages/components/src/components/Link/style.tsx
@@ -2,7 +2,7 @@ import { css } from 'styled-components';
 import ThemeType from '../../types/ThemeType';
 import styled from '../../utility/styled';
 import ThemeTools from '../../themes/CustomTheme/ThemeTools';
-import SeverityType from '../../types/SeverityType';
+import { LinkSeverityType } from '.';
 
 type LinkThemeType = {
     common: {
@@ -50,9 +50,7 @@ type LinkThemeType = {
     };
 };
 
-type LinkSeverityType = SeverityType | 'default';
 type ThemePropsType = { theme: ThemeType; severity: LinkSeverityType };
-
 type LinkProps = {
     severity: LinkSeverityType;
 };

--- a/packages/components/src/components/Link/style.tsx
+++ b/packages/components/src/components/Link/style.tsx
@@ -2,86 +2,183 @@ import { css } from 'styled-components';
 import ThemeType from '../../types/ThemeType';
 import styled from '../../utility/styled';
 import ThemeTools from '../../themes/CustomTheme/ThemeTools';
+import SeverityType from '../../types/SeverityType';
 
 type LinkThemeType = {
-    default: {
-        color: string;
+    common: {
         textDecoration: string;
-        fontSize: string;
     };
-    hover: {
-        color: string;
+    default: {
+        idle: {
+            color: string;
+        };
+        hover: {
+            color: string;
+        };
+    };
+    success: {
+        idle: {
+            color: string;
+        };
+        hover: {
+            color: string;
+        };
+    };
+    info: {
+        idle: {
+            color: string;
+        };
+        hover: {
+            color: string;
+        };
+    };
+    warning: {
+        idle: {
+            color: string;
+        };
+        hover: {
+            color: string;
+        };
+    };
+    error: {
+        idle: {
+            color: string;
+        };
+        hover: {
+            color: string;
+        };
     };
 };
 
-type ThemePropsType = { theme: ThemeType };
+type LinkSeverityType = SeverityType | 'default';
+type ThemePropsType = { theme: ThemeType; severity: LinkSeverityType };
+
+type LinkProps = {
+    severity: LinkSeverityType;
+};
 
 const LinkStyles = css`
-    color: ${({ theme }: ThemePropsType): string => theme.Link.default.color};
-    text-decoration: ${({ theme }: ThemePropsType): string => theme.Link.default.textDecoration};
+    color: ${({ theme }: ThemePropsType): string => theme.Link.default.idle.color};
+    text-decoration: ${({ theme }: ThemePropsType): string => theme.Link.common.textDecoration};
     transition: color 100ms;
     background-color: transparent;
     font-family: inherit;
+    font-size: inherit;
 
     &:hover {
-        color: ${({ theme }: ThemePropsType): string => theme.Link.hover.color};
+        color: ${({ theme }: ThemePropsType): string => theme.Link.default.hover.color};
         background-color: transparent;
     }
 
     &:focus {
-        color: ${({ theme }): string => theme.Link.default.color};
+        color: ${({ theme }): string => theme.Link.default.idle.color};
         background-color: transparent;
 
         &:hover {
-            color: ${({ theme }: ThemePropsType): string => theme.Link.hover.color};
+            color: ${({ theme }: ThemePropsType): string => theme.Link.default.hover.color};
             background-color: transparent;
         }
     }
 `;
 
-const StyledLink = styled.a`
-    ${LinkStyles};
+const StyledLink = styled.a<LinkProps>`
+    color: ${({ theme, severity }: ThemePropsType): string => theme.Link[severity].idle.color};
+    text-decoration: ${({ theme }: ThemePropsType): string => theme.Link.common.textDecoration};
+    transition: color 100ms;
+    background-color: transparent;
+    font-family: inherit;
+    font-size: inherit;
+
+    &:hover {
+        color: ${({ theme, severity }: ThemePropsType): string => theme.Link[severity].hover.color};
+        background-color: transparent;
+    }
+
+    &:focus {
+        color: ${({ theme, severity }): string => theme.Link[severity].idle.color};
+        background-color: transparent;
+
+        &:hover {
+            color: ${({ theme, severity }: ThemePropsType): string => theme.Link[severity].hover.color};
+            background-color: transparent;
+        }
+    }
 `;
 
 const StyledButton = styled.button`
-    color: ${({ theme }): string => theme.Link.default.color};
-    text-decoration: ${({ theme }): string => theme.Link.default.textDecoration};
+    color: ${({ theme }): string => theme.Link.default.idle.color};
+    text-decoration: ${({ theme }): string => theme.Link.common.textDecoration};
     cursor: pointer;
     transition: color 100ms;
     display: inline;
     border: none;
     font-family: inherit;
-    font-size: ${({ theme }): string => theme.Link.default.fontSize};
+    font-size: inherit;
     background-color: transparent;
     padding: 0;
 
     &:hover {
-        color: ${({ theme }): string => theme.Link.hover.color};
+        color: ${({ theme }): string => theme.Link.default.hover.color};
         background-color: transparent;
     }
 
     &:focus {
-        color: ${({ theme }): string => theme.Link.default.color};
+        color: ${({ theme }): string => theme.Link.default.idle.color};
         background-color: transparent;
 
         &:hover {
-            color: ${({ theme }: ThemePropsType): string => theme.Link.hover.color};
+            color: ${({ theme }: ThemePropsType): string => theme.Link.default.hover.color};
             background-color: transparent;
         }
     }
 `;
 
 const composeLinkTheme = (themeTools: ThemeTools): LinkThemeType => {
-    const { colors, text } = themeTools.themeSettings;
+    const { colors } = themeTools.themeSettings;
 
     return {
-        default: {
-            color: 'inherit',
+        common: {
             textDecoration: 'underline',
-            fontSize: text.fontSize.base,
         },
-        hover: {
-            color: colors.primary.base,
+        default: {
+            idle: {
+                color: 'inherit',
+            },
+            hover: {
+                color: colors.primary.base,
+            },
+        },
+        success: {
+            idle: {
+                color: 'inherit',
+            },
+            hover: {
+                color: colors.severity.success,
+            },
+        },
+        info: {
+            idle: {
+                color: 'inherit',
+            },
+            hover: {
+                color: colors.severity.info,
+            },
+        },
+        warning: {
+            idle: {
+                color: 'inherit',
+            },
+            hover: {
+                color: colors.severity.warning,
+            },
+        },
+        error: {
+            idle: {
+                color: 'inherit',
+            },
+            hover: {
+                color: colors.severity.error,
+            },
         },
     };
 };

--- a/packages/components/src/components/Notification/story.tsx
+++ b/packages/components/src/components/Notification/story.tsx
@@ -14,6 +14,7 @@ storiesOf('Notification', module)
     ))
     .add('With react node children', () => (
         <Notification severity="info">
-            A message with React nodes like a <Link title="Link" target="_blank" href="https://google.com" />
+            A message with React nodes like a&nbsp;
+            <Link severity="info" title="link" target="_blank" href="https://google.com" />
         </Notification>
     ));

--- a/packages/components/src/themes/MosTheme/MosTheme.theme.ts
+++ b/packages/components/src/themes/MosTheme/MosTheme.theme.ts
@@ -359,13 +359,48 @@ const theme: ThemeType = {
         size: '186px',
     },
     Link: {
-        default: {
-            color: colors.grey800,
+        common: {
             textDecoration: 'underline',
-            fontSize: fontSize.base,
         },
-        hover: {
-            color: colors.green400,
+        default: {
+            idle: {
+                color: 'inherit',
+            },
+            hover: {
+                color: colors.green400,
+            },
+        },
+        success: {
+            idle: {
+                color: 'inherit',
+            },
+            hover: {
+                color: colors.green900,
+            },
+        },
+        info: {
+            idle: {
+                color: 'inherit',
+            },
+            hover: {
+                color: colors.blue900,
+            },
+        },
+        warning: {
+            idle: {
+                color: 'inherit',
+            },
+            hover: {
+                color: colors.yellow900,
+            },
+        },
+        error: {
+            idle: {
+                color: 'inherit',
+            },
+            hover: {
+                color: colors.red900,
+            },
         },
     },
     MessageStream: {

--- a/packages/components/src/themes/MosTheme/MosTheme.theme.ts
+++ b/packages/components/src/themes/MosTheme/MosTheme.theme.ts
@@ -383,7 +383,7 @@ const theme: ThemeType = {
                 color: 'inherit',
             },
             hover: {
-                color: colors.blue900,
+                color: colors.blue800,
             },
         },
         warning: {
@@ -399,7 +399,7 @@ const theme: ThemeType = {
                 color: 'inherit',
             },
             hover: {
-                color: colors.red900,
+                color: colors.red800,
             },
         },
     },


### PR DESCRIPTION
BREAKING CHANGE: Adjusted Link theme object

### This PR:
resolves #605 

note: I removed the `fontSize` from the theme object as well and hard coded it as `inherit`. It wasn't being used in the anchor element anyway. The idea is that a Link should always be placed in a textual context, whether it be a `Text`, `Heading` or something else.

**Breaking changes** 🔥
- Adjusted `Link` theme object

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>