### PR TITLE
fix(Checkbox): Remove margin for label when there is no label

### DIFF
--- a/packages/components/src/components/Checkbox/index.tsx
+++ b/packages/components/src/components/Checkbox/index.tsx
@@ -47,7 +47,7 @@ class Checkbox extends Component<PropsType, StateType> {
 
         return (
             <Box onClick={this.changeHandler} data-testid={this.props['data-testid']} alignItems="flex-start">
-                <Box margin={[3, 12, 0, 0]}>
+                <Box margin={[3, this.props.label ? 12 : 0, 0, 0]}>
                     <StyledCheckboxSkin
                         checkedState={this.props.checked}
                         elementFocus={this.state.focus}


### PR DESCRIPTION
### This PR:

A margin was reserved in the `Checkbox` for its label, even when it wasn't rendered. This removes the margin when there is no label, fixing the spacing in the  `Table`.

**Bugfixes/Changed internals** 🎈
- Remove extra margin when `Checkbox` has no label.
 
**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>