### PR TITLE
feat!: Add checked error state to Checkbox

### DIFF
--- a/packages/components/src/components/Checkbox/story.tsx
+++ b/packages/components/src/components/Checkbox/story.tsx
@@ -1,4 +1,4 @@
-import { boolean, text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React, { FC, useState } from 'react';
 import Checkbox from '.';
@@ -6,13 +6,13 @@ import Checkbox from '.';
 type PropsType = {};
 
 const Demo: FC<PropsType> = () => {
-    const [checked, setChecked] = useState('indeterminate' as boolean | 'indeterminate');
+    const [checked, setChecked] = useState(select('checked', [true, false, 'indeterminate'], false));
 
     return (
         <Checkbox
             onChange={({ checked }): void => setChecked(checked)}
             value="bar"
-            checked={checked}
+            checked={checked as boolean | 'indeterminate'}
             disabled={boolean('disabled', false)}
             error={boolean('error', false)}
             name="foo"

--- a/packages/components/src/components/Checkbox/style.tsx
+++ b/packages/components/src/components/Checkbox/style.tsx
@@ -30,6 +30,9 @@ type CheckboxThemeType = {
     checkedDisabled: {
         backgroundColor: string;
     };
+    checkedError: {
+        backgroundColor: string;
+    };
     error: {
         borderColor: string;
         backgroundColor: string;
@@ -74,6 +77,10 @@ const StyledCheckboxSkin = styled.div<StyledCheckboxSkinType>`
 
     ${({ theme, disabled, checkedState, error }): string => {
         if (checkedState === 'indeterminate' || checkedState) {
+            if (error && checkedState) {
+                return `background-color: ${theme.Checkbox.checkedError.backgroundColor};`;
+            }
+
             if (disabled && checkedState) {
                 return `background-color: ${theme.Checkbox.checkedDisabled.backgroundColor};`;
             }
@@ -142,6 +149,9 @@ const composeCheckboxTheme = (themeTools: ThemeTools): CheckboxThemeType => {
         },
         checkedDisabled: {
             backgroundColor: colors.silver.darker2,
+        },
+        checkedError: {
+            backgroundColor: colors.severity.error,
         },
         error: {
             borderColor: colors.severity.error,

--- a/packages/components/src/components/Checkbox/test.tsx
+++ b/packages/components/src/components/Checkbox/test.tsx
@@ -78,7 +78,7 @@ describe('Checkbox', () => {
         expect(mockChangeHandler).not.toHaveBeenCalled();
     });
 
-    it('should show an error state', () => {
+    it('should show an error state when not checked', () => {
         const checkbox = mountWithTheme(
             <Checkbox onChange={(): void => undefined} name="demo" error={true} checked={false} value="bar" />,
         );
@@ -86,6 +86,17 @@ describe('Checkbox', () => {
         expect(checkbox.find(StyledCheckboxSkin)).toHaveStyleRule(
             'border',
             `1px solid ${mosTheme.Checkbox.error.borderColor}`,
+        );
+    });
+
+    it('should show an error state when checked', () => {
+        const checkbox = mountWithTheme(
+            <Checkbox onChange={(): void => undefined} name="demo" error={true} checked={true} value="bar" />,
+        );
+
+        expect(checkbox.find(StyledCheckboxSkin)).toHaveStyleRule(
+            'background-color',
+            `${mosTheme.Checkbox.checkedError.backgroundColor}`,
         );
     });
 

--- a/packages/components/src/themes/MosTheme/MosTheme.theme.ts
+++ b/packages/components/src/themes/MosTheme/MosTheme.theme.ts
@@ -251,6 +251,9 @@ const theme: ThemeType = {
         checkedDisabled: {
             backgroundColor: colors.grey200,
         },
+        checkedError: {
+            backgroundColor: colors.red400,
+        },
         error: {
             backgroundColor: rgba(colors.red100, 0.1),
             borderColor: colors.red600,


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- Adds `checkedError` state to the Checkbox, this changes the `ThemeType`.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>