### PR TITLE
fix(Table): Also show error state in undraggable rows

### DIFF
--- a/packages/components/src/components/Table/Row/index.tsx
+++ b/packages/components/src/components/Table/Row/index.tsx
@@ -96,7 +96,11 @@ class Row extends Component<PropsType, StateType> {
                         </Draggable>
                     );
                 }}
-                ifFalse={(children): JSX.Element => <StyledRow selected={this.props.selected}>{children}</StyledRow>}
+                ifFalse={(children): JSX.Element => (
+                    <StyledRow selected={this.props.selected} error={this.props.row.error}>
+                        {children}
+                    </StyledRow>
+                )}
             >
                 {this.props.selectable && (
                     <Cell align="start" width={'18px'}>


### PR DESCRIPTION
### This PR:

**Bugfixes/Changed internals** 🎈
- Missed the false condition of the `Branch` in `TableRow` when introducing the error state.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>