### PR TITLE
fix: Prevent box-shadow on Link buttons and IconButtons

### DIFF
--- a/packages/components/src/components/Button/base/index.tsx
+++ b/packages/components/src/components/Button/base/index.tsx
@@ -23,6 +23,7 @@ const ButtonBase: FunctionComponent<PropsType> = (props): JSX.Element => {
     const clickAction = (event: MouseEvent<HTMLButtonElement>): void => {
         if (props.onClick !== undefined && props.disabled !== true && props.loading !== true) {
             props.onClick(event);
+            event.stopPropagation();
         }
     };
 

--- a/packages/components/src/components/IconButton/index.tsx
+++ b/packages/components/src/components/IconButton/index.tsx
@@ -37,6 +37,7 @@ const StyledIconButton = styled(BareButton)<Pick<PropsType, 'variant'>>`
         const idle = `
             transform: none;
             background-color: transparent;
+            box-shadow: none;
             color: ${theme.IconButton[buttonVariant].idle.color};
         `;
 

--- a/packages/components/src/components/Link/style.tsx
+++ b/packages/components/src/components/Link/style.tsx
@@ -114,6 +114,7 @@ const StyledButton = styled.button`
     font-size: inherit;
     background-color: transparent;
     padding: 0;
+    box-shadow: none;
 
     &:hover {
         color: ${({ theme, severity }: ThemePropsType): string => theme.Link[severity].hover.color};


### PR DESCRIPTION
### This PR:

In some places, the `Link`, when used as a button, and `IconButton` components received box-shadows from legacy stylesheets. This PR explicitly sets them to none to prevent this.

**Bugfixes/Changed internals** 🎈
- No more box-shadow for `Link` and `IconButton`


<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>