### PR TITLE
chore: Moved title under media when small

### DIFF
--- a/packages/components/src/components/Modal/index.tsx
+++ b/packages/components/src/components/Modal/index.tsx
@@ -124,6 +124,10 @@ const Modal: FC<PropsType> = props => {
                             scrollBoxTopPadding = 36;
                         }
 
+                        if (!isSplit && props.media) {
+                            scrollBoxTopPadding = 24;
+                        }
+
                         let scrollBoxPadding: PaddingType = [scrollBoxTopPadding, 36, 36, 36];
 
                         if (isSmall) {
@@ -188,7 +192,7 @@ const Modal: FC<PropsType> = props => {
                                             {props.media}
                                         </MediaWrapper>
                                     )}
-                                    {!isSplit && (
+                                    {!isSplit && !props.media && (
                                         <Box direction="column" padding={headingPadding}>
                                             {heading}
                                         </Box>
@@ -200,7 +204,7 @@ const Modal: FC<PropsType> = props => {
                                                     {props.media}
                                                 </MediaWrapper>
                                             )}
-                                            {isSplit && (
+                                            {(isSplit || (!isSplit && props.media)) && (
                                                 <Box margin={[0, 0, 12, 0]} direction="column">
                                                     {heading}
                                                 </Box>


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- Modal with media now has the title moved under the media on `size=small`

**Bugfixes/Changed internals** 🎈
- None

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>