### PR TITLE
fix: Adjust bricks-assets peerDependency version

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -60,7 +60,7 @@
     "styled-components": "^5.0.0"
   },
   "peerDependencies": {
-    "@myonlinestore/bricks-assets": "0.2.0",
+    "@myonlinestore/bricks-assets": "^0.2.0",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
     "react": "^16.8.0",


### PR DESCRIPTION
### This PR:

The pinned version of `bricks-assets` in `bricks` causes dependency errors when you have a higher version installed.

**Bugfixes/Changed internals** 🎈
- `bricks-assets` version no longer pinned in `bricks` package

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>