### PR TITLE
chore: Added hover/disabled states to FileInput component

### DIFF
--- a/packages/components/src/components/FileInput/index.tsx
+++ b/packages/components/src/components/FileInput/index.tsx
@@ -12,6 +12,7 @@ export type InputSeverityType = 'error';
 
 export type PropsType = {
     name: string;
+    disabled?: boolean;
     feedback?: {
         'data-testid'?: string;
         severity: SeverityType;
@@ -38,7 +39,7 @@ const FileInput: FC<PropsType> = props => {
         <>
             <StyledWrapper
                 focus={draggingOver}
-                disabled={false}
+                disabled={props.disabled}
                 hasPreview={typeof preview === 'string'}
                 severity={props.feedback?.severity === 'error' ? props.feedback.severity : undefined}
                 height="230px"
@@ -55,6 +56,7 @@ const FileInput: FC<PropsType> = props => {
                     </Box>
                 )}
                 <StyledFileInput
+                    disabled={props.disabled}
                     ref={ref => {
                         inputRef.current = ref;
                     }}

--- a/packages/components/src/components/FileInput/story.tsx
+++ b/packages/components/src/components/FileInput/story.tsx
@@ -2,18 +2,35 @@ import { storiesOf } from '@storybook/react';
 import React from 'react';
 import Component from './index';
 
-storiesOf('FileInput', module).add('Default', () => {
-    return (
-        <Component
-            name="HelloWorld"
-            placeholder={
-                <>
-                    Drag and drop here
-                    <br />
-                    or <u>browse</u>
-                </>
-            }
-            dropPlaceholder={<>Drop your file here</>}
-        />
-    );
-});
+storiesOf('FileInput', module)
+    .add('Default', () => {
+        return (
+            <Component
+                name="HelloWorld"
+                placeholder={
+                    <>
+                        Drag and drop here
+                        <br />
+                        or <u>browse</u>
+                    </>
+                }
+                dropPlaceholder={<>Drop your file here</>}
+            />
+        );
+    })
+    .add('Disabled', () => {
+        return (
+            <Component
+                name="HelloWorld"
+                placeholder={
+                    <>
+                        Drag and drop here
+                        <br />
+                        or <u>browse</u>
+                    </>
+                }
+                dropPlaceholder={<>Drop your file here</>}
+                disabled
+            />
+        );
+    });

--- a/packages/components/src/components/FileInput/style.tsx
+++ b/packages/components/src/components/FileInput/style.tsx
@@ -17,6 +17,12 @@ export type FileInputThemeType = {
             borderColor: string;
             background: string;
         };
+        hover: {
+            borderColor: string;
+            boxShadow: string;
+            background: string;
+            color: string;
+        };
         focus: {
             borderColor: string;
             boxShadow: string;
@@ -56,6 +62,7 @@ export const StyledFileInput = styled.input`
     right: 0;
     top: 0;
     bottom: 0;
+    cursor: pointer;
 `;
 
 export const StyledWrapper = styled(Box)<WrapperPropsType>`
@@ -106,6 +113,20 @@ export const StyledWrapper = styled(Box)<WrapperPropsType>`
             background: ${theme.FileInput.input.idle.background};
             border: dashed 1px ${theme.FileInput.input.idle.borderColor};
             box-shadow: none;
+
+            u {
+                transition: color 300ms;
+            }
+
+            &:hover {
+                background-color: ${theme.FileInput.input.hover.background};
+                box-shadow: ${theme.FileInput.input.hover.boxShadow};
+                border: solid 1px ${theme.FileInput.input.hover.borderColor};
+
+                u {
+                    color: ${theme.FileInput.input.hover.color}
+                }
+            }
         `;
     }}
 `;
@@ -125,6 +146,12 @@ export const composeFileInputTheme = (themeTools: ThemeTools): FileInputThemeTyp
                 color: forms.color,
                 borderColor: forms.borderColor,
                 background: forms.background,
+            },
+            hover: {
+                borderColor: forms.borderColor,
+                color: forms.activeColor,
+                background: `${chroma(colors.primary.lighter1).alpha(0.1)}`,
+                boxShadow: `0 0 0 4px ${chroma(forms.focusBorderColor).alpha(0.4)}`,
             },
             focus: {
                 borderColor: forms.focusBorderColor,

--- a/packages/components/src/components/FileInput/style.tsx
+++ b/packages/components/src/components/FileInput/style.tsx
@@ -105,7 +105,10 @@ export const StyledWrapper = styled(Box)<WrapperPropsType>`
                 background: ${theme.FileInput.input.disabled.background};
                 border: solid 1px ${theme.FileInput.input.disabled.borderColor};
                 box-shadow: none;
-                cursor: not-allowed;
+
+                input {
+                    cursor: not-allowed;
+                }
             `;
         }
 

--- a/packages/components/src/themes/MosTheme/MosTheme.theme.ts
+++ b/packages/components/src/themes/MosTheme/MosTheme.theme.ts
@@ -40,6 +40,12 @@ const theme: ThemeType = {
                 borderColor: colors.grey300,
                 color: colors.grey600,
             },
+            hover: {
+                borderColor: colors.grey300,
+                background: rgba(0, 0, 0, 0.03),
+                boxShadow: 'none',
+                color: colors.green600,
+            },
             focus: {
                 borderColor: colors.green600,
                 background: `${rgba(colors.green100, 0.1)}`,


### PR DESCRIPTION
### This PR:

**Based upon BIER-2951!**

**Backwards compatible additions** ✨
- Added hover/disabled states to FileInput component

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>