### PR TITLE
chore: Added value and onError props to FileInput

### DIFF
--- a/packages/components/src/components/FileInput/index.tsx
+++ b/packages/components/src/components/FileInput/index.tsx
@@ -10,17 +10,25 @@ import { ThemeContext } from 'styled-components';
 
 export type InputSeverityType = 'error';
 
+export type FeedbackType = {
+    'data-testid'?: string;
+    severity: SeverityType;
+    message: string;
+};
+
 export type PropsType = {
     name: string;
+    value?: {
+        url: string;
+        alt: string;
+    };
     disabled?: boolean;
     accept: Array<string>;
-    feedback?: {
-        'data-testid'?: string;
-        severity: SeverityType;
-        message: string;
-    };
+    feedback?: FeedbackType;
     placeholder: ReactNode;
     dropPlaceholder: ReactNode;
+    onError(error: string | null): void;
+    onResetError(): void;
 };
 
 const FileInput: FC<PropsType> = props => {
@@ -36,6 +44,26 @@ const FileInput: FC<PropsType> = props => {
         }
     }, [focus]);
 
+    const whatImageToDisplay = (): { source: string; alt: string } | null => {
+        if (typeof preview === 'string') {
+            return {
+                source: preview,
+                alt: previewFilename,
+            };
+        }
+
+        if (props.value?.url) {
+            return {
+                source: props.value.url,
+                alt: props.value.alt,
+            };
+        }
+
+        return null;
+    };
+
+    const image = whatImageToDisplay();
+
     return (
         <>
             <StyledWrapper
@@ -48,8 +76,8 @@ const FileInput: FC<PropsType> = props => {
                 justifyContent="center"
                 alignItems="center"
             >
-                {typeof preview === 'string' ? (
-                    <StyledPreviewImage src={preview} alt={previewFilename || 'Preview'} />
+                {image ? (
+                    <StyledPreviewImage src={image.source} alt={image.alt} />
                 ) : (
                     <Box direction="column" justifyContent="center" alignItems="center">
                         <Icon icon={<CloudUploadIcon />} size="large" color={themeContext.FileInput.common.iconColor} />
@@ -80,9 +108,14 @@ const FileInput: FC<PropsType> = props => {
                             const reader = new FileReader();
 
                             reader.onload = event => {
+                                setPreview(null);
+                                setPreviewFilename('');
+
                                 if (props.accept && !props.accept.includes(firstFile.type)) {
-                                    return false;
+                                    throw props.onError('Filetype not accepted.');
                                 }
+
+                                props.onResetError();
 
                                 setPreview(event?.target?.result);
                                 setPreviewFilename(firstFile.name);

--- a/packages/components/src/components/FileInput/index.tsx
+++ b/packages/components/src/components/FileInput/index.tsx
@@ -113,6 +113,7 @@ const FileInput: FC<PropsType> = props => {
 
                                 if (props.accept && !props.accept.includes(firstFile.type)) {
                                     props.onError('Filetype not accepted.');
+
                                     return;
                                 }
 

--- a/packages/components/src/components/FileInput/index.tsx
+++ b/packages/components/src/components/FileInput/index.tsx
@@ -112,7 +112,8 @@ const FileInput: FC<PropsType> = props => {
                                 setPreviewFilename('');
 
                                 if (props.accept && !props.accept.includes(firstFile.type)) {
-                                    throw props.onError('Filetype not accepted.');
+                                    props.onError('Filetype not accepted.');
+                                    return;
                                 }
 
                                 props.onResetError();

--- a/packages/components/src/components/FileInput/story.tsx
+++ b/packages/components/src/components/FileInput/story.tsx
@@ -1,5 +1,5 @@
-import React, { ComponentProps } from 'react';
-import FileInput from './index';
+import React, { ComponentProps, useState } from 'react';
+import FileInput, { FeedbackType } from './index';
 
 export default {
     title: 'FileInput',
@@ -19,7 +19,47 @@ export default {
 };
 
 export const Default = (props: ComponentProps<typeof FileInput>) => {
-    return <FileInput {...props} />;
+    const [error, setError] = useState<null | FeedbackType>(null);
+
+    return (
+        <FileInput
+            {...props}
+            onError={(error: string) => {
+                if (error === 'Filetype not accepted.') {
+                    setError({
+                        message: 'Sorry, that’s not a valid image file. Please choose a JPG, .PNG, or .GIF file.',
+                        severity: 'error',
+                    });
+                }
+            }}
+            onResetError={() => setError(null)}
+            feedback={error !== null ? error : undefined}
+        />
+    );
+};
+
+export const WithValue = (props: ComponentProps<typeof FileInput>) => {
+    const [error, setError] = useState<null | FeedbackType>(null);
+
+    return (
+        <FileInput
+            {...props}
+            value={{
+                url: 'https://thisisthedailyrad.files.wordpress.com/2013/02/large_193482-1915212.jpg',
+                alt: 'Roaling Coal Volvo 242',
+            }}
+            onError={(error: string) => {
+                if (error === 'Filetype not accepted.') {
+                    setError({
+                        message: 'Sorry, that’s not a valid image file. Please choose a JPG, .PNG, or .GIF file.',
+                        severity: 'error',
+                    });
+                }
+            }}
+            onResetError={() => setError(null)}
+            feedback={error !== null ? error : undefined}
+        />
+    );
 };
 
 export const Disabled = (props: ComponentProps<typeof FileInput>) => {


### PR DESCRIPTION
### This PR:

**Bugfixes/Changed internals** 🎈
- Added value and onError props to FileInput

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>