### PR TITLE
feat: Added hover color to TextualButton

### DIFF
--- a/packages/components/src/components/TextualButton/index.tsx
+++ b/packages/components/src/components/TextualButton/index.tsx
@@ -7,11 +7,13 @@ import Icon from '../Icon';
 export type PropsType = BasePropsType & {
     variant: 'primary' | 'secondary';
     icon?: ReactNode;
+    alignIcon?: 'left' | 'right';
 };
 
 type VariantType = {
     color: string;
     fontWeight: number;
+    hoverColor: string;
 };
 
 export type TextualButtonThemeType = {
@@ -26,12 +28,12 @@ const StyledTextualButton = styled(Base)<PropsType>`
 
     &:hover {
         background-color: transparent;
-        color: ${({ theme, variant }) => theme.TextualButton[variant].color};
+        color: ${({ theme, variant }) => theme.TextualButton[variant].hoverColor};
     }
 
     &:focus {
         background-color: transparent;
-        color: ${({ theme, variant }) => theme.TextualButton[variant].color};
+        color: ${({ theme, variant }) => theme.TextualButton[variant].hoverColor};
     }
 `;
 
@@ -40,18 +42,23 @@ const StyledTextContainer = styled.span<Pick<PropsType, 'variant'> & { hover: bo
 
     &::before {
         content: '';
-        transition: background 300ms;
         position: absolute;
         bottom: 1px;
         left: 0;
         width: 100%;
         height: 1px;
-        background: ${({ theme, variant, hover }) => (hover ? theme.TextualButton[variant].color : 'transparent')};
+        background: ${({ theme, variant, hover }) => (hover ? theme.TextualButton[variant].hoverColor : 'transparent')};
     }
+`;
+
+const Spacer = styled.span`
+    width: 6px;
+    display: inline-block;
 `;
 
 const TextualButton: FC<PropsType> = props => {
     const [isHovering, setHovering] = useState(false);
+    const alignIcon = props.alignIcon || 'right';
 
     return (
         <StyledTextualButton
@@ -64,10 +71,16 @@ const TextualButton: FC<PropsType> = props => {
             }}
         >
             <StyledTextContainer variant={props.variant} hover={isHovering}>
-                {Children.count(props.children) > 0 ? props.children : props.title}
-                {props.icon && (
+                {props.icon && alignIcon === 'left' && (
                     <>
-                        &nbsp;
+                        <Icon size="small" icon={props.icon} />
+                        <Spacer />
+                    </>
+                )}
+                <span>{Children.count(props.children) > 0 ? props.children : props.title}</span>
+                {props.icon && alignIcon === 'right' && (
+                    <>
+                        <Spacer />
                         <Icon size="small" icon={props.icon} />
                     </>
                 )}
@@ -81,10 +94,12 @@ export const composeTextualButton = (tools: ThemeTools): TextualButtonThemeType 
         primary: {
             color: tools.themeSettings.colors.primary.darker2,
             fontWeight: 600,
+            hoverColor: tools.themeSettings.colors.primary.darker2,
         },
         secondary: {
             color: tools.calculateContrastTextColor(tools.themeSettings.colors.background),
             fontWeight: 600,
+            hoverColor: tools.calculateContrastTextColor(tools.themeSettings.colors.background),
         },
     };
 };

--- a/packages/components/src/components/TextualButton/story.tsx
+++ b/packages/components/src/components/TextualButton/story.tsx
@@ -1,30 +1,48 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import TextualButton, { PropsType } from '.';
-import { ChevronRightIcon } from '@myonlinestore/bricks-assets';
+import { ChevronRightIcon, ArrowLeftIcon } from '@myonlinestore/bricks-assets';
 import { select } from '@storybook/addon-knobs';
 
-storiesOf('Buttons/TextualButton', module)
-    .add('Default', () => {
-        return (
-            <TextualButton
-                icon={<ChevronRightIcon />}
-                variant={select('variant', ['primary', 'secondary'], 'primary') as PropsType['variant']}
-                title="Click me"
-            >
-                Click me
-            </TextualButton>
-        );
-    })
-    .add('As an anchor', () => {
-        return (
-            <TextualButton
-                icon={<ChevronRightIcon />}
-                href=""
-                variant={select('variant', ['primary', 'secondary'], 'primary') as PropsType['variant']}
-                title="Click me"
-            >
-                Click me
-            </TextualButton>
-        );
-    });
+export default {
+    title: 'Button/TextualButton',
+    component: TextualButton,
+};
+
+export const Default = () => {
+    return (
+        <TextualButton
+            icon={<ChevronRightIcon />}
+            variant={select('variant', ['primary', 'secondary'], 'primary') as PropsType['variant']}
+            title="Click me"
+        >
+            Click me
+        </TextualButton>
+    );
+};
+
+export const AsAnAnchor = () => {
+    return (
+        <TextualButton
+            icon={<ChevronRightIcon />}
+            href=""
+            variant={select('variant', ['primary', 'secondary'], 'primary') as PropsType['variant']}
+            title="Click me"
+        >
+            Click me
+        </TextualButton>
+    );
+};
+
+export const WithIconLeft = () => {
+    return (
+        <TextualButton
+            icon={<ArrowLeftIcon />}
+            alignIcon="left"
+            href=""
+            variant={select('variant', ['primary', 'secondary'], 'primary') as PropsType['variant']}
+            title="Click me"
+        >
+            Text
+        </TextualButton>
+    );
+};

--- a/packages/components/src/themes/MosTheme/MosTheme.theme.ts
+++ b/packages/components/src/themes/MosTheme/MosTheme.theme.ts
@@ -891,10 +891,12 @@ const theme: ThemeType = {
         primary: {
             color: colors.green500,
             fontWeight: 400,
+            hoverColor: colors.green500,
         },
         secondary: {
-            color: colors.grey800,
+            color: colors.grey500,
             fontWeight: 400,
+            hoverColor: colors.green500,
         },
     },
     Tile: {


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- You can now style the hover color of the `TextualButton`

**Bugfixes/Changed internals** 🎈
- none

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>