### PR TITLE
feat!: Add 'default' Notification variant

### DIFF
--- a/packages/components/src/components/Notification/index.tsx
+++ b/packages/components/src/components/Notification/index.tsx
@@ -4,16 +4,24 @@ import Icon from '../Icon';
 import Box from '../Box';
 import StyledNotification from './style';
 import { SeverityIcons } from '../../types/SeverityType';
+import { InfoCircleIcon } from '@myonlinestore/bricks-assets';
 
 type PropsType = {
-    severity: keyof typeof SeverityIcons;
+    severity: keyof typeof SeverityIcons | 'default';
     message?: string;
     icon?: ReactNode;
     'data-testid'?: string;
 };
 
 const Notification: FunctionComponent<PropsType> = (props): JSX.Element => {
-    const icon = props.icon !== undefined ? props.icon : SeverityIcons[props.severity];
+    const icon =
+        props.icon !== undefined ? (
+            props.icon
+        ) : props.severity === 'default' ? (
+            <InfoCircleIcon />
+        ) : (
+            SeverityIcons[props.severity]
+        );
 
     return (
         <StyledNotification severity={props.severity} data-testid={props['data-testid']}>

--- a/packages/components/src/components/Notification/story.tsx
+++ b/packages/components/src/components/Notification/story.tsx
@@ -5,6 +5,7 @@ import { MehIcon } from '@myonlinestore/bricks-assets';
 import Link from '../Link';
 
 storiesOf('Notification', module)
+    .add('Default', () => <Notification severity="default" message="A message with default styling" />)
     .add('Success', () => <Notification severity="success" message="Wow, Great job!" />)
     .add('Error', () => <Notification severity="error" message="Oops, something wen't wrong. Please try again." />)
     .add('Warning', () => <Notification severity="warning" message="Careful, this might go wrong." />)

--- a/packages/components/src/components/Notification/style.tsx
+++ b/packages/components/src/components/Notification/style.tsx
@@ -14,6 +14,7 @@ type NotificationThemeType = {
         fontSize: string;
         borderRadius: string;
     };
+    default: VariantStyleType;
     error: VariantStyleType;
     info: VariantStyleType;
     success: VariantStyleType;
@@ -21,7 +22,7 @@ type NotificationThemeType = {
 };
 
 type PropsType = {
-    severity: SeverityType;
+    severity: SeverityType | 'default';
 };
 
 const StyledNotification = styled.div<PropsType>`
@@ -48,6 +49,12 @@ const composeNotificationTheme = (themeTools: ThemeTools): NotificationThemeType
             fontSize: text.fontSize.base,
             // no common borderRadius in themeTools yet
             borderRadius: '0px',
+        },
+        default: {
+            color: colors.silver.lighter1,
+            backgroundColor: chroma(colors.grey.darker1)
+                .set('hsl.l', 0.93)
+                .hex(),
         },
         error: {
             color: colors.severity.error,

--- a/packages/components/src/themes/MosTheme/MosTheme.theme.ts
+++ b/packages/components/src/themes/MosTheme/MosTheme.theme.ts
@@ -497,6 +497,10 @@ const theme: ThemeType = {
             fontSize: fontSize.base,
             borderRadius: '3px',
         },
+        default: {
+            color: colors.grey700,
+            backgroundColor: colors.grey200,
+        },
         error: {
             color: colors.red700,
             backgroundColor: colors.red100,


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- Adds 'default' to `Notification` themetype

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>