### PR TITLE
feat: Checkbox and RadioButton now support a ReactNode as label

### DIFF
--- a/packages/components/src/components/Checkbox/index.tsx
+++ b/packages/components/src/components/Checkbox/index.tsx
@@ -1,4 +1,4 @@
-import React, { Component, MouseEvent } from 'react';
+import React, { ReactNode, Component, MouseEvent } from 'react';
 import Icon from '../Icon';
 import { StyledCheckbox, StyledCheckboxSkin } from './style';
 import Box from '../Box';
@@ -15,7 +15,7 @@ type PropsType = {
     error?: boolean;
     value: string;
     name: string;
-    label?: string;
+    label?: ReactNode;
     id?: string;
     'data-testid'?: string;
     onChange(change: { checked: boolean | 'indeterminate'; event: MouseEvent<HTMLDivElement> }): void;
@@ -46,7 +46,13 @@ class Checkbox extends Component<PropsType, StateType> {
         const htmlChecked = this.props.checked === true;
 
         return (
-            <Box onClick={this.changeHandler} data-testid={this.props['data-testid']} alignItems="flex-start">
+            <Box
+                style={{ cursor: 'pointer' }}
+                onClick={this.changeHandler}
+                data-testid={this.props['data-testid']}
+                alignItems="flex-start"
+                grow={1}
+            >
                 <Box margin={[3, this.props.label ? 12 : 0, 0, 0]}>
                     <StyledCheckboxSkin
                         checkedState={this.props.checked}

--- a/packages/components/src/components/RadioButton/index.tsx
+++ b/packages/components/src/components/RadioButton/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, ReactNode, useState } from 'react';
 import Box from '../Box';
 import Text from '../Text';
 import StyledRadioButton, { StyledRadioButtonSkin, StyledRadioWrapper } from './style';
@@ -14,7 +14,7 @@ type PropsType = {
     value: string;
     name: string;
     id?: string;
-    label: string;
+    label: ReactNode;
     'data-testid'?: string;
     onChange(change: { checked: boolean; value: string }): void;
 };

--- a/packages/components/src/components/RadioButton/style.tsx
+++ b/packages/components/src/components/RadioButton/style.tsx
@@ -43,6 +43,7 @@ type RadioButtonThemeType = {
 const StyledRadioWrapper = styled.div`
     display: flex;
     align-items: flex-start;
+    flex-grow: 1;
 `;
 
 const StyledRadioButton = styled.input<RadioButtonPropsType>`


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- Checkbox and RadioButton now support a ReactNode as label
- Checkbox and RadioButton now also have a grow of 1

**Bugfixes/Changed internals** 🎈
- None

**Checklist** 🛡
- [ ] I have exported my addition from `src/index.ts` (check if not applicable).
- [ ] Appropriate tests have been added for my functionality (check if not applicable).
- [ ] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [ ] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [ ] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>