### PR TITLE
feat!: Select.Search now has to be passed in through search prop

### DIFF
--- a/packages/components/src/components/Select/SelectOption.tsx
+++ b/packages/components/src/components/Select/SelectOption.tsx
@@ -12,7 +12,7 @@ type ContainerPropsType = {
     isTargeted: boolean;
 };
 
-const SelectOptionContainer = styled.div<ContainerPropsType>`
+export const SelectOptionContainer = styled.div<ContainerPropsType>`
     cursor: pointer;
     background: ${({ theme, isTargeted }): string =>
         isTargeted ? theme.Select.option.hover.background : 'transparent'};

--- a/packages/components/src/components/Select/SelectSearch.tsx
+++ b/packages/components/src/components/Select/SelectSearch.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ChangeEvent, RefObject, useContext } from 'react';
+import React, { FC, ChangeEvent, useContext, useRef, useEffect } from 'react';
 import Box from '../Box';
 import Icon from '../Icon';
 import styled, { withTheme } from 'styled-components';
@@ -62,7 +62,6 @@ const SelectSearchInner = styled.div<SearchPropsType>`
 `;
 
 type PropsType = {
-    inputRef: RefObject<HTMLInputElement>;
     placeholder: string;
     theme: ThemeType;
     'data-testid'?: string;
@@ -70,13 +69,21 @@ type PropsType = {
 
 const SelectSearch: FC<PropsType> = props => {
     const { filter, setFilter, isOpen, setOpen, isDisabled, hasFocus } = useContext(SelectContext);
+    const ref = useRef<HTMLInputElement>();
+
+    /** Focus the input field when the field gets opened */
+    useEffect(() => {
+        if (isOpen) {
+            ref.current?.focus();
+        }
+    }, [isOpen]);
 
     return (
         <SelectSearchContainer
             role="searchbox"
             aria-autocomplete="list"
             aria-controls={isOpen ? 'select-window' : undefined}
-            data-testid={props['data-testid'] ? `${props['data-testid']}-input` : undefined}
+            data-testid={props['data-testid']}
             onClick={() => {
                 if (!isOpen) {
                     setOpen(true);
@@ -90,11 +97,15 @@ const SelectSearch: FC<PropsType> = props => {
                             <Icon icon={<SearchIcon />} size="small" color={colors.grey400} />
                         </Box>
                         <input
-                            ref={props.inputRef}
+                            ref={inputRef => {
+                                if (inputRef) {
+                                    ref.current = inputRef;
+                                }
+                            }}
                             type="text"
                             placeholder={props.placeholder}
                             value={filter}
-                            data-testid={props['data-testid'] ? `${props['data-testid']}-input-field` : undefined}
+                            data-testid={props['data-testid'] ? `${props['data-testid']}-input` : undefined}
                             onChange={(event: ChangeEvent<HTMLInputElement>): void => {
                                 event.stopPropagation();
                                 setFilter(event.target.value);

--- a/packages/components/src/components/Select/index.tsx
+++ b/packages/components/src/components/Select/index.tsx
@@ -35,6 +35,7 @@ type PropsType<GenericOptionType extends OptionBaseType> = {
     options?: Array<GenericOptionType>;
     emptyText: string;
     disabled?: boolean;
+    search?: ReactNode;
     'data-testid'?: string;
     onChange(value: string): void;
     renderOption?(option: GenericOptionType, state: OptionStateType): JSX.Element;
@@ -68,9 +69,18 @@ export const SelectContext = createContext({
     },
 });
 
+/**
+ * This Select component renders a non-native select component that has the option to:
+ * - custom render it's options
+ * - add hierarchy to it's options
+ * - optionally add a search bar to filter options
+ *
+ * If you need none of these features, please refer to the <NativeSelect /> since it has
+ * better performance on large sets and provides a better UI on mobile devices.
+ */
+
 const Select = <GenericOptionType extends OptionBaseType>(props: PropsType<GenericOptionType>): ReactElement => {
     const initialRender = useRef(true);
-    const inputRef = useRef<HTMLInputElement | null>(null);
     const wrapperRef = useRef<HTMLDivElement | null>(null);
     const modalRef = useRef<HTMLDivElement | null>(null);
     const [hasFocus, setFocus] = useState(false);
@@ -210,9 +220,7 @@ const Select = <GenericOptionType extends OptionBaseType>(props: PropsType<Gener
 
     /** Focus the input field when the field gets opened */
     useEffect(() => {
-        if (isOpen) {
-            inputRef.current?.focus();
-        } else if (!initialRender.current) {
+        if (!isOpen && !initialRender.current) {
             wrapperRef.current?.focus();
         }
     }, [isOpen]);
@@ -272,11 +280,7 @@ const Select = <GenericOptionType extends OptionBaseType>(props: PropsType<Gener
                     modalRef={modalRef}
                     data-testid={props['data-testid']}
                 >
-                    <SelectSearch
-                        inputRef={inputRef}
-                        placeholder={props.placeholder || ''}
-                        data-testid={props['data-testid']}
-                    />
+                    {props.search}
                     <SelectList isOpen={isOpen} emptyText={props.emptyText || ''} data-testid={props['data-testid']}>
                         {props.options?.map(option => {
                             const optionState = { isSelected: option.value === props.value };
@@ -316,10 +320,12 @@ SelectOptionGroup.displayName = 'Select.OptionGroup';
  */
 
 type SelectType = typeof SelectWithTheme & {
+    Search: typeof SelectSearch;
     Option: typeof SelectOption;
     OptionGroup: typeof SelectOptionGroup;
 };
 
+(SelectWithTheme as SelectType).Search = SelectSearch;
 (SelectWithTheme as SelectType).Option = SelectOption;
 (SelectWithTheme as SelectType).OptionGroup = SelectOptionGroup;
 

--- a/packages/components/src/components/Select/story.tsx
+++ b/packages/components/src/components/Select/story.tsx
@@ -273,4 +273,26 @@ storiesOf('Select', module)
                 <Select.Option label="Option L" value="l" />
             </Select>
         );
+    })
+    .add('With search', () => {
+        const [value, setValue] = useState('');
+
+        return (
+            <Select
+                value={value}
+                emptyText="No results"
+                placeholder="Select a value"
+                search={<Select.Search placeholder="Search a value" />}
+                onChange={value => {
+                    setValue(value);
+                }}
+            >
+                <Select.Option label="Option A" value="a" />
+                <Select.Option label="Option B" value="b" />
+                <Select.Option label="Option C" value="c" />
+                <Select.Option label="Option D" value="d" />
+                <Select.Option label="Option E" value="e" />
+                <Select.Option label="Option F" value="f" />
+            </Select>
+        );
     });

--- a/packages/components/src/components/Select/test.tsx
+++ b/packages/components/src/components/Select/test.tsx
@@ -113,6 +113,7 @@ describe('Select', () => {
     it('should show an input and options on click', () => {
         const component = mountWithTheme(
             <Select
+                search={<Select.Search placeholder="foo" data-testid="select-search" />}
                 onChange={(): void => undefined}
                 value=""
                 emptyText="empty"
@@ -125,14 +126,15 @@ describe('Select', () => {
             key: ' ',
         });
 
-        expect(component.find('input').length).toBe(1);
-        expect(component.findByTestId('select-input-field')).toHaveLength(1);
+        expect(component.findByTestId('select-search').length).toBe(1);
+        expect(component.findByTestId('select-search-input')).toHaveLength(1);
         expect(component.find('[data-testid^="select-option-"]').hostNodes().length).toBe(options.length);
     });
 
     it('should filter options on input', () => {
         const component = mountWithTheme(
             <Select
+                search={<Select.Search placeholder="foo" data-testid="select-search" />}
                 onChange={(): void => undefined}
                 value=""
                 emptyText="empty"
@@ -182,6 +184,7 @@ describe('Select', () => {
 
         const component = mountWithTheme(
             <Select
+                search={<Select.Search placeholder="foo" data-testid="select-search" />}
                 onChange={(): void => undefined}
                 value=""
                 emptyText="empty"
@@ -190,7 +193,7 @@ describe('Select', () => {
             />,
         );
 
-        component.findByTestId('select-input').simulate('click');
+        component.findByTestId('select-search').simulate('click');
 
         expect(component.findByTestId('select-window-open')).toHaveLength(1);
 
@@ -396,10 +399,17 @@ describe('Select', () => {
 
     it('should target an Option when mouse enters', () => {
         const component = mountWithTheme(
-            <Select onChange={(): void => undefined} value="" emptyText="" options={options} data-testid="select" />,
+            <Select
+                search={<Select.Search placeholder="foo" data-testid="select-search" />}
+                onChange={(): void => undefined}
+                value=""
+                emptyText=""
+                options={options}
+                data-testid="select"
+            />,
         );
 
-        component.findByTestId('select-input').simulate('click');
+        component.findByTestId('select-search').simulate('click');
 
         component.findByTestId('select-option-C').simulate('mouseEnter');
 
@@ -409,6 +419,7 @@ describe('Select', () => {
     it('should not open the Option-Select window when the component is disabled', () => {
         const component = mountWithTheme(
             <Select
+                search={<Select.Search placeholder="foo" data-testid="select-search" />}
                 onChange={(): void => undefined}
                 value=""
                 emptyText=""
@@ -420,7 +431,7 @@ describe('Select', () => {
 
         expect(component.findByTestId('select-window-closed')).toHaveLength(1);
 
-        component.findByTestId('select-input').simulate('click');
+        component.findByTestId('select-search').simulate('click');
 
         expect(component.findByTestId('select-window-closed')).toHaveLength(1);
     });
@@ -430,6 +441,7 @@ describe('Select', () => {
             return (
                 <MosTheme>
                     <Select
+                        search={<Select.Search placeholder="foo" data-testid="select-search" />}
                         onChange={(): void => undefined}
                         value=""
                         emptyText=""
@@ -443,7 +455,7 @@ describe('Select', () => {
 
         const component = mount(<Root />);
 
-        component.findByTestId('select-input').simulate('click');
+        component.findByTestId('select-search').simulate('click');
 
         expect(component.findByTestId('select-window-open')).toHaveLength(1);
 
@@ -470,12 +482,19 @@ describe('Select', () => {
         const changeMock = jest.fn();
 
         const component = mountWithTheme(
-            <Select onChange={changeMock} value="" emptyText="" options={options} data-testid="select" />,
+            <Select
+                search={<Select.Search data-testid="select-search" placeholder="foo" />}
+                onChange={changeMock}
+                value=""
+                emptyText=""
+                options={options}
+                data-testid="select"
+            />,
         );
 
-        component.findByTestId('select-input').simulate('click');
+        component.findByTestId('select-search').simulate('click');
 
-        component.findByTestId('select-input-field').simulate('change', {
+        component.findByTestId('select-search-input').simulate('change', {
             target: {
                 value: 'Foo',
             },
@@ -499,6 +518,7 @@ describe('Select', () => {
     it('should display the empty text when all options are filtered out', () => {
         const component = mountWithTheme(
             <Select
+                search={<Select.Search placeholder="foo" data-testid="select-search" />}
                 onChange={(): void => undefined}
                 value=""
                 emptyText="empty"
@@ -520,7 +540,7 @@ describe('Select', () => {
             key: ' ',
         });
 
-        component.find('input').simulate('change', {
+        component.findByTestId('select-search-input').simulate('change', {
             target: {
                 value: 'AAAAAAAAAAA',
             },


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- Select.Search now has to be passed in through search prop and is no longer rendered by default. This allows us to do custom rending for smaller selects (that only hold flags for instance) that do not require a searchbar.
- "testid"-input no longer exists by default, you can restore this behavior by giving the searchbar in the search prop a data-testid.

**Backwards compatible additions** ✨
- None

**Bugfixes/Changed internals** 🎈
- None

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [ x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>