### PR TITLE
fix(ScrollBox): Added height property

### DIFF
--- a/packages/components/src/components/Button/base/style.tsx
+++ b/packages/components/src/components/Button/base/style.tsx
@@ -15,6 +15,7 @@ const StyledButton = styled.button<PropsType & { isLoading?: boolean }>`
     justify-content: center;
     line-height: 24px;
     outline: none;
+    margin: 0;
     padding: 0;
     position: relative;
     text-decoration: none;

--- a/packages/components/src/components/ScrollBox/style.tsx
+++ b/packages/components/src/components/ScrollBox/style.tsx
@@ -24,6 +24,7 @@ const StyledWrapper = styled.div`
     flex-grow: 1;
     display: flex;
     max-height: inherit;
+    height: 100%;
     overflow: hidden;
 
     ${simplebarStyles}

--- a/packages/components/src/components/Tag/index.tsx
+++ b/packages/components/src/components/Tag/index.tsx
@@ -1,0 +1,80 @@
+import styled from '../../utility/styled';
+import ThemeTools from '../../themes/CustomTheme/ThemeTools';
+import React, { FC } from 'react';
+import { CloseSmallIcon } from '@myonlinestore/bricks-assets';
+import IconButton from '../IconButton';
+import Box from '../Box';
+
+type PropsType = {
+    label: string;
+    onClick?(): void;
+    'data-testid'?: string;
+};
+
+type TagThemeType = {
+    backgroundColor: string;
+    color: string;
+    fontFamily: string;
+};
+
+const StyledTag = styled.div`
+    position: relative;
+    display: inline-flex;
+    flex-flow: row nowrap;
+    box-sizing: border-box;
+    min-width: 36px;
+    min-height: 36px;
+    max-width: 100%;
+    padding: 0px;
+    border-radius: 18px;
+    background: ${({ theme }) => theme.Tag.backgroundColor};
+    font-family: ${({ theme }) => theme.Tag.fontFamily};
+    color: ${({ theme }) => theme.Tag.color};
+    font-size: 15px;
+    line-height: 1.6; //leads to 24px line-height
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+`;
+
+const StyledTagWrap = styled.div<{ hasButton: boolean }>`
+    padding: ${({ hasButton }) => (hasButton ? '6px 6px 6px 12px' : '6px 12px')};
+    box-sizing: border-box;
+    width: ${({ hasButton }) => (hasButton ? 'calc(100% - 30px)' : '100%')};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+`;
+
+const composeTagTheme = (themeTools: ThemeTools): TagThemeType => {
+    const { colors, text } = themeTools.themeSettings;
+
+    return {
+        backgroundColor: colors.silver.base,
+        color: themeTools.calculateContrastTextColor(colors.silver.base),
+        fontFamily: text.primaryFont,
+    };
+};
+
+const Tag: FC<PropsType> = props => {
+    const testId = props['data-testid'] ? props['data-testid'] : 'tag';
+
+    return (
+        <StyledTag data-testid={testId}>
+            <StyledTagWrap hasButton={props.onClick !== undefined}>{props.label}</StyledTagWrap>
+            {props.onClick && (
+                <Box padding={[3, 3, 3, 0]}>
+                    <IconButton
+                        title="Remove"
+                        iconSize="small"
+                        icon={<CloseSmallIcon />}
+                        onClick={props.onClick}
+                        data-testid={`${testId}-remove-button`}
+                    />
+                </Box>
+            )}
+        </StyledTag>
+    );
+};
+
+export default Tag;
+export { PropsType, TagThemeType, composeTagTheme };

--- a/packages/components/src/components/Tag/index.tsx
+++ b/packages/components/src/components/Tag/index.tsx
@@ -37,9 +37,9 @@ const StyledTag = styled.div`
 `;
 
 const StyledTagWrap = styled.div<{ hasButton: boolean }>`
-    padding: ${({ hasButton }) => (hasButton ? '6px 6px 6px 12px' : '6px 12px')};
+    padding: ${({ hasButton }) => (hasButton ? '6px 0px 6px 12px' : '6px 12px')};
     box-sizing: border-box;
-    width: ${({ hasButton }) => (hasButton ? 'calc(100% - 30px)' : '100%')};
+    width: ${({ hasButton }) => (hasButton ? 'calc(100% - 36px)' : '100%')};
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
@@ -62,7 +62,7 @@ const Tag: FC<PropsType> = props => {
         <StyledTag data-testid={testId}>
             <StyledTagWrap hasButton={props.onClick !== undefined}>{props.label}</StyledTagWrap>
             {props.onClick && (
-                <Box padding={[3, 3, 3, 0]}>
+                <Box padding={[3]}>
                     <IconButton
                         title="Remove"
                         iconSize="small"

--- a/packages/components/src/components/Tag/story.tsx
+++ b/packages/components/src/components/Tag/story.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import Tag from '.';
+
+export default {
+    title: 'Tag',
+    component: Tag,
+};
+
+export const Default = () => {
+    return <Tag label="Short Label" />;
+};
+
+export const WithCloseButton = () => {
+    return (
+        <Tag
+            label="With close button"
+            onClick={() => {
+                alert('Delete');
+            }}
+        />
+    );
+};
+
+export const LongLabel = () => {
+    return (
+        <Tag label="Fire up your browser focus on the customer journey code. Products need full resourcing and support from a cross-functional team in order to be built, maintained, and evolved. Quick win." />
+    );
+};
+
+export const LongLabelWithCloseButton = () => {
+    return (
+        <Tag
+            label="Fire up your browser focus on the customer journey code. Products need full resourcing and support from a cross-functional team in order to be built, maintained, and evolved. Quick win."
+            onClick={() => {
+                alert('Delete');
+            }}
+        />
+    );
+};

--- a/packages/components/src/components/Tag/test.tsx
+++ b/packages/components/src/components/Tag/test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Tag from '.';
+import { mountWithTheme } from '../../utility/styled/testing';
+import 'jest-styled-components';
+
+describe('Tag', () => {
+    it('should render a label', () => {
+        const component = mountWithTheme(<Tag label="Label" />);
+
+        expect(component.text()).toBe('Label');
+    });
+
+    it('should render a remove button and execute the callback if passed as onClick', () => {
+        const mockOnClose = jest.fn();
+        const component = mountWithTheme(<Tag label="Label" onClick={mockOnClose} />);
+        const button = component.findByTestId('tag-remove-button');
+
+        button.simulate('click');
+
+        expect(button).toHaveLength(1);
+        expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be testable with a testid', () => {
+        const component = mountWithTheme(<Tag label="Label" data-testid="tag-test-id" />);
+
+        expect(component.findByTestId('tag-test-id')).toHaveLength(1);
+    });
+});

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -49,6 +49,7 @@ export { default as Skeleton } from './components/Skeleton';
 export { default as Slider } from './components/Slider';
 export { default as Spinner } from './components/Spinner';
 export { default as Table } from './components/Table';
+export { default as Tag } from './components/Tag';
 export { default as Text } from './components/Text';
 export { default as TextArea } from './components/TextArea';
 export { default as TextField } from './components/TextField';

--- a/packages/components/src/themes/CustomTheme/genTheme.ts
+++ b/packages/components/src/themes/CustomTheme/genTheme.ts
@@ -42,6 +42,7 @@ import { composeCardTheme } from '../../components/Card/style';
 import { composePaginationTheme } from '../../components/Pagination/style';
 import { composeFileInputTheme } from '../../components/FileInput/style';
 import { composeColorDropTheme } from '../../components/ColorDrop';
+import { composeTagTheme } from '../../components/Tag';
 
 const generateThemeObject = (
     providedOptions: ThemeTypes.ProvidedThemeOptionsType,
@@ -110,6 +111,7 @@ const generateThemeObject = (
         Skeleton: composeSkeletonTheme(themeTools),
         Slider: composeSliderTheme(themeTools),
         Table: composeTableTheme(themeTools),
+        Tag: composeTagTheme(themeTools),
         Text: composeTextTheme(themeTools),
         TextArea: composeTextAreaTheme(themeTools),
         TextField: composeTextFieldTheme(themeTools),

--- a/packages/components/src/themes/MosTheme/MosTheme.theme.ts
+++ b/packages/components/src/themes/MosTheme/MosTheme.theme.ts
@@ -774,6 +774,11 @@ const theme: ThemeType = {
             },
         },
     },
+    Tag: {
+        backgroundColor: colors.grey200,
+        color: colors.grey700,
+        fontFamily: bodyFont,
+    },
     Text: {
         default: {
             color: colors.grey600,

--- a/packages/components/src/types/ThemeType/index.ts
+++ b/packages/components/src/types/ThemeType/index.ts
@@ -37,6 +37,7 @@ import { CardThemeType } from '../../components/Card/style';
 import { PaginationThemeType } from '../../components/Pagination/style';
 import { FileInputThemeType } from '../../components/FileInput/style';
 import { ColorDropThemeType } from '../../components/ColorDrop';
+import { TagThemeType } from '../../components/Tag';
 
 type ThemeType = {
     Accordion: AccordionThemeType;
@@ -70,6 +71,7 @@ type ThemeType = {
     Skeleton: SkeletonThemeType;
     Slider: SliderThemeType;
     Table: TableThemeType;
+    Tag: TagThemeType;
     Text: TextThemeType;
     TextArea: TextAreaThemeType;
     TextField: TextFieldThemeType;


### PR DESCRIPTION
### This PR:

Addresses an issue where the `ScrollBox` would grow out of its parent with only a max-height. Adding a height of `100%` seems to fix that without breaking things.

- [ ] Rebase after #644 

**Breaking changes** 🔥
- none

**Backwards compatible additions** ✨
- none

**Bugfixes/Changed internals** 🎈
- Added `height` property to `ScrollBox`

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>