### PR TITLE
chore: Added initialValue and ResetButton to ColorField

### DIFF
--- a/packages/components/src/components/ColorField/index.tsx
+++ b/packages/components/src/components/ColorField/index.tsx
@@ -1,14 +1,17 @@
 /// <reference path="../../_declarations/global.d.ts" />
 import TextField, { PropsType as TextFieldPropsType } from '../TextField';
-import React, { FC, useRef } from 'react';
+import React, { FC, useRef, useState } from 'react';
 import ColorDrop from '../ColorDrop';
 import Box from '../Box';
 
 type OmittedKeys = 'prefix';
 
-type PropsType = Pick<TextFieldPropsType, Exclude<keyof TextFieldPropsType, OmittedKeys>>;
+type PropsType = Pick<TextFieldPropsType, Exclude<keyof TextFieldPropsType, OmittedKeys>> & {
+    initialValue: string;
+};
 
 const ColorField: FC<PropsType> = props => {
+    const [showResetButton, setShowResetButton] = useState(props.value !== props.initialValue);
     const inputRef = useRef<HTMLInputElement>();
 
     // Since the ColorField uses a prefix for the # character, it needs to strip the # from the value when

--- a/packages/components/src/components/ColorField/index.tsx
+++ b/packages/components/src/components/ColorField/index.tsx
@@ -1,6 +1,6 @@
 /// <reference path="../../_declarations/global.d.ts" />
 import TextField, { PropsType as TextFieldPropsType } from '../TextField';
-import React, { FC, useRef, useState } from 'react';
+import React, { FC, useRef } from 'react';
 import ColorDrop from '../ColorDrop';
 import Box from '../Box';
 import { UndoIcon } from '@myonlinestore/bricks-assets';
@@ -15,7 +15,6 @@ type PropsType = Pick<TextFieldPropsType, Exclude<keyof TextFieldPropsType, Omit
 };
 
 const ColorField: FC<PropsType> = props => {
-    const [showResetButton, setShowResetButton] = useState(props.value !== props.initialValue);
     const inputRef = useRef<HTMLInputElement>();
 
     // Since the ColorField uses a prefix for the # character, it needs to strip the # from the value when
@@ -41,18 +40,16 @@ const ColorField: FC<PropsType> = props => {
                     value={stripHashtag(props.value)}
                     prefix="#"
                     onChange={value => {
-                        setShowResetButton(value !== props.initialValue);
                         props.onChange(`#${value}`);
                     }}
                 />
             </Box>
             <Box width="38px">
-                {showResetButton && (
+                {props.value !== props.initialValue && (
                     <IconButton
                         icon={<UndoIcon />}
                         title={props.resetButtonTitle}
                         onClick={() => {
-                            setShowResetButton(false);
                             props.onChange(props.initialValue);
                         }}
                     />

--- a/packages/components/src/components/ColorField/index.tsx
+++ b/packages/components/src/components/ColorField/index.tsx
@@ -3,11 +3,15 @@ import TextField, { PropsType as TextFieldPropsType } from '../TextField';
 import React, { FC, useRef, useState } from 'react';
 import ColorDrop from '../ColorDrop';
 import Box from '../Box';
+import { UndoIcon } from '@myonlinestore/bricks-assets';
+import IconButton from '../IconButton';
 
 type OmittedKeys = 'prefix';
 
 type PropsType = Pick<TextFieldPropsType, Exclude<keyof TextFieldPropsType, OmittedKeys>> & {
     initialValue: string;
+    resetButtonTitle: string;
+    onChange(value: string): void;
 };
 
 const ColorField: FC<PropsType> = props => {
@@ -36,10 +40,23 @@ const ColorField: FC<PropsType> = props => {
                     }}
                     value={stripHashtag(props.value)}
                     prefix="#"
-                    onChange={(value, event) => {
-                        props.onChange(`#${value}`, event);
+                    onChange={value => {
+                        setShowResetButton(value !== props.initialValue);
+                        props.onChange(`#${value}`);
                     }}
                 />
+            </Box>
+            <Box width="38px">
+                {showResetButton && (
+                    <IconButton
+                        icon={<UndoIcon />}
+                        title={props.resetButtonTitle}
+                        onClick={() => {
+                            setShowResetButton(false);
+                            props.onChange(props.initialValue);
+                        }}
+                    />
+                )}
             </Box>
         </Box>
     );

--- a/packages/components/src/components/ColorField/story.tsx
+++ b/packages/components/src/components/ColorField/story.tsx
@@ -4,6 +4,9 @@ import ColorField from '.';
 export default {
     title: 'ColorField',
     component: ColorField,
+    args: {
+        resetButtonTitle: 'Undo',
+    },
 };
 
 export const Default = (args: ComponentProps<typeof ColorField>) => {
@@ -13,6 +16,7 @@ export const Default = (args: ComponentProps<typeof ColorField>) => {
         <ColorField
             {...args}
             value={value}
+            initialValue="#6bde78"
             onChange={(val: string) => {
                 setValue(val);
             }}


### PR DESCRIPTION
**Backwards compatible additions** ✨
- Added initialValue prop and ResetButton

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>