### PR TITLE
chore: Added validation, errorstate and masking to ColorField

### DIFF
--- a/packages/components/src/components/ColorField/index.tsx
+++ b/packages/components/src/components/ColorField/index.tsx
@@ -23,10 +23,6 @@ const ColorField: FC<PropsType> = props => {
         return hexcode.replace('#', '');
     };
 
-    const validHexcode = (hexcode: string) => {
-        return false;
-    };
-
     return (
         <Box alignItems="flex-start">
             <Box padding={[6, 12, 0, 0]}>
@@ -43,14 +39,6 @@ const ColorField: FC<PropsType> = props => {
                     }}
                     value={stripHashtag(props.value)}
                     prefix="#"
-                    feedback={
-                        !validHexcode(props.value)
-                            ? {
-                                  severity: 'error',
-                                  message: "Da's nie goed jong",
-                              }
-                            : undefined
-                    }
                     onChange={value => {
                         if (value.length < 7) {
                             const negatedValues = `[^0-9a-f]`;

--- a/packages/components/src/components/ColorField/index.tsx
+++ b/packages/components/src/components/ColorField/index.tsx
@@ -23,12 +23,16 @@ const ColorField: FC<PropsType> = props => {
         return hexcode.replace('#', '');
     };
 
+    const validHexcode = (hexcode: string) => {
+        return false;
+    };
+
     return (
-        <Box alignItems="center">
-            <Box margin={[0, 12, 0, 0]}>
+        <Box alignItems="flex-start">
+            <Box padding={[6, 12, 0, 0]}>
                 <ColorDrop color={props.value} />
             </Box>
-            <Box grow={1}>
+            <Box grow={1} direction="column">
                 <TextField
                     {...props}
                     extractRef={ref => {
@@ -39,8 +43,21 @@ const ColorField: FC<PropsType> = props => {
                     }}
                     value={stripHashtag(props.value)}
                     prefix="#"
+                    feedback={
+                        !validHexcode(props.value)
+                            ? {
+                                  severity: 'error',
+                                  message: "Da's nie goed jong",
+                              }
+                            : undefined
+                    }
                     onChange={value => {
-                        props.onChange(`#${value}`);
+                        if (value.length < 7) {
+                            const negatedValues = `[^0-9a-f]`;
+                            const stripped = value.replace(new RegExp(negatedValues, 'gi'), '');
+
+                            props.onChange(`#${stripped}`);
+                        }
                     }}
                 />
             </Box>

--- a/packages/components/src/components/ColorField/story.tsx
+++ b/packages/components/src/components/ColorField/story.tsx
@@ -9,6 +9,10 @@ export default {
     },
 };
 
+const validHexcode = (hexcode: string) => {
+    return !(hexcode.length !== 4 && hexcode.length !== 7);
+};
+
 export const Default = (args: ComponentProps<typeof ColorField>) => {
     const [value, setValue] = useState('#6bde78');
 
@@ -17,6 +21,14 @@ export const Default = (args: ComponentProps<typeof ColorField>) => {
             {...args}
             value={value}
             initialValue="#6bde78"
+            feedback={
+                !validHexcode(value)
+                    ? {
+                          severity: 'error',
+                          message: 'That is not a valid hex code!',
+                      }
+                    : undefined
+            }
             onChange={(val: string) => {
                 setValue(val);
             }}

--- a/packages/components/src/components/ColorField/story.tsx
+++ b/packages/components/src/components/ColorField/story.tsx
@@ -10,11 +10,12 @@ export default {
 };
 
 const validHexcode = (hexcode: string) => {
-    return !(hexcode.length !== 4 && hexcode.length !== 7);
+    return !(hexcode.replace('#', '').length !== 3 && hexcode.replace('#', '').length !== 6);
 };
 
 export const Default = (args: ComponentProps<typeof ColorField>) => {
     const [value, setValue] = useState('#6bde78');
+    const [hasHexError, setHasHexError] = useState(!validHexcode(value));
 
     return (
         <ColorField
@@ -22,14 +23,21 @@ export const Default = (args: ComponentProps<typeof ColorField>) => {
             value={value}
             initialValue="#6bde78"
             feedback={
-                !validHexcode(value)
+                hasHexError
                     ? {
                           severity: 'error',
                           message: 'That is not a valid hex code!',
                       }
                     : undefined
             }
+            onBlur={() => {
+                setHasHexError(!validHexcode(value));
+            }}
             onChange={(val: string) => {
+                if (validHexcode(val)) {
+                    setHasHexError(false);
+                }
+
                 setValue(val);
             }}
         />


### PR DESCRIPTION
**Backwards compatible additions** ✨
- Add validation to story
- Masking of input characters to component
- Styling changes to accomodate for feedback messages

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>