### PR TITLE
chore: Added disabled styling to ColorField

### DIFF
--- a/packages/components/src/components/ColorField/index.tsx
+++ b/packages/components/src/components/ColorField/index.tsx
@@ -24,8 +24,8 @@ const ColorField: FC<PropsType> = props => {
     };
 
     return (
-        <Box alignItems="center">
-            <Box margin={[0, 12, 0, 0]}>
+        <Box alignItems="flex-start" style={props.disabled ? { cursor: 'not-allowed' } : {}}>
+            <Box padding={[6, 12, 0, 0]}>
                 <ColorDrop color={props.value} />
             </Box>
             <Box grow={1}>

--- a/packages/components/src/components/ColorField/story.tsx
+++ b/packages/components/src/components/ColorField/story.tsx
@@ -23,3 +23,7 @@ export const Default = (args: ComponentProps<typeof ColorField>) => {
         />
     );
 };
+
+export const Disabled = (args: ComponentProps<typeof ColorField>) => {
+    return <ColorField {...args} value="#6bde78" initialValue="#6bde78" disabled />;
+};


### PR DESCRIPTION
**Backwards compatible additions** ✨
- Correct mouse cursor when disabled

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>