### PR TITLE
chore: Added transparency support to ColorField

### DIFF
--- a/packages/components/src/components/ColorField/index.tsx
+++ b/packages/components/src/components/ColorField/index.tsx
@@ -9,9 +9,11 @@ import IconButton from '../IconButton';
 type OmittedKeys = 'prefix';
 
 type PropsType = Pick<TextFieldPropsType, Exclude<keyof TextFieldPropsType, OmittedKeys>> & {
-    allowTransparent?: boolean;
+    emptyIsTransparent?: boolean;
+    transparentPlaceholder: string;
     initialValue: string;
     resetButtonTitle: string;
+    /* returns either a full hexcode with hashtag ór `transparent` */
     onChange(value: string): void;
 };
 
@@ -19,15 +21,26 @@ const ColorField: FC<PropsType> = props => {
     const inputRef = useRef<HTMLInputElement>();
 
     // Since the ColorField uses a prefix for the # character, it needs to strip the # from the value when
-    // passing it to the TextField, and add it in the onChange call.
+    // passing it to the TextField, and add it in the onChange call. It should also convert 'transparent' to an
+    // empty string, since this equals transparancy.
     const stripHashtag = (hexcode: string) => {
+        if (hexcode === 'transparent') {
+            return '';
+        }
+
         return hexcode.replace('#', '');
+    };
+
+    const isTransparent = (hexcode: string) => {
+        return hexcode === '#' || hexcode === '' || hexcode === 'transparent';
     };
 
     return (
         <Box alignItems="flex-start" style={props.disabled ? { cursor: 'not-allowed' } : {}}>
             <Box padding={[6, 12, 0, 0]}>
-                <ColorDrop color={props.value} />
+                <ColorDrop
+                    color={props.emptyIsTransparent && isTransparent(props.value) ? 'transparent' : props.value}
+                />
             </Box>
             <Box grow={1} direction="column">
                 <TextField
@@ -38,6 +51,11 @@ const ColorField: FC<PropsType> = props => {
                             props.extractRef(ref);
                         }
                     }}
+                    placeholder={
+                        props.emptyIsTransparent && isTransparent(props.value)
+                            ? props.transparentPlaceholder
+                            : undefined
+                    }
                     value={stripHashtag(props.value)}
                     prefix="#"
                     onChange={value => {
@@ -45,7 +63,7 @@ const ColorField: FC<PropsType> = props => {
                             const negatedValues = `[^0-9a-f]`;
                             const stripped = value.replace(new RegExp(negatedValues, 'gi'), '');
 
-                            props.onChange(`#${stripped}`);
+                            props.onChange(stripped === '#' || stripped === '' ? 'transparent' : `#${stripped}`);
                         }
                     }}
                 />

--- a/packages/components/src/components/ColorField/index.tsx
+++ b/packages/components/src/components/ColorField/index.tsx
@@ -63,7 +63,11 @@ const ColorField: FC<PropsType> = props => {
                             const negatedValues = `[^0-9a-f]`;
                             const stripped = value.replace(new RegExp(negatedValues, 'gi'), '');
 
-                            props.onChange(stripped === '#' || stripped === '' ? 'transparent' : `#${stripped}`);
+                            props.onChange(
+                                props.emptyIsTransparent && (stripped === '#' || stripped === '')
+                                    ? 'transparent'
+                                    : `#${stripped}`,
+                            );
                         }
                     }}
                 />

--- a/packages/components/src/components/ColorField/index.tsx
+++ b/packages/components/src/components/ColorField/index.tsx
@@ -9,6 +9,7 @@ import IconButton from '../IconButton';
 type OmittedKeys = 'prefix';
 
 type PropsType = Pick<TextFieldPropsType, Exclude<keyof TextFieldPropsType, OmittedKeys>> & {
+    allowTransparent?: boolean;
     initialValue: string;
     resetButtonTitle: string;
     onChange(value: string): void;

--- a/packages/components/src/components/ColorField/story.tsx
+++ b/packages/components/src/components/ColorField/story.tsx
@@ -6,6 +6,7 @@ export default {
     component: ColorField,
     args: {
         resetButtonTitle: 'Undo',
+        transparentPlaceholder: 'transparent',
     },
 };
 
@@ -20,6 +21,7 @@ export const Default = (args: ComponentProps<typeof ColorField>) => {
     return (
         <ColorField
             {...args}
+            emptyIsTransparent
             value={value}
             initialValue="#6bde78"
             feedback={
@@ -31,7 +33,7 @@ export const Default = (args: ComponentProps<typeof ColorField>) => {
                     : undefined
             }
             onBlur={() => {
-                setHasHexError(!validHexcode(value));
+                setHasHexError(!validHexcode(value) && value !== 'transparent');
             }}
             onChange={(val: string) => {
                 if (validHexcode(val)) {


### PR DESCRIPTION
**Backwards compatible additions** ✨
- Added support for transparency

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>