### PR TITLE
fix: Removed overload in the ColorField onChange

### DIFF
--- a/packages/components/src/components/ColorField/index.tsx
+++ b/packages/components/src/components/ColorField/index.tsx
@@ -6,7 +6,7 @@ import Box from '../Box';
 import { UndoIcon } from '@myonlinestore/bricks-assets';
 import IconButton from '../IconButton';
 
-type OmittedKeys = 'prefix';
+type OmittedKeys = 'prefix' | 'onChange';
 
 type PropsType = Pick<TextFieldPropsType, Exclude<keyof TextFieldPropsType, OmittedKeys>> & {
     emptyIsTransparent?: boolean;


### PR DESCRIPTION
### This PR:
![Screenshot 2021-06-08 at 10 32 50](https://user-images.githubusercontent.com/6347900/121151944-1543de00-c845-11eb-8ca0-e22dbd23827a.png)

**Bugfixes/Changed internals** 🎈
- Because the onChange prop wasn't excluded from the original TextField PropsType the props get overloaded with the new type, resulting in a type like: `(value: string) => void | (value:string, event: Event) => void`. This results in an any on the `value` argument when using the callback because ts cannot determine which type should be used

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>