### PR TITLE
feat: Added ColorPicker component (to ColorField)

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -64,6 +64,7 @@
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
     "react": "^16.8.0",
+    "react-color": "^2.19.3",
     "react-dom": "^16.8.0",
     "react-is": "^16.12.0",
     "react-measure": "^2.2.4",

--- a/packages/components/src/components/ColorDrop/index.tsx
+++ b/packages/components/src/components/ColorDrop/index.tsx
@@ -7,7 +7,7 @@ export type ColorDropThemeType = {
     transparentStripeColor: string;
 };
 
-const ColorDrop = styled.div<{ color: string }>`
+const ColorDrop = styled.div<{ color: string; onClick(): void }>`
     display: flex;
     width: ${({ theme }) => theme.ColorDrop.size};
     height: ${({ theme }) => theme.ColorDrop.size};
@@ -17,6 +17,11 @@ const ColorDrop = styled.div<{ color: string }>`
             : color};
     box-shadow: ${({ theme }) => theme.ColorDrop.shadowBorder};
     border-radius: ${({ theme }) => theme.ColorDrop.borderRadius};
+    ${({ onClick }) =>
+        onClick &&
+        `
+        cursor: pointer;
+    `}
 `;
 
 export const composeColorDropTheme = (): ColorDropThemeType => {

--- a/packages/components/src/components/ColorField/index.tsx
+++ b/packages/components/src/components/ColorField/index.tsx
@@ -67,7 +67,6 @@ const ColorField: FC<PropsType> = props => {
                         onClick={() => {
                             setShow(!show);
                         }}
-                        style={{ cursor: 'pointer' }}
                     />
                 </Box>
                 <Box grow={1} direction="column">

--- a/packages/components/src/components/ColorField/index.tsx
+++ b/packages/components/src/components/ColorField/index.tsx
@@ -1,10 +1,11 @@
 /// <reference path="../../_declarations/global.d.ts" />
 import TextField, { PropsType as TextFieldPropsType } from '../TextField';
-import React, { FC, useRef } from 'react';
+import React, { FC, useRef, useState } from 'react';
 import ColorDrop from '../ColorDrop';
 import Box from '../Box';
 import { UndoIcon } from '@myonlinestore/bricks-assets';
 import IconButton from '../IconButton';
+import ColorPicker from '../ColorPicker';
 
 type OmittedKeys = 'prefix' | 'onChange';
 
@@ -24,6 +25,7 @@ export enum TestIds {
 }
 
 const ColorField: FC<PropsType> = props => {
+    const [show, setShow] = useState(false);
     const inputRef = useRef<HTMLInputElement>();
 
     // Since the ColorField uses a prefix for the # character, it needs to strip the # from the value when
@@ -42,60 +44,79 @@ const ColorField: FC<PropsType> = props => {
     };
 
     return (
-        <Box
-            alignItems="flex-start"
-            style={props.disabled ? { cursor: 'not-allowed' } : {}}
-            data-testid={`${props['data-testid']}-${TestIds.container}`}
+        <ColorPicker
+            transparentSwatch={props.emptyIsTransparent}
+            show={show}
+            color={props.value}
+            onClickOutside={() => {
+                setShow(false);
+            }}
+            onChange={color => {
+                props.onChange(color.hex);
+            }}
         >
-            <Box padding={[6, 12, 0, 0]}>
-                <ColorDrop
-                    color={props.emptyIsTransparent && isTransparent(props.value) ? 'transparent' : props.value}
-                    data-testid={`${props['data-testid']}-${TestIds.colorDrop}`}
-                />
-            </Box>
-            <Box grow={1} direction="column">
-                <TextField
-                    {...props}
-                    extractRef={ref => {
-                        inputRef.current = ref;
-                        if (ref && props.extractRef !== undefined) {
-                            props.extractRef(ref);
-                        }
-                    }}
-                    placeholder={
-                        props.emptyIsTransparent && isTransparent(props.value)
-                            ? props.transparentPlaceholder
-                            : undefined
-                    }
-                    value={stripHashtag(props.value)}
-                    prefix="#"
-                    onChange={value => {
-                        if (value.length < 7) {
-                            const negatedValues = `[^0-9a-f]`;
-                            const stripped = value.replace(new RegExp(negatedValues, 'gi'), '');
-
-                            props.onChange(
-                                props.emptyIsTransparent && (stripped === '#' || stripped === '')
-                                    ? 'transparent'
-                                    : `#${stripped}`,
-                            );
-                        }
-                    }}
-                />
-            </Box>
-            <Box width="38px">
-                {props.value !== props.initialValue && (
-                    <IconButton
-                        data-testid={`${props['data-testid']}-${TestIds.reset}`}
-                        icon={<UndoIcon />}
-                        title={props.resetButtonTitle}
+            <Box
+                alignItems="flex-start"
+                style={props.disabled ? { cursor: 'not-allowed' } : {}}
+                data-testid={`${props['data-testid']}-${TestIds.container}`}
+            >
+                <Box padding={[6, 12, 0, 0]}>
+                    <ColorDrop
+                        color={props.emptyIsTransparent && isTransparent(props.value) ? 'transparent' : props.value}
+                        data-testid={`${props['data-testid']}-${TestIds.colorDrop}`}
                         onClick={() => {
-                            props.onChange(props.initialValue);
+                            setShow(!show);
+                        }}
+                        style={{ cursor: 'pointer' }}
+                    />
+                </Box>
+                <Box grow={1} direction="column">
+                    <TextField
+                        {...props}
+                        extractRef={ref => {
+                            inputRef.current = ref;
+                            if (ref && props.extractRef !== undefined) {
+                                props.extractRef(ref);
+                            }
+                        }}
+                        placeholder={
+                            props.emptyIsTransparent && isTransparent(props.value)
+                                ? props.transparentPlaceholder
+                                : undefined
+                        }
+                        value={stripHashtag(props.value)}
+                        prefix="#"
+                        onChange={value => {
+                            if (value.length < 7) {
+                                const negatedValues = `[^0-9a-f]`;
+                                const stripped = value.replace(new RegExp(negatedValues, 'gi'), '');
+
+                                props.onChange(
+                                    props.emptyIsTransparent && (stripped === '#' || stripped === '')
+                                        ? 'transparent'
+                                        : `#${stripped}`,
+                                );
+                            }
+                        }}
+                        onFocus={() => {
+                            setShow(true);
                         }}
                     />
-                )}
+                </Box>
+                <Box width="38px">
+                    {props.value !== props.initialValue && (
+                        <IconButton
+                            data-testid={`${props['data-testid']}-${TestIds.reset}`}
+                            icon={<UndoIcon />}
+                            title={props.resetButtonTitle}
+                            onClick={() => {
+                                props.onChange(props.initialValue);
+                            }}
+                        />
+                    )}
+                </Box>
             </Box>
-        </Box>
+        </ColorPicker>
     );
 };
 

--- a/packages/components/src/components/ColorField/story.tsx
+++ b/packages/components/src/components/ColorField/story.tsx
@@ -46,6 +46,37 @@ export const Default = (args: ComponentProps<typeof ColorField>) => {
     );
 };
 
+export const NoTransparency = (args: ComponentProps<typeof ColorField>) => {
+    const [value, setValue] = useState('#6bde78');
+    const [hasHexError, setHasHexError] = useState(!validHexcode(value));
+
+    return (
+        <ColorField
+            {...args}
+            value={value}
+            initialValue="#6bde78"
+            feedback={
+                hasHexError
+                    ? {
+                          severity: 'error',
+                          message: 'That is not a valid hex code!',
+                      }
+                    : undefined
+            }
+            onBlur={() => {
+                setHasHexError(!validHexcode(value) && value !== 'transparent');
+            }}
+            onChange={(val: string) => {
+                if (validHexcode(val)) {
+                    setHasHexError(false);
+                }
+
+                setValue(val);
+            }}
+        />
+    );
+};
+
 export const Disabled = (args: ComponentProps<typeof ColorField>) => {
     return <ColorField {...args} value="#6bde78" initialValue="#6bde78" disabled />;
 };

--- a/packages/components/src/components/ColorPicker/index.tsx
+++ b/packages/components/src/components/ColorPicker/index.tsx
@@ -1,0 +1,101 @@
+import React, { FC } from 'react';
+import Box from '../Box';
+import { CustomPicker, ColorResult, HSLColor } from 'react-color';
+import { Hue, Saturation } from 'react-color/lib/components/common';
+import styled from 'styled-components';
+import Popover from '../Popover';
+import ColorDrop from '../ColorDrop';
+
+type PropsType = {
+    show: boolean;
+    transparentSwatch?: boolean;
+    color: string;
+    hex?: string;
+    hsl?: HSLColor;
+    onChange(value: ColorResult): void;
+    onClickOutside(): void;
+};
+
+const CustomHuePointer = styled.div`
+    display: flex;
+    width: 18px;
+    height: 18px;
+    box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.4);
+    background: white;
+    border-radius: 100%;
+    margin-top: -3px;
+    margin-left: -9px;
+`;
+
+const CustomSaturationPointer = styled.div`
+    display: flex;
+    width: 12px;
+    height: 12px;
+    box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.4);
+    background: transparent;
+    border: 2px solid white;
+    border-radius: 100%;
+    margin-top: -6px;
+    margin-left: -6px;
+`;
+const HiddenSaturationPointer = styled.div`
+    width: 0;
+    height: 0;
+`;
+
+const ColorPicker: FC<PropsType> = props => {
+    const { children, ...propsWithoutChildren } = { ...props };
+
+    return (
+        <Popover
+            stretch
+            show={props.show}
+            placement={'bottom-start'}
+            arrowStyle={{
+                left: '5px',
+            }}
+            onClickOutside={() => {
+                props.onClickOutside();
+            }}
+            renderContent={() => (
+                <Box direction="column" padding={[12]} width="230px">
+                    <Box height="130px" width="100%" style={{ position: 'relative' }}>
+                        <Saturation
+                            {...propsWithoutChildren}
+                            pointer={props.color === 'transparent' ? HiddenSaturationPointer : CustomSaturationPointer}
+                            onChange={props.onChange}
+                        />
+                    </Box>
+                    <Box margin={[12, 0, 0, 0]} direction="row" alignItems="center">
+                        {props.transparentSwatch && (
+                            <Box margin={[0, 9, 0, 0]}>
+                                <ColorDrop
+                                    color="transparent"
+                                    onClick={() => {
+                                        props.onChange({
+                                            hex: 'transparent',
+                                            hsl: { a: 0, h: 0, l: 0, s: 0 },
+                                            rgb: { a: 0, r: 0, g: 0, b: 0 },
+                                        });
+                                    }}
+                                />
+                            </Box>
+                        )}
+                        <Box height="12px" width="100%" style={{ position: 'relative' }}>
+                            <Hue
+                                {...propsWithoutChildren}
+                                direction="horizontal"
+                                pointer={CustomHuePointer}
+                                onChange={props.onChange}
+                            />
+                        </Box>
+                    </Box>
+                </Box>
+            )}
+        >
+            {props.children}
+        </Popover>
+    );
+};
+
+export default CustomPicker(ColorPicker);

--- a/packages/components/src/components/ColorPicker/index.tsx
+++ b/packages/components/src/components/ColorPicker/index.tsx
@@ -44,7 +44,7 @@ const HiddenSaturationPointer = styled.div`
 `;
 
 const ColorPicker: FC<PropsType> = props => {
-    const { children, ...propsWithoutChildren } = { ...props };
+    const { children, ...propsWithoutChildren } = props;
 
     return (
         <Popover
@@ -59,7 +59,7 @@ const ColorPicker: FC<PropsType> = props => {
             }}
             renderContent={() => (
                 <Box direction="column" padding={[12]} width="230px">
-                    <Box height="130px" width="100%" style={{ position: 'relative' }}>
+                    <Box height="130px" width="100%" position="relative">
                         <Saturation
                             {...propsWithoutChildren}
                             pointer={props.color === 'transparent' ? HiddenSaturationPointer : CustomSaturationPointer}
@@ -81,7 +81,7 @@ const ColorPicker: FC<PropsType> = props => {
                                 />
                             </Box>
                         )}
-                        <Box height="12px" width="100%" style={{ position: 'relative' }}>
+                        <Box height="12px" width="100%" position="relative">
                             <Hue
                                 {...propsWithoutChildren}
                                 direction="horizontal"

--- a/packages/components/src/components/ColorPicker/story.tsx
+++ b/packages/components/src/components/ColorPicker/story.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import ColorPicker from './index';
+import Button from '../Button';
+
+export default {
+    title: 'ColorPicker',
+    component: ColorPicker,
+};
+
+export const Default = () => {
+    const [color, setColor] = useState('#EEBE2E');
+    const [show, setShow] = useState(true);
+
+    return (
+        <ColorPicker
+            transparentSwatch
+            show={show}
+            color={color}
+            onClickOutside={() => {
+                setShow(false);
+            }}
+            onChange={color => {
+                setColor(color.hex);
+            }}
+        >
+            <Button
+                variant="primary"
+                title={`Change color ${color.toUpperCase()}`}
+                onClick={() => {
+                    setShow(!show);
+                }}
+            />
+        </ColorPicker>
+    );
+};

--- a/packages/components/src/components/Popover/index.tsx
+++ b/packages/components/src/components/Popover/index.tsx
@@ -173,7 +173,11 @@ const Popover: FC<PropsType> = props => {
                                     style={{ ...arrowProps.style, ...props.arrowStyle }}
                                     placement={placement}
                                 />
-                                <PopoverArrow shadow style={arrowProps.style} placement={placement} />
+                                <PopoverArrow
+                                    shadow
+                                    style={{ ...arrowProps.style, ...props.arrowStyle }}
+                                    placement={placement}
+                                />
                             </PopoverWindow>
                         )}
                     </Popper>

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -10,6 +10,7 @@ export { default as Carousel } from './components/Carousel';
 export { default as Checkbox } from './components/Checkbox';
 export { default as ColorDrop } from './components/ColorDrop';
 export { default as ColorField } from './components/ColorField';
+export { default as ColorPicker } from './components/ColorPicker';
 export { default as Contrast } from './components/Contrast';
 export { default as Counter } from './components/Counter';
 export { default as CurrencyField } from './components/CurrencyField';


### PR DESCRIPTION
### This PR:

**Backwards compatible additions** ✨
- Added new ColorPicker component to Bricks which implements react-color (custom version)
- Added ColorPicker to ColorField component
- Made the transparent swatch in the ColorPicker optional

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [ ] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>