### PR TITLE
fix: Added several default to flex components and fixed grow prop

### DIFF
--- a/packages/components/src/components/Card/index.tsx
+++ b/packages/components/src/components/Card/index.tsx
@@ -9,13 +9,15 @@ type CardThemeType = {
 };
 
 const Card = styled.div<BoxProps & FlexProps>`
-    ${box}
-    ${flex}
+    flex-direction: column;
+    flex-grow: 1;
+    width: 100%;
     position: relative;
     background: ${({ theme }) => theme.Card.background};
     border: 1px solid ${({ theme }) => theme.Card.borderColor};
     border-radius: ${({ theme }) => theme.Card.borderRadius};
-    flex: 1 1 auto;
+    ${box}
+    ${flex}
 `;
 
 const composeCardTheme = (themeTools: ThemeTools): CardThemeType => {

--- a/packages/components/src/components/Card/story.tsx
+++ b/packages/components/src/components/Card/story.tsx
@@ -6,5 +6,6 @@ import Text from '../Text';
 storiesOf('Card', module).add('Default', () => (
     <Card $padding={[24]}>
         <Text>Cras justo odio, dapibus ac facilisis in, egestas eget quam.</Text>
+        <Text>Cras justo odio, dapibus ac facilisis in, egestas eget quam.</Text>
     </Card>
 ));

--- a/packages/components/src/components/FileInput/style.tsx
+++ b/packages/components/src/components/FileInput/style.tsx
@@ -75,8 +75,7 @@ export type WrapperPropsType = {
 };
 
 export const StyledWrapper = styled.div<WrapperPropsType & typeof box.props & typeof flex.props>`
-    ${box}
-    ${flex}
+    flex-grow: 1;
     transition: border-color 150ms, box-shadow 150ms, background 150ms;
     font-size: ${({ theme }) => theme.FileInput.common.fontSize};
     font-family: ${({ theme }) => theme.FileInput.common.fontFamily};
@@ -84,6 +83,8 @@ export const StyledWrapper = styled.div<WrapperPropsType & typeof box.props & ty
     overflow: hidden;
     box-sizing: border-box;
     position: relative;
+    ${box}
+    ${flex}
 
     ${({ focus, hover, drop, disabled, severity, theme }) => {
         if (severity === 'error' && focus && !disabled) {

--- a/packages/components/src/components/FormRow/index.tsx
+++ b/packages/components/src/components/FormRow/index.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, FunctionComponent } from 'react';
 import Box from '../Box';
 import Measure from 'react-measure';
 import { StyledFormRow, StyledDisabledText } from './style';
-import { flex, box } from '../../utility/box';
+import { flex, box, flexProps, boxProps } from '../../utility/box';
 
 export type PropsType = typeof flex.props &
     typeof box.props & {
@@ -18,8 +18,8 @@ const FormRow: FunctionComponent<PropsType> = (props): JSX.Element => {
         <Measure client>
             {({ measureRef, contentRect }) => {
                 return (
-                    <StyledFormRow ref={measureRef}>
-                        <Box basis={'180px'} direction="row" grow={1} maxWidth="241px" margin={[15, 9, 0, 0]} wrap>
+                    <StyledFormRow ref={measureRef} {...flexProps(props)} {...boxProps(props)} $wrap $maxWidth="720px">
+                        <Box basis="180px" direction="row" grow={1} maxWidth="241px" margin={[15, 12, 0, 0]} wrap>
                             <Box grow={1} wrap={false}>
                                 <Box direction={props.description ? 'column' : 'row'} grow={props.badge ? 0 : 1}>
                                     <StyledDisabledText as="div" disabled={props.disabled} strong>
@@ -31,13 +31,11 @@ const FormRow: FunctionComponent<PropsType> = (props): JSX.Element => {
                                         </StyledDisabledText>
                                     )}
                                 </Box>
-                                <Box margin={[-9, 3]}>{props.badge !== undefined && props.badge}</Box>
+                                {props.badge && <Box margin={[-9, 3]}>{props.badge}</Box>}
                             </Box>
                         </Box>
                         <Box
-                            basis={'180px'}
                             grow={1}
-                            maxWidth="470px"
                             margin={[contentRect.client && contentRect.client.width < 369 ? 6 : 9, 0]}
                             alignItems="flex-start"
                             wrap

--- a/packages/components/src/components/FormRow/story.tsx
+++ b/packages/components/src/components/FormRow/story.tsx
@@ -9,8 +9,11 @@ import TextField from '../TextField';
 import Toggle from '../Toggle';
 import Separated from '../Separated';
 import { text, boolean } from '@storybook/addon-knobs';
-import { Skeleton } from '../..';
+import Skeleton from '../Skeleton';
+import NativeSelect from '../NativeSelect';
+import Select from '../Select';
 import TextArea from '../TextArea';
+import FileInput from '../FileInput';
 
 type PropsType = {
     descriptions: boolean;
@@ -24,6 +27,8 @@ type StateType = {
     checked: boolean;
     bacon: boolean;
     supersize: boolean;
+    patty: string;
+    sauce: string;
 };
 
 class DemoComponent extends Component<PropsType, StateType> {
@@ -38,6 +43,8 @@ class DemoComponent extends Component<PropsType, StateType> {
             cheese: true,
             checked: false,
             supersize: false,
+            patty: 'chicken',
+            sauce: 'mayo',
         };
     }
 
@@ -147,6 +154,44 @@ class DemoComponent extends Component<PropsType, StateType> {
                     }
                 />
                 <FormRow
+                    label={<label>Choose your patty</label>}
+                    disabled={disabled}
+                    description={description}
+                    field={
+                        <Separated before>
+                            <Select
+                                value={this.state.patty}
+                                $minWidth="300px"
+                                emptyText="empty"
+                                onChange={patty => this.setState({ patty })}
+                            >
+                                <Select.Option label="Chicken" value="chicken" />
+                                <Select.Option label="Veggy" value="veggy" />
+                                <Select.Option label="Beef" value="beef" />
+                            </Select>
+                        </Separated>
+                    }
+                />
+                <FormRow
+                    label={<label>Choose your patty</label>}
+                    disabled={disabled}
+                    description={description}
+                    field={
+                        <Separated before>
+                            <NativeSelect
+                                value={this.state.patty}
+                                onChange={sauce => this.setState({ sauce })}
+                                $minWidth="300px"
+                                options={[
+                                    { label: 'Mayo', value: 'mayo' },
+                                    { label: 'Ketchup', value: 'ketchup' },
+                                    { label: 'Mustard', value: 'mustard' },
+                                ]}
+                            ></NativeSelect>
+                        </Separated>
+                    }
+                />
+                <FormRow
                     label={<label>Supersized?</label>}
                     disabled={disabled}
                     description={description}
@@ -161,6 +206,21 @@ class DemoComponent extends Component<PropsType, StateType> {
                                 disabled={disabled}
                             />
                         </Separated>
+                    }
+                />
+                <FormRow
+                    label={<label>Upload your logo</label>}
+                    field={
+                        <FileInput
+                            accept={[]}
+                            name=""
+                            placeholder="Drag and drop your image"
+                            dropPlaceholder="Drop your image here"
+                            instance={{ current: null } as any}
+                            onChange={() => {
+                                return;
+                            }}
+                        />
                     }
                 />
             </form>

--- a/packages/components/src/components/FormRow/style.tsx
+++ b/packages/components/src/components/FormRow/style.tsx
@@ -21,9 +21,6 @@ const StyledDisabledText = styled(Text)<StyledDisabledTextType>`
 const StyledFormRow = styled.div<typeof flex.props & typeof box.props>`
     ${flex}
     ${box}
-    display: flex;
-    flex-wrap: wrap;
-    flex-grow: 1;
 `;
 
 const composeFormRowTheme = (themeTools: ThemeTools): FormRowThemeType => {

--- a/packages/components/src/components/NativeSelect/index.tsx
+++ b/packages/components/src/components/NativeSelect/index.tsx
@@ -2,26 +2,34 @@ import React, { FC, useState, ChangeEvent } from 'react';
 import { StyledSelect } from './style';
 import { CaretDownIcon, CaretUpIcon } from '@myonlinestore/bricks-assets';
 import Icon from '../Icon';
+import { boxProps, flexProps, flex, box } from '../../utility/box';
 
 type OptionType = {
     value: string;
     label: string;
 };
 
-type PropsType = {
-    options: Array<OptionType>;
-    value: OptionType['value'];
-    disabled?: boolean;
-    'data-testid'?: string;
-    onChange(value: string, event: ChangeEvent): void;
-};
+type PropsType = typeof flex.props &
+    typeof box.props & {
+        options: Array<OptionType>;
+        value: OptionType['value'];
+        disabled?: boolean;
+        'data-testid'?: string;
+        onChange(value: string, event: ChangeEvent): void;
+    };
 
 const NativeSelect: FC<PropsType> = (props): JSX.Element => {
     const [hasFocus, setFocus] = useState(false);
     const [isOpen, setOpen] = useState(false);
 
     return (
-        <StyledSelect focus={hasFocus} disabled={props.disabled} data-testid={props['data-testid']}>
+        <StyledSelect
+            focus={hasFocus}
+            disabled={props.disabled}
+            data-testid={props['data-testid']}
+            {...flexProps(props)}
+            {...boxProps(props)}
+        >
             <select
                 onFocus={() => setFocus(true)}
                 onBlur={() => {

--- a/packages/components/src/components/NativeSelect/style.tsx
+++ b/packages/components/src/components/NativeSelect/style.tsx
@@ -2,6 +2,7 @@ import styled from '../../utility/styled';
 import ThemeTools from '../../themes/CustomTheme/ThemeTools';
 import chroma from 'chroma-js';
 import StyledIcon from '../Icon/style';
+import { flex, box } from '../../utility/box';
 
 type NativeSelectThemeType = {
     common: {
@@ -38,6 +39,8 @@ const StyledSelect = styled.div<SelectPropsType>`
     box-sizing: border-box;
     width: 100%;
     border-radius: ${({ theme }): string => theme.NativeSelect.common.borderRadius};
+    ${flex}
+    ${box}
 
     ${({ theme, focus, disabled }) => {
         if (focus && !disabled) {

--- a/packages/components/src/components/Select/style.tsx
+++ b/packages/components/src/components/Select/style.tsx
@@ -67,6 +67,8 @@ const StyledWrapper = styled.div<WrapperPropsType>`
     outline: none;
     display: inline-block;
     position: relative;
+    flex-grow: 1;
+    width: 100%;
     ${flex}
     ${box}
 `;

--- a/packages/components/src/utility/box/index.tsx
+++ b/packages/components/src/utility/box/index.tsx
@@ -117,6 +117,7 @@ export const flexProps = <P extends FlexProps>(props: P): FlexProps => {
         $alignSelf: props.$alignSelf,
         $inline: props.$inline,
         $wrap: props.$wrap,
+        $grow: props.$grow,
         $shrink: props.$shrink,
         $basis: props.$basis,
     };
@@ -124,17 +125,17 @@ export const flexProps = <P extends FlexProps>(props: P): FlexProps => {
 
 const flexMixin = css<FlexProps>`
     box-sizing: border-box;
-    display: ${({ $inline }): string => ($inline ? 'inline-flex' : 'flex')};
-    flex-wrap: ${({ $wrap }): string => ($wrap !== undefined && $wrap ? 'wrap' : '')};
-    flex-direction: ${({ $direction }): string => ($direction !== undefined ? $direction : '')};
-    justify-content: ${({ $justifyContent }): string => ($justifyContent !== undefined ? $justifyContent : '')};
-    align-items: ${({ $alignItems }): string => ($alignItems !== undefined ? $alignItems : '')};
-    align-content: ${({ $alignContent }): string => ($alignContent !== undefined ? $alignContent : '')};
-    flex-grow: ${({ $grow }): number => ($grow ? $grow : 0)};
-    flex-shrink: ${({ $shrink }): number => ($shrink !== undefined ? $shrink : 1)};
-    flex-basis: ${({ $basis }): string => ($basis ? $basis : 'auto')};
-    order: ${({ $order }): number => ($order ? $order : 0)};
-    align-self: ${({ $alignSelf }): string => ($alignSelf ? $alignSelf : '')};
+    display: ${({ $inline }) => ($inline ? 'inline-flex' : 'flex')};
+    flex-wrap: ${({ $wrap }) => ($wrap !== undefined && $wrap ? 'wrap' : '')};
+    flex-direction: ${({ $direction }) => ($direction !== undefined ? $direction : '')};
+    justify-content: ${({ $justifyContent }) => ($justifyContent !== undefined ? $justifyContent : '')};
+    align-items: ${({ $alignItems }) => ($alignItems !== undefined ? $alignItems : '')};
+    align-content: ${({ $alignContent }) => ($alignContent !== undefined ? $alignContent : '')};
+    flex-grow: ${({ $grow }) => ($grow !== undefined ? $grow : '')};
+    flex-shrink: ${({ $shrink }) => ($shrink !== undefined ? $shrink : '')};
+    flex-basis: ${({ $basis }) => ($basis ? $basis : 'auto')};
+    order: ${({ $order }) => ($order ? $order : '')};
+    align-self: ${({ $alignSelf }) => ($alignSelf ? $alignSelf : '')};
 `;
 
 // These exports are a small hack to export the box and flex props along with


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- None

**Bugfixes/Changed internals** 🎈
- The $grow prop wasnt properly applied for components with the flex mixin
- Added better defaults to Select, FormRow, Card and NativeSelect
- Added a few stories for FormRow

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>