### PR TITLE
fix: Formrow flex fixes

### DIFF
--- a/packages/components/src/components/FileInput/index.tsx
+++ b/packages/components/src/components/FileInput/index.tsx
@@ -74,10 +74,8 @@ const FileInput: FC<PropsType> = props => {
     }, [!!props.preview]);
 
     return (
-        <>
+        <Box {...flexProps(props)} {...boxProps(props)} $direction="column" $grow={1} $width="100%">
             <StyledWrapper
-                {...flexProps(props)}
-                {...boxProps(props)}
                 focus={hasFocus}
                 drop={drop}
                 hover={hover}
@@ -88,6 +86,7 @@ const FileInput: FC<PropsType> = props => {
                 onMouseLeave={() => setHover(false)}
                 $alignItems="stretch"
                 $justifyContent="center"
+                $width="100%"
             >
                 {hasImage ? (
                     <>
@@ -171,7 +170,7 @@ const FileInput: FC<PropsType> = props => {
                     />
                 </Box>
             )}
-        </>
+        </Box>
     );
 };
 

--- a/packages/components/src/components/FormRow/story.tsx
+++ b/packages/components/src/components/FormRow/story.tsx
@@ -220,6 +220,10 @@ class DemoComponent extends Component<PropsType, StateType> {
                             onChange={() => {
                                 return;
                             }}
+                            feedback={{
+                                severity: 'info',
+                                message: 'Some message',
+                            }}
                         />
                     }
                 />

--- a/packages/components/src/components/FormRow/style.tsx
+++ b/packages/components/src/components/FormRow/style.tsx
@@ -19,6 +19,8 @@ const StyledDisabledText = styled(Text)<StyledDisabledTextType>`
 `;
 
 const StyledFormRow = styled.div<typeof flex.props & typeof box.props>`
+    width: 100%;
+    flex-grow: 1;
     ${flex}
     ${box}
 `;


### PR DESCRIPTION
### This PR:

**Bugfixes/Changed internals** 🎈
- Fixed a few leftover flex properties for FormRow and FileInput

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>