### PR TITLE
fix: Adjust line-heights to match 6px spacial system

### DIFF
--- a/packages/components/src/themes/MosTheme/MosTheme.theme.ts
+++ b/packages/components/src/themes/MosTheme/MosTheme.theme.ts
@@ -355,7 +355,7 @@ const theme: ThemeType = {
             fontFamily: headingFont,
             fontSize: fontSize.larger5,
             fontWeight: fontWeight.regular,
-            lineHeight: '39px',
+            lineHeight: '42px',
             color: colors.grey800,
         },
         3: {
@@ -369,14 +369,14 @@ const theme: ThemeType = {
             fontFamily: headingFont,
             fontSize: fontSize.larger3,
             fontWeight: fontWeight.regular,
-            lineHeight: '33px',
+            lineHeight: '30px',
             color: colors.grey800,
         },
         5: {
             fontFamily: headingFont,
             fontSize: fontSize.larger2,
             fontWeight: fontWeight.regular,
-            lineHeight: '27px',
+            lineHeight: '24px',
             color: colors.grey800,
         },
     },
@@ -807,7 +807,7 @@ const theme: ThemeType = {
                 fontSize: fontSize.larger1,
                 fontWeight: fontWeight.regular,
                 lineHeight: {
-                    default: '27px',
+                    default: '30px',
                     compact: '21px',
                 },
             },
@@ -816,7 +816,7 @@ const theme: ThemeType = {
                 fontSize: fontSize.larger2,
                 fontWeight: fontWeight.regular,
                 lineHeight: {
-                    default: '33px',
+                    default: '36px',
                     compact: '27px',
                 },
             },


### PR DESCRIPTION
### This PR:

**Bugfixes/Changed internals** 🎈
- Changes the line-heights of a few headings and body text formats to fit the 6px spatial system that UX adopted.

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>