### PR TITLE
chore: Added strikethrough support to Text component

### DIFF
--- a/packages/components/src/components/Text/index.tsx
+++ b/packages/components/src/components/Text/index.tsx
@@ -42,6 +42,7 @@ type PropsType = {
     textAlign?: 'left' | 'right' | 'center' | 'justify';
     compact?: boolean;
     strong?: boolean;
+    strikethrough?: boolean;
 };
 
 const Text = styled.p<PropsType>`
@@ -75,6 +76,28 @@ const Text = styled.p<PropsType>`
     margin: 0;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+
+    ${({ theme, strikethrough, variant }) =>
+        strikethrough &&
+        `
+        display: inline-block;
+        position: relative;
+
+        &::after {
+            content: '';
+            position: absolute;
+            left: 0;
+            right: 0;
+            top: 6px;
+            bottom: 6px;
+            display: block;
+            background: linear-gradient(-6deg, transparent calc(50% - 2px), ${
+                variant ? theme.Text.variant[variant] : theme.Text.default.color
+            } calc(50% - 1px), ${
+            variant ? theme.Text.variant[variant] : theme.Text.default.color
+        } calc(50% + 1px), transparent calc(50% + 2px)) no-repeat 0px 0px / 100% 100%;
+        }
+    `}
 `;
 
 const composeTextTheme = (themeTools: ThemeTools): TextThemeType => {

--- a/packages/components/src/components/Text/story.tsx
+++ b/packages/components/src/components/Text/story.tsx
@@ -38,7 +38,7 @@ storiesOf('Text', module).add('Default', () => (
         textAlign={select('text-align', ['left', 'right', 'center', 'justify'], 'left') as PropsType['textAlign']}
         compact={boolean('compact', false)}
         strong={boolean('strong', false)}
-        strikethrough={boolean('strikethrough', true)}
+        strikethrough={boolean('strikethrough', false)}
     >
         {text('Text', demoContent)}
     </Text>

--- a/packages/components/src/components/Text/story.tsx
+++ b/packages/components/src/components/Text/story.tsx
@@ -1,4 +1,4 @@
-import { boolean, select } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import Text, { PropsType } from '.';
@@ -40,7 +40,6 @@ storiesOf('Text', module).add('Default', () => (
         strong={boolean('strong', false)}
         strikethrough={boolean('strikethrough', true)}
     >
-        Vanaf €299,-
-        {/* {demoContent} */}
+        {text('Text', demoContent)}
     </Text>
 ));

--- a/packages/components/src/components/Text/story.tsx
+++ b/packages/components/src/components/Text/story.tsx
@@ -38,7 +38,9 @@ storiesOf('Text', module).add('Default', () => (
         textAlign={select('text-align', ['left', 'right', 'center', 'justify'], 'left') as PropsType['textAlign']}
         compact={boolean('compact', false)}
         strong={boolean('strong', false)}
+        strikethrough={boolean('strikethrough', true)}
     >
-        {demoContent}
+        Vanaf €299,-
+        {/* {demoContent} */}
     </Text>
 ));


### PR DESCRIPTION
**Backwards compatible additions** ✨
- Strikthrough prop added to Text component

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>