### PR TITLE
feat: Added color prop to Text and Heading

### DIFF
--- a/packages/components/src/components/Heading/index.tsx
+++ b/packages/components/src/components/Heading/index.tsx
@@ -24,10 +24,21 @@ type PropsType = typeof box.props & {
     hierarchy?: HierarchyType;
     as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'div' | 'span' | 'p';
     textAlign?: 'left' | 'right' | 'center' | 'justify';
+    color?: string;
 };
 
 const Heading = styled.div.attrs(() => ({ role: 'heading' }))<PropsType>`
-    color: ${({ hierarchy, theme }): string => (!hierarchy ? theme.Heading[1].color : theme.Heading[hierarchy].color)};
+    color: ${({ hierarchy, theme, color }): string => {
+        if (color) {
+            return color;
+        }
+
+        if (hierarchy) {
+            return theme.Heading[hierarchy].color;
+        }
+
+        return theme.Heading[1].color;
+    }};
     font-family: ${({ hierarchy, theme }): string =>
         !hierarchy ? theme.Heading[1].fontFamily : theme.Heading[hierarchy].fontFamily};
     font-size: ${({ hierarchy, theme }): string =>

--- a/packages/components/src/components/Heading/story.tsx
+++ b/packages/components/src/components/Heading/story.tsx
@@ -1,4 +1,4 @@
-import { select } from '@storybook/addon-knobs';
+import { color, select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import Heading, { PropsType } from '.';
@@ -9,7 +9,12 @@ storiesOf('Heading', module).add('Default', () => {
     const textAlign = select('Text-align', ['left', 'right', 'center', 'justify'], 'left') as PropsType['textAlign'];
 
     return (
-        <Heading hierarchy={hierarchy} as={as} textAlign={textAlign}>
+        <Heading
+            hierarchy={hierarchy}
+            as={as}
+            textAlign={textAlign}
+            color={color('color', (undefined as unknown) as string)}
+        >
             Happy Selling!
         </Heading>
     );

--- a/packages/components/src/components/Text/index.tsx
+++ b/packages/components/src/components/Text/index.tsx
@@ -44,10 +44,21 @@ type PropsType = typeof box.props & {
     compact?: boolean;
     strong?: boolean;
     strikethrough?: boolean;
+    color?: string;
 };
 
 const Text = styled.p<PropsType>`
-    color: ${({ variant, theme }): string => (variant ? theme.Text.variant[variant] : theme.Text.default.color)};
+    color: ${({ variant, theme, color }): string => {
+        if (color) {
+            return color;
+        }
+
+        if (variant) {
+            return theme.Text.variant[variant];
+        }
+
+        return theme.Text.default.color;
+    }};
     font-family: ${({ size, theme }): string =>
         !size ? theme.Text.size.regular.fontFamily : theme.Text.size[size].fontFamily};
     font-size: ${({ size, theme }): string =>

--- a/packages/components/src/components/Text/story.tsx
+++ b/packages/components/src/components/Text/story.tsx
@@ -1,4 +1,4 @@
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, color, select, text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 import Text, { PropsType } from '.';
@@ -39,6 +39,7 @@ storiesOf('Text', module).add('Default', () => (
         compact={boolean('compact', false)}
         strong={boolean('strong', false)}
         strikethrough={boolean('strikethrough', false)}
+        color={color('color', (undefined as unknown) as string)}
     >
         {text('Text', demoContent)}
     </Text>

--- a/packages/components/src/types/OffsetType/index.ts
+++ b/packages/components/src/types/OffsetType/index.ts
@@ -12,6 +12,7 @@ export type OffsetType =
     | 36
     | 48
     | 60
+    | 72
     | -3
     | -6
     | -9
@@ -24,6 +25,7 @@ export type OffsetType =
     | -36
     | -48
     | -60
+    | -72
     | 'auto';
 
 export type OffsetShorthandType =


### PR DESCRIPTION
### This PR:

**Breaking changes** 🔥
- None

**Backwards compatible additions** ✨
- Added color prop to Text and Heading that lets you make them white of color

**Bugfixes/Changed internals** 🎈
- None

**Checklist** 🛡
- [x] I have exported my addition from `src/index.ts` (check if not applicable).
- [x] Appropriate tests have been added for my functionality (check if not applicable).
- [x] A designer has seen and approved my changes (tag `@LuukHorsmans` or `@RianneSchaekens` for a design review when applicable).
- [x] I have tested my addition in all supported browsers and for responsiveness (Chrome, Firefox, Safari, Edge, IE11 and mobile browsers).
- [x] Appropriate documentation has been written (check if not applicable).

<details>
  <summary>ℹ️ Conventional commit help</summary>

  - Use `fix: ...` for patches
  - Use `feat: ...` for a minor change
  - Use `feat!: ...` for features with breaking changes
  - Optionally you can use a scope `feat(SomeContainer)!: ...`
  - A breaking change **must** have `BREAKING CHANGE: ...` in the commit message
  - You can use multiple `BREAKING CHANGE: ...` lines in the commit message
  - Use `build`, `chore`, `ci`, `docs`, `perf`, `refactor`, `style`, or `test`  for other types

  More info see full [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).

  _Tip: make sure the first commit message is the one you want to merge, because that's the one Github picks for squashing._
</details>